### PR TITLE
[ADD] DevTools: use localstorage for basic state

### DIFF
--- a/src/plugins/DevTools/DevTools.xml
+++ b/src/plugins/DevTools/DevTools.xml
@@ -253,15 +253,15 @@
             t-on-click="toggleClosed"
             t-on-mousedown="startResize">
             <button t-on-click="openTab('inspector')" t-att-class="{
-                selected: state.openTab == 'inspector',
+                selected: state.currentTab == 'inspector',
             }">Inspector</button>
             <button t-on-click="openTab('actions')" t-att-class="{
-                selected: state.openTab == 'actions',
+                selected: state.currentTab == 'actions',
             }">Actions</button>
         </devtools-navbar>
         <t t-if="!state.closed">
-            <InspectorComponent isOpen="state.openTab == 'inspector'"/>
-            <ActionsComponent isOpen="state.openTab == 'actions'"/>
+            <InspectorComponent isOpen="state.currentTab == 'inspector'"/>
+            <ActionsComponent isOpen="state.currentTab == 'actions'"/>
         </t>
     </jw-devtools>
 

--- a/src/plugins/DevTools/components/DevToolsComponent.ts
+++ b/src/plugins/DevTools/components/DevToolsComponent.ts
@@ -1,7 +1,6 @@
 import { ActionsComponent } from './ActionsComponent';
-import { Component } from 'owl-framework';
-import { Env } from 'owl-framework/src/component/component';
 import { InspectorComponent } from './InspectorComponent';
+import { OwlUIComponent } from '../../../ui/OwlUIComponent';
 
 ////////////////////////////// todo: use API ///////////////////////////////////
 
@@ -11,7 +10,7 @@ interface DevToolsState {
     openTab: 'inspector' | 'actions';
 }
 
-export class DevToolsComponent extends Component<Env, {}, DevToolsState> {
+export class DevToolsComponent extends OwlUIComponent<{}, DevToolsState> {
     static components = { ActionsComponent, InspectorComponent };
     state: DevToolsState = {
         closed: false,

--- a/src/plugins/DevTools/components/DevToolsComponent.ts
+++ b/src/plugins/DevTools/components/DevToolsComponent.ts
@@ -1,23 +1,25 @@
 import { ActionsComponent } from './ActionsComponent';
+import { Component } from 'owl-framework';
+import { Env } from 'owl-framework/src/component/component';
 import { InspectorComponent } from './InspectorComponent';
-import { OwlUIComponent } from '../../../ui/OwlUIComponent';
 
 ////////////////////////////// todo: use API ///////////////////////////////////
 
 interface DevToolsState {
     closed: boolean; // Are the devtools open?
     height: number; // In px
-    openTab: 'inspector' | 'actions';
+    currentTab: string; // Name of the current tab
 }
 
-export class DevToolsComponent extends OwlUIComponent<{}, DevToolsState> {
+export class DevToolsComponent extends Component<Env, {}, DevToolsState> {
     static components = { ActionsComponent, InspectorComponent };
-    state: DevToolsState = {
-        closed: false,
-        height: 300,
-        openTab: 'inspector',
-    };
     static template = 'devtools';
+    state = {
+        closed: true,
+        currentTab: 'inspector',
+        height: 300,
+    };
+    localStorage = ['closed', 'currentTab', 'height'];
     // For resizing/opening (see toggleClosed)
     _heightOnLastMousedown: number = this.state.height;
 
@@ -30,8 +32,8 @@ export class DevToolsComponent extends OwlUIComponent<{}, DevToolsState> {
      *
      * @param {'inspector' | 'actions'} tabName
      */
-    openTab(tabName: 'inspector' | 'actions'): void {
-        this.state.openTab = tabName;
+    openTab(tabName: string): void {
+        this.state.currentTab = tabName;
     }
     /**
      * Drag the DevTools to resize them

--- a/src/ui/OwlUIComponent.ts
+++ b/src/ui/OwlUIComponent.ts
@@ -1,0 +1,81 @@
+import { Component } from 'owl-framework';
+import { Env } from 'owl-framework/src/component/component';
+
+export class OwlUIComponent<Props, State> extends Component<Env, Props, State> {
+    _storageKeyPrefix = 'OwlUI' + this.constructor.name + ':';
+    localStorage: string[] = [];
+
+    /**
+     * Owl hook called exactly once before the initial rendering.
+     */
+    willStart(): Promise<void> {
+        this._readState(localStorage, this.localStorage);
+        return super.willStart();
+    }
+
+    /**
+     * Called by the Owl state observer every time the state changes.
+     *
+     * @param force see Owl Component
+     */
+    render(force = false): Promise<void> {
+        this._writeState(localStorage, this.localStorage);
+        return super.render(force);
+    }
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Read the given storable state items from the given storage.
+     *
+     * @param storage from which to read the state items
+     * @param storableItems names of the state items to read from storage
+     */
+    _readState(storage: Storage, storableItems: string[]): void {
+        storableItems.forEach(itemName => {
+            const storageKey = this._storageKeyPrefix + itemName;
+            const value = storage.getItem(storageKey);
+
+            // The value of items that were not yet set in storage is null.
+            if (value !== null) {
+                // Otherwise, the value was stored as a string in the storage.
+                // Convert it to the type of the default value for the state.
+                try {
+                    this.state[itemName] = JSON.parse(value);
+                } catch (e) {
+                    // Stored item is not parseable. Keep the default value.
+                    console.warn(
+                        `Storage: Ignoring state.${itemName} stored value.\n` +
+                            `${e.name}: ${e.message}\n` +
+                            `Stored value: ${value}`,
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * write the given storable state items to the given storage.
+     *
+     * @param storage to write the state items to
+     * @param storableItems names of the state items to write to storage
+     */
+    _writeState(storage: Storage, storableItems: string[]): void {
+        storableItems.forEach(itemName => {
+            const storageKey = this._storageKeyPrefix + itemName;
+            // Storage require items to be stored as strings.
+            try {
+                const serializedValue = JSON.stringify(this.state[itemName]);
+                storage.setItem(storageKey, serializedValue);
+            } catch (e) {
+                // State item is not serializable. Skip storing it.
+                console.warn(
+                    `Storage: Unserializable state.${itemName} value.\n` +
+                        `${e.name}: ${e.message}`,
+                );
+            }
+        });
+    }
+}


### PR DESCRIPTION
Keep DevTool's height, open tab etc. between refreshes. Handy when debugging with auto-refresh.