### PR TITLE
[POC] Renderer: render DOM and Range

### DIFF
--- a/src/core/JWEditor.ts
+++ b/src/core/JWEditor.ts
@@ -37,9 +37,6 @@ export class JWEditor {
         // handler that might have been previously registered.
         this.editable = this._originalEditable.cloneNode(true) as HTMLElement;
 
-        // Parse the editable in the internal format of the editor.
-        this.vDocument = new VDocument(this.editable);
-
         // The original editable node is hidden until the editor stops.
         this._originalEditable.style.display = 'none';
         // Cloning the editable node might lead to duplicated id.
@@ -52,6 +49,11 @@ export class JWEditor {
         this.editable.setAttribute('contenteditable', 'true');
         this.el.appendChild(this.editable);
         document.body.appendChild(this.el);
+
+        // Parse the editable in the internal format of the editor.
+        // Must happen after appending `this.editable to the DOM so the range
+        // can be set.
+        this.vDocument = new VDocument(this.editable);
 
         // Add the CorePlugin
         // CorePlugin is a special mandatory plugin. It's the plugin that will

--- a/src/core/stores/VDocument.ts
+++ b/src/core/stores/VDocument.ts
@@ -1,13 +1,19 @@
 import { VNode, VNodeType } from './VNode';
 import { Parser } from '../utils/Parser';
+import { Renderer } from '../utils/Renderer';
+
+export type DomMap = Map<DOMElement | Node, VNode[]>;
 
 export class VDocument {
     _root = new VNode(VNodeType.ROOT);
+    domMap: DomMap = new Map();
+    editable: HTMLElement;
+    renderer: Renderer = new Renderer(this);
 
-    constructor(startValue?: HTMLElement) {
-        if (startValue) {
-            this.setContents(startValue);
-        }
+    constructor(editable: HTMLElement) {
+        this.editable = editable;
+        this.domMap.set(this.editable, [this._root]);
+        this.setContents(this.editable);
     }
 
     //--------------------------------------------------------------------------
@@ -31,6 +37,10 @@ export class VDocument {
         parsedNodes.forEach(parsedNode => {
             this._root.append(parsedNode);
         });
+
+        // Render the contents of this.editable
+        this.renderer.render(this.editable);
+
         return this._root;
     }
 }

--- a/src/core/stores/VDocument.ts
+++ b/src/core/stores/VDocument.ts
@@ -9,6 +9,10 @@ export class VDocument {
     domMap: DomMap = new Map();
     editable: HTMLElement;
     renderer: Renderer = new Renderer(this);
+    rangeNodes = {
+        start: new VNode(VNodeType.RANGE_START),
+        end: new VNode(VNodeType.RANGE_END),
+    };
 
     constructor(editable: HTMLElement) {
         this.editable = editable;
@@ -34,8 +38,9 @@ export class VDocument {
         while (this._root.children.length) {
             this._root.removeChild(0);
         }
-        parsedNodes.forEach(parsedNode => {
-            this._root.append(parsedNode);
+        const rangeNodes: VNode[] = [this.rangeNodes.start, this.rangeNodes.end];
+        rangeNodes.concat(parsedNodes).forEach(vNode => {
+            this._root.append(vNode);
         });
 
         // Render the contents of this.editable

--- a/src/core/stores/VNode.ts
+++ b/src/core/stores/VNode.ts
@@ -114,7 +114,8 @@ export class VNode {
      */
     removeChild(index: number): VNode {
         delete this.children[index];
-        this.children.splice(index);
+        this.children.splice(index, 1);
+        this._updateIndexes();
         return this;
     }
     /**
@@ -122,14 +123,31 @@ export class VNode {
      * nodes in this node, and to this node in other nodes.
      */
     setPosition(parent: VNode, index: number, children?: VNode[]): VNode {
+        const nodeAtIndex = parent.children[index];
         if (this.parent) {
             // remove this from old parent
-            this.parent.children.splice(this.index);
+            this.parent.children.splice(this.index, 1);
+            this.parent._updateIndexes();
+            index = (nodeAtIndex && nodeAtIndex.index) || index; // make sure to still have the right index
         }
         this.parent = parent;
         this.parent.children.splice(index, 0, this);
-        this.index = index;
+        this.parent._updateIndexes();
         this.children = children || this.children;
+        return this;
+    }
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Recalculate the indexes of this node's children.
+     */
+    _updateIndexes(): VNode {
+        this.children.forEach((child: VNode, i: number) => {
+            child.index = i;
+        });
         return this;
     }
 }

--- a/src/core/utils/CorePlugin.ts
+++ b/src/core/utils/CorePlugin.ts
@@ -1,15 +1,25 @@
 import { JWPlugin } from '../JWPlugin';
 import { VDocument } from '../stores/VDocument';
+import { VNode } from '../stores/VNode';
+
+interface VPosition {
+    ref: VNode;
+    side: 'before' | 'after';
+}
 
 export class CorePlugin extends JWPlugin {
     vDocument: VDocument;
     handlers = {
         intents: {
             remove: 'onRemoveIntent', // names are just to show relationships here
+            render: 'render',
+            setRange: 'navigate',
         },
     };
     commands = {
+        navigate: this.navigate.bind(this),
         onRemoveIntent: this.removeSide,
+        render: this.render.bind(this),
     };
     constructor(dispatcher, vDocument) {
         super(dispatcher);
@@ -20,7 +30,96 @@ export class CorePlugin extends JWPlugin {
     // Public
     //--------------------------------------------------------------------------
 
-    removeSide(intent: Action): void {
+    removeSide(intent: Intent): void {
         console.log('REMOVE SIDE:' + intent);
+    }
+    /**
+     * Navigate to a given Range (in the payload of the Intent).
+     *
+     * @param intent
+     */
+    navigate(intent: Intent): void {
+        this._setRange(intent.payload['value']);
+    }
+    /**
+     * Render the `vDocument`.
+     */
+    render(): void {
+        this.vDocument.renderer.render(this.vDocument.editable);
+    }
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return a position in the `VDocument` as a tuple `[VNode, 'before' | 'after']`
+     * (ie. the position is before or after a given `VNode`). The position is
+     * always given on the leaf.
+     *
+     * @param container
+     * @param offset
+     */
+    _getPosition(container: DOMElement | Node, offset: number): VPosition {
+        const containers = this.vDocument.domMap.get(container);
+        const isTextNode = container.nodeType === 3;
+        if (isTextNode) {
+            return this._positionToLeaf({
+                ref: containers[offset] || containers[containers.length - 1],
+                side: offset < containers.length ? 'before' : 'after',
+            });
+        }
+        return this._positionToLeaf({ ref: containers[offset], side: 'before' });
+    }
+    /**
+     * Return a tuple with the range nodes in ltr order (rtl if `reverse` is
+     * true) and updates their `order` property accordingly.
+     *
+     * @param reverse
+     */
+    _orderedRangeNodes(reverse = false): [VNode, VNode] {
+        const rangeNodes = this.vDocument.rangeNodes;
+        const res: [VNode, VNode] = [rangeNodes.start, rangeNodes.end];
+        if (reverse) {
+            res.reverse();
+        }
+        res.forEach((rangeNode: VNode, i: 0 | 1) => {
+            rangeNode.order = i;
+        });
+        return res;
+    }
+    /**
+     * Move the position to its deepest first descendent.
+     *
+     * @param position
+     */
+    _positionToLeaf(position: VPosition): VPosition {
+        while (position.ref.children.length) {
+            position.ref = position.ref.firstChild;
+            position.side = 'before';
+        }
+        return position;
+    }
+    /**
+     * Move the `Range VNodes` to the position in `VDocument` corresponding to
+     * the given DOM Range and trigger a rendering.
+     *
+     * @param range
+     */
+    _setRange(range: Range): void {
+        const startPos: VPosition = this._getPosition(range.startContainer, range.startOffset);
+        const endPos: VPosition = this._getPosition(range.endContainer, range.endOffset);
+        const [first, last] = this._orderedRangeNodes(range['direction'] === 'rtl');
+
+        // Move the range nodes. If the start has to be moved *after* its
+        // reference node, the end should be moved first.
+        if (startPos.side === 'after') {
+            endPos.ref[endPos.side](last);
+            startPos.ref[startPos.side](first);
+        } else {
+            startPos.ref[startPos.side](first);
+            endPos.ref[endPos.side](last);
+        }
+        this.dispatcher.dispatch(this.intent({ name: 'render' }));
     }
 }

--- a/src/core/utils/Parser.ts
+++ b/src/core/utils/Parser.ts
@@ -56,6 +56,56 @@ export class Parser {
         }
     }
     /**
+     * Return true if the given node is immediately preceding (`side` === 'end')
+     * or following (`side` === 'start') a segment break, to see if its edge
+     * space must be removed.
+     *
+     * @param {Element} node
+     * @param {'start'|'end'} side
+     * @returns {boolean}
+     */
+    static _isAgainstSegmentBreak(node: Element, side: 'start' | 'end'): boolean {
+        const siblingSide = side === 'start' ? 'previousSibling' : 'nextSibling';
+        const sibling = node && (node[siblingSide] as DOMElement);
+        return (sibling && this._isBlock(sibling)) || this._isEdgeOfBlock(node, side);
+    }
+    /**
+     * Return true if the node is a block.
+     * Is considered a block, every node that is displayed as a block, and `BR`
+     * elements.
+     *
+     * @param {DOMElement} node
+     * @returns {boolean}
+     */
+    static _isBlock(node: DOMElement): boolean {
+        const display = window.getComputedStyle(node, null).display;
+        return display === 'block' || node.tagName === 'BR';
+    }
+    /**
+     * Return true if the node is at the given edge of a block.
+     *
+     * @param {Element | Node} node
+     * @param {'start'|'end'} side
+     */
+    static _isEdgeOfBlock(node: Element | Node, side: 'start' | 'end'): boolean {
+        const ancestorsUpToBlock = [];
+
+        // Move up to the first block ancestor
+        let ancestor = node;
+        const isTextNode = ancestor.nodeType === 3;
+        while (ancestor && (isTextNode || !this._isBlock(ancestor as DOMElement))) {
+            ancestorsUpToBlock.push(ancestor);
+            ancestor = ancestor.parentElement;
+        }
+
+        // Return true if no ancestor up to the first block ancestor has a
+        // sibling on the specified side
+        const siblingSide = side === 'start' ? 'previousSibling' : 'nextSibling';
+        return ancestorsUpToBlock.every(ancestor => {
+            return !ancestor[siblingSide];
+        });
+    }
+    /**
      * Parse an (non-text, non-format) element.
      *
      * @param {Element} node the node to parse
@@ -128,11 +178,78 @@ export class Parser {
      */
     static _parseTextNode(node: Element, format?: FormatType): VNode[] {
         const parsedNodes: VNode[] = [];
-        for (let i = 0; i < node.textContent.length; i++) {
-            const char: string = node.textContent.charAt(i);
-            const parsedNode: VNode = new VNode(VNodeType.CHAR, node.tagName, char, format);
+        const text: string = this._removeFormatSpace(node);
+        for (let i = 0; i < text.length; i++) {
+            const char: string = text.charAt(i);
+            const parsedNode: VNode = new VNode(
+                VNodeType.CHAR,
+                node.tagName || '#text',
+                char,
+                format,
+            );
             parsedNodes.push(parsedNode);
         }
         return parsedNodes;
+    }
+    /**
+     * Return a string with the value of a text node stripped of its format space,
+     * applying the w3 rules for white space processing
+     *
+     * @see https://www.w3.org/TR/css-text-3/#white-space-processing
+     * @returns {string}
+     */
+    static _removeFormatSpace(node: Element): string {
+        // TODO: check the value of the `white-space` property
+        const text: string = node.textContent;
+        const spaceBeforeNewline = /([ \t])*(\n)/g;
+        const spaceAfterNewline = /(\n)([ \t])*/g;
+        const tabs = /\t/g;
+        const newlines = /\n/g;
+        const consecutiveSpace = /  */g;
+
+        // (Comments refer to the w3 link provided above.)
+        // Phase I: Collapsing and Transformation
+        let newText = text
+            // 1. All spaces and tabs immediately preceding or following a
+            //    segment break are removed.
+            .replace(spaceBeforeNewline, '$2')
+            .replace(spaceAfterNewline, '$1')
+            // 2. Segment breaks are transformed for rendering according to the
+            //    segment break transformation rules.
+            .replace(newlines, ' ')
+            // 3. Every tab is converted to a space (U+0020).
+            .replace(tabs, ' ')
+            // 4. Any space immediately following another collapsible space —
+            //    even one outside the boundary of the inline containing that
+            //    space, provided both spaces are within the same inline
+            //    formatting context—is collapsed to have zero advance width.
+            //    (It is invisible, but retains its soft wrap opportunity, if
+            //    any.)
+            .replace(consecutiveSpace, ' ');
+
+        // Phase II: Trimming and Positioning
+        // 1. A sequence of collapsible spaces at the beginning of a line
+        //    (ignoring any intervening inline box boundaries) is removed.
+        if (this._isAgainstSegmentBreak(node, 'start')) {
+            const startSpace = /^ */g;
+            newText = newText.replace(startSpace, '');
+        }
+        // 2. If the tab size is zero, tabs are not rendered. Otherwise, each
+        //    tab is rendered as a horizontal shift that lines up the start edge
+        //    of the next glyph with the next tab stop. If this distance is less
+        //    than 0.5ch, then the subsequent tab stop is used instead. Tab
+        //    stops occur at points that are multiples of the tab size from the
+        //    block’s starting content edge. The tab size is given by the
+        //    tab-size property.
+        // TODO
+        // 3. A sequence at the end of a line (ignoring any intervening inline
+        //    box boundaries) of collapsible spaces (U+0020) and/or ideographic
+        //    spaces (U+3000) whose white-space value collapses spaces is
+        //    removed.
+        if (this._isAgainstSegmentBreak(node, 'end')) {
+            const endSpace = /[ \u3000]*$/g;
+            newText = newText.replace(endSpace, '');
+        }
+        return newText;
     }
 }

--- a/src/core/utils/Renderer.ts
+++ b/src/core/utils/Renderer.ts
@@ -1,6 +1,13 @@
 import { VNode, VNodeType } from '../stores/VNode';
 import { VDocument } from '../stores/VDocument';
 
+interface RangeToSet {
+    startContainer: 'start' | 'end' | DOMElement | Node;
+    endContainer: 'start' | 'end' | DOMElement | Node;
+    startOffset: 'end' | number;
+    endOffset: 'end' | number;
+}
+
 // TODO: centralize
 const formats = {
     bold: 'B',
@@ -15,6 +22,14 @@ export class Renderer {
     // list of char nodes to aggregate:
     _currentCharNodes: VNode[] = [];
     _lastCreatedNode: DOMElement | Node;
+    _nextEndOffset = 0;
+    _nextStartOffset = 0;
+    _rangeToSet: RangeToSet;
+    _waitedForFormat = false;
+    _delayingRange = {
+        start: false,
+        end: false,
+    };
     constructor(vDocument: VDocument) {
         this.vDocument = vDocument;
     }
@@ -23,12 +38,39 @@ export class Renderer {
     // Public
     //--------------------------------------------------------------------------
 
-    render(target: Element): void {
+    /**
+     * Ensure that all instance variables that are required for a rendering are
+     * properly set to their initial values before initiating a new rendering.
+     *
+     * @param {Element} target
+     */
+    initializeRendering(target: Element): void {
         target.innerHTML = ''; // TODO: update instead of recreate
         this.vDocument.domMap = new Map(); // TODO: update instead of recreate
+        this._currentCharNodes = [];
+        this._lastCreatedNode = undefined;
+        this._nextEndOffset = 0;
+        this._nextStartOffset = 0;
+        this._rangeToSet = {
+            startContainer: undefined,
+            endContainer: undefined,
+            startOffset: undefined,
+            endOffset: undefined,
+        };
+        this._waitedForFormat = false;
+        this._undelayRange();
+    }
+    /**
+     * Initiate a rendering of `vDocument`'s contents into `target`.
+     *
+     * @param {Element} target
+     */
+    render(target: Element): void {
+        this.initializeRendering(target);
         const fragment: DocumentFragment = document.createDocumentFragment();
         this._renderBranch(this.vDocument.contents, fragment);
         target.appendChild(fragment);
+        this._setRange(target);
     }
 
     //--------------------------------------------------------------------------
@@ -60,8 +102,21 @@ export class Renderer {
         formatNodes.forEach(formatNode => {
             this._setMap(formatNode, vNode);
         });
-        this._lastCreatedNode = formatNodes[formatNodes.length - 1];
+        if (formatNodes.length) {
+            this._lastCreatedNode = formatNodes[formatNodes.length - 1];
+        }
         return formatNodes;
+    }
+    /**
+     * Delay the update of one side of the range (start or end).
+     * `updateRange` will simply be skipped while `this._delayingRange` is true
+     * for the side it wants to update. This is useful when the range might need
+     * a node that hasn't been rendered yet (eg. when aggregating char nodes).
+     *
+     * @param side
+     */
+    _delayRange(side: 'start' | 'end'): void {
+        this._delayingRange[side] = true;
     }
     /**
      * Return a string containing the aggregated text of all CHAR VNodes that
@@ -73,6 +128,47 @@ export class Renderer {
             text += vNode.value;
         });
         return text;
+    }
+    /**
+     * Get the start/end container to set as range: retrieve it from
+     * `this._rangeToSet`, then get the right container if it was set to 'start'
+     * or 'end', in relationship to the target ('start' will return the first
+     * leaf of `target`).
+     *
+     * @param {DOMElement} target
+     * @param {'start'|'end} edge
+     * @returns {DOMElement|Node}
+     */
+    _getRangeContainerToSet(target: Element, edge: 'start' | 'end'): DOMElement | Node {
+        const edgeContainer = edge === 'start' ? 'startContainer' : 'endContainer';
+        const containerOrSide = this._rangeToSet[edgeContainer];
+        if (typeof containerOrSide === 'string') {
+            return this._toLeaf(target, containerOrSide === 'start' ? 'first' : 'last');
+        }
+        return this._toLeaf(containerOrSide, 'first');
+    }
+    /**
+     * Get the start/end offset to set as range: retrieve it from
+     * `this._rangeToSet`, then get the right offset if it was set to 'end', in
+     * relationship to its target ('end' will return the maximum offset into
+     * that target).
+     *
+     * @param {Element} target
+     * @param {'start'|'end} edge
+     * @returns {number}
+     */
+    _getRangeOffsetToSet(target: Element, edge: 'start' | 'end'): number {
+        const edgeOffset = edge === 'start' ? 'startOffset' : 'endOffset';
+        const offsetOrSide = this._rangeToSet[edgeOffset];
+        if (offsetOrSide === 'end') {
+            const container = this._getRangeContainerToSet(target, edge);
+            if (container) {
+                const isTextNode = container.nodeType === 3;
+                return container[isTextNode ? 'textContent' : 'childNodes'].length;
+            }
+            return 0;
+        }
+        return offsetOrSide;
     }
     /**
      * Take a `VNodeType` and return the corresponding `tagName`, if any.
@@ -94,6 +190,9 @@ export class Renderer {
                 return 'BR';
             case 'PARAGRAPH':
                 return 'P';
+            case 'RANGE_START':
+            case 'RANGE_END':
+                return;
         }
     }
     /**
@@ -103,6 +202,13 @@ export class Renderer {
      * @param parent the parent in which to append it
      */
     _renderBranch(vNode: VNode, parent: Element | DocumentFragment): void {
+        // Update the range to set if that was delayed by the creation of a
+        // format node and we are not in the process of aggregating char nodes
+        if (this._waitedForFormat && !this._currentCharNodes.length) {
+            this._updateRange('start');
+            this._updateRange('end');
+        }
+
         /* If the node has a format, render that format node first
            Note: Later we remove the empty ones and do the DomMap matching
                  (see at the bottom of this method). */
@@ -110,7 +216,8 @@ export class Renderer {
         parent = formatNodes.length ? formatNodes[formatNodes.length - 1] : parent;
 
         // If this is the end of a series of characters, render that text
-        if (vNode.type !== 'CHAR' && this._currentCharNodes.length) {
+        const isRange = vNode.type.startsWith('RANGE');
+        if (vNode.type !== 'CHAR' && this._currentCharNodes.length && !isRange) {
             this._renderText(parent);
         }
 
@@ -128,6 +235,21 @@ export class Renderer {
         }
     }
     /**
+     * Render a single VNode representing a simple element.
+     * Return the created node.
+     *
+     * @param vNode the node to render
+     * @param parent the parent in which to append it
+     */
+    _renderElement(vNode: VNode, parent: Element | DocumentFragment): Element {
+        const tagName: string = this._getTagName(vNode.type);
+        const createdNode: Element = document.createElement(tagName);
+        parent.appendChild(createdNode);
+        this._setMap(createdNode, vNode);
+        this._lastCreatedNode = createdNode;
+        return createdNode;
+    }
+    /**
      * Render a single VNode. Return the created node if any.
      *
      * @param vNode the node to render
@@ -143,13 +265,40 @@ export class Renderer {
             this._currentCharNodes.push(vNode);
             return;
         }
+        // Node is range
+        if (vNode.type.startsWith('RANGE')) {
+            this._renderRangeNode(vNode);
+            return;
+        }
         // Node is element
-        const tagName: string = this._getTagName(vNode.type);
-        const createdNode: Element = document.createElement(tagName);
-        parent.appendChild(createdNode);
-        this._setMap(createdNode, vNode);
-        this._lastCreatedNode = createdNode;
-        return createdNode;
+        return this._renderElement(vNode, parent);
+    }
+    /**
+     * Render a Range node: update the range to set if possible or delay that
+     * update for when the required rendered node is available
+     * (see `_delayRange`).
+     *
+     * @param vNode
+     */
+    _renderRangeNode(vNode: VNode): void {
+        const side = vNode.type.endsWith('START') ? 'start' : 'end';
+        const isRenderingText = !!this._currentCharNodes.length;
+        // If we are busy rendering text, save the offset (the number of
+        // char nodes collected so far) and delay the range update until the
+        // text node is rendered.
+        if (isRenderingText) {
+            this._delayRange(side);
+            const offsetName = side === 'start' ? '_nextStartOffset' : '_nextEndOffset';
+            this[offsetName] = this._currentCharNodes.length;
+            return;
+        }
+        // Otherwise, simply update the range to set. If both sides need to be
+        // updated, do it right away.
+        const doUpdateBoth = this._delayingRange.start && this._delayingRange.end;
+        this._updateRange(side);
+        if (doUpdateBoth) {
+            this._updateRange(side === 'end' ? 'start' : 'end');
+        }
     }
     /**
      * Render the CHAR VNodes in `this._currentCharNodes` as one text node.
@@ -161,6 +310,7 @@ export class Renderer {
         const text = this._getCurrentText();
         const textNode: Text = document.createTextNode(text);
         parent.appendChild(textNode);
+
         // Map each CHAR VNode to its rendered text node
         // and format parents if any
         this._currentCharNodes.forEach((vNode: VNode): void => {
@@ -169,8 +319,20 @@ export class Renderer {
                 this._setMap(parent, vNode);
             }
         });
+
         this._currentCharNodes = [];
         this._lastCreatedNode = textNode;
+
+        // Update the delayed range if necessary
+        const doUpdateBoth = this._delayingRange.start && this._delayingRange.end;
+        if (doUpdateBoth) {
+            this._updateRange('start', this._nextStartOffset);
+            this._updateRange('end', this._nextEndOffset);
+        } else if (this._delayingRange.start || this._delayingRange.end) {
+            const side = this._delayingRange.start ? 'start' : 'end';
+            const savedOffset = side === 'start' ? this._nextStartOffset : this._nextEndOffset;
+            this._updateRange(side, savedOffset);
+        }
     }
     /**
      * Map an DOM Element/Node to a VNode in `vDocument.domMap`.
@@ -187,5 +349,116 @@ export class Renderer {
         } else {
             this.vDocument.domMap.set(element, [vNode]);
         }
+    }
+    /**
+     * Compute and set a new range in the DOM.
+     *
+     * @param {Element} target
+     */
+    _setRange(target: Element): void {
+        const direction = this.vDocument.rangeNodes.start.order === 0 ? 'ltr' : 'rtl';
+        const computedRange = {
+            startContainer: this._getRangeContainerToSet(target, 'start'),
+            endContainer: this._getRangeContainerToSet(target, 'end'),
+            startOffset: this._getRangeOffsetToSet(target, 'start'),
+            endOffset: this._getRangeOffsetToSet(target, 'end'),
+        };
+
+        if (direction === 'ltr') {
+            this._setRangeForward(computedRange, target);
+        } else {
+            this._setRangeBackward(computedRange, target);
+        }
+    }
+    /**
+     * Set a new backward range in the DOM.
+     *
+     * @param computedRange
+     * @param target
+     */
+    _setRangeBackward(computedRange, target): void {
+        const domRange: Range = target.ownerDocument.createRange();
+        const selection = document.getSelection();
+        domRange.setEnd(computedRange.startContainer, computedRange.startOffset);
+        domRange.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(domRange);
+        selection.extend(computedRange.endContainer, computedRange.endOffset);
+    }
+    /**
+     * Set a new forward range in the DOM.
+     *
+     * @param computedRange
+     * @param target
+     */
+    _setRangeForward(computedRange, target): void {
+        const domRange: Range = target.ownerDocument.createRange();
+        const selection = document.getSelection();
+        domRange.setStart(computedRange.startContainer, computedRange.startOffset);
+        domRange.setEnd(computedRange.endContainer, computedRange.endOffset);
+        selection.removeAllRanges();
+        selection.addRange(domRange);
+    }
+    /**
+     * Move a node to its first/last leaf
+     *
+     * @param node
+     * @param side
+     */
+    _toLeaf(node: DOMElement | Node, side: 'first' | 'last'): DOMElement | Node {
+        const edgeChild = side === 'first' ? 'firstChild' : 'lastChild';
+        let leaf: DOMElement | Node = node;
+        while (leaf && leaf[edgeChild]) {
+            leaf = leaf[edgeChild];
+        }
+        return leaf;
+    }
+    /**
+     * Set `this._delayingRange` to false on start and end.
+     *
+     * @see _delayRange
+     */
+    _undelayRange(): void {
+        this._delayingRange.start = false;
+        this._delayingRange.end = false;
+    }
+    /**
+     * Update the range to set base on the last node created.
+     *
+     * @param {'start'|'end'} edge
+     */
+    _updateRange(edge: 'start' | 'end', offset?: number | 'end'): void {
+        this._undelayRange();
+        const waitedForFormat = this._waitedForFormat;
+        this._waitedForFormat = false;
+        // If no node has be created yet, set the range to the start
+        if (!this._lastCreatedNode) {
+            this._rangeToSet[edge + 'Container'] = 'start';
+            this._rangeToSet[edge + 'Offset'] = 0;
+            return;
+        }
+        // If the last created node was a format node, delay the update
+        if (formatTags.indexOf(this._lastCreatedNode['tagName']) !== -1) {
+            this._delayRange(edge);
+            this._waitedForFormat = true;
+            return;
+        }
+
+        this._rangeToSet[edge + 'Container'] = this._lastCreatedNode;
+
+        // If the last created node was not a text node,
+        // or no offset was passed and we waited for a format node
+        const lastIsText = this._lastCreatedNode.nodeType === 3;
+        if (!lastIsText || (waitedForFormat && typeof offset !== 'number')) {
+            this._rangeToSet[edge + 'Offset'] = 0;
+            return;
+        }
+        // Use the offset that was passed if any
+        if (typeof offset === 'number') {
+            this._rangeToSet[edge + 'Offset'] = offset;
+            return;
+        }
+        // In any other case, set to the end of the container
+        this._rangeToSet[edge + 'Offset'] = 'end';
     }
 }

--- a/src/core/utils/Renderer.ts
+++ b/src/core/utils/Renderer.ts
@@ -1,0 +1,197 @@
+import { VNode, VNodeType, FormatType } from '../stores/VNode';
+import { VDocument } from '../stores/VDocument';
+
+// TODO: centralize
+const formats = {
+    bold: 'B',
+    italic: 'I',
+    underline: 'U',
+};
+const formatTags = Object.keys(formats).map(key => formats[key]);
+
+export class Renderer {
+    vDocument: VDocument;
+    // When aggregating char nodes to render a text node, this keeps the current
+    // list of char nodes to aggregate:
+    _currentCharNodes: VNode[] = [];
+    _lastCreatedNode: DOMElement | Node;
+    constructor(vDocument: VDocument) {
+        this.vDocument = vDocument;
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    render(target: Element): void {
+        target.innerHTML = ''; // TODO: update instead of recreate
+        this.vDocument.domMap = new Map(); // TODO: update instead of recreate
+        const fragment: DocumentFragment = document.createDocumentFragment();
+        this._renderBranch(this.vDocument.contents, fragment);
+        target.appendChild(fragment);
+    }
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Take a node's formats, create the relevant format nodes and append them
+     * to the given parent and each other (parent > 1st-format > 2d-format ...)
+     *
+     * @param format the node's formats
+     * @param parent the parent in which to append the first format node
+     */
+    _createFormatNodes(format: FormatType, parent: Element | DocumentFragment): Element[] {
+        const formatsToApply: string[] = Object.keys(format).filter(
+            (key: string): boolean => format[key],
+        );
+        return formatsToApply.map(
+            (key: string): Element => {
+                const tag = formats[key];
+                const formatNode = document.createElement(tag);
+                parent.appendChild(formatNode);
+                parent = formatNode;
+                return formatNode;
+            },
+        );
+    }
+    /**
+     * Return a string containing the aggregated text of all CHAR VNodes that
+     * are inside `this._currentCharNodes`, for rendering.
+     */
+    _getCurrentText(): string {
+        let text = '';
+        this._currentCharNodes.forEach((vNode: VNode): void => {
+            text += vNode.value;
+        });
+        return text;
+    }
+    /**
+     * Take a `VNodeType` and return the corresponding `tagName`, if any.
+     *
+     * @param vNodeType
+     */
+    _getTagName(vNodeType: VNodeType): string {
+        switch (vNodeType) {
+            case 'CHAR':
+                return;
+            case 'HEADING1':
+            case 'HEADING2':
+            case 'HEADING3':
+            case 'HEADING4':
+            case 'HEADING5':
+            case 'HEADING6':
+                return 'H' + vNodeType[7];
+            case 'LINE_BREAK':
+                return 'BR';
+            case 'PARAGRAPH':
+                return 'P';
+        }
+    }
+    /**
+     * Render a VNode and its children.
+     *
+     * @param vNode the node to render
+     * @param parent the parent in which to append it
+     */
+    _renderBranch(vNode: VNode, parent: Element | DocumentFragment): void {
+        /* If the node has a format, render that format node first
+           Note: Later we remove the empty ones and do the DomMap matching
+                 (see at the bottom of this method). */
+        const formatNodes: Element[] = this._createFormatNodes(vNode.format, parent);
+        parent = formatNodes.length ? formatNodes[formatNodes.length - 1] : parent;
+
+        // If this is the end of a series of characters, render that text
+        if (vNode.type !== 'CHAR' && this._currentCharNodes.length) {
+            this._renderText(parent);
+        }
+
+        // Create the element matching this vNode if possible, and append it
+        parent = this._renderOne(vNode, parent) || parent;
+
+        // Render the children
+        vNode.children.forEach((child: VNode): void => {
+            this._renderBranch(child, parent);
+        });
+
+        // Render aggregated text at the end of an element
+        if (!vNode.nextSibling && this._currentCharNodes.length) {
+            this._renderText(parent);
+        }
+
+        // Remove empty format nodes (due to technical spaces)
+        // and ensure proper DOM/VDoc matching
+        if (formatNodes.length) {
+            formatNodes.forEach((formatNode: Element): void => {
+                if (!formatNode.childNodes.length) {
+                    formatNode.remove();
+                } else {
+                    this._setMap(formatNode, vNode);
+                }
+            });
+            this._lastCreatedNode = formatNodes[formatNodes.length - 1];
+        }
+    }
+    /**
+     * Render a single VNode. Return the created node if any.
+     *
+     * @param vNode the node to render
+     * @param parent the parent in which to append it
+     */
+    _renderOne(vNode: VNode, parent: Element | DocumentFragment): Element | void {
+        // Node is root
+        if (vNode.type === 'ROOT') {
+            return;
+        }
+        // Node is character
+        if (vNode.type === 'CHAR') {
+            this._currentCharNodes.push(vNode);
+            return;
+        }
+        // Node is element
+        const tagName: string = this._getTagName(vNode.type);
+        const createdNode: Element = document.createElement(tagName);
+        parent.appendChild(createdNode);
+        this._setMap(createdNode, vNode);
+        this._lastCreatedNode = createdNode;
+        return createdNode;
+    }
+    /**
+     * Render the CHAR VNodes in `this._currentCharNodes` as one text node.
+     * Then reinitialize `this._currentCharNodes`.
+     *
+     * @param parent the parent in which to append the text node
+     */
+    _renderText(parent: Element | DocumentFragment): void {
+        const text = this._getCurrentText();
+        const textNode: Text = document.createTextNode(text);
+        parent.appendChild(textNode);
+        // Map each CHAR VNode to its rendered text node
+        // and format parents if any
+        this._currentCharNodes.forEach((vNode: VNode): void => {
+            this._setMap(textNode, vNode);
+            if (formatTags.indexOf(parent['tagName']) !== -1) {
+                this._setMap(parent, vNode);
+            }
+        });
+        this._currentCharNodes = [];
+        this._lastCreatedNode = textNode;
+    }
+    /**
+     * Map an DOM Element/Node to a VNode in `vDocument.domMap`.
+     *
+     * @param element
+     * @param vNode
+     */
+    _setMap(element: Element | Node, vNode: VNode): void {
+        if (this.vDocument.domMap.has(element)) {
+            const matches = this.vDocument.domMap.get(element);
+            if (!matches.some((match: VNode): boolean => match.id === vNode.id)) {
+                matches.push(vNode);
+            }
+        } else {
+            this.vDocument.domMap.set(element, [vNode]);
+        }
+    }
+}

--- a/src/plugins/DevTools/DevTools.css
+++ b/src/plugins/DevTools/DevTools.css
@@ -147,6 +147,10 @@ devtools-tree > devtools-node.root > span.element-name {
     box-sizing: border-box;
 }
 
+devtools-tree devtools-node > span.range-node {
+    color: red;
+}
+
 devtools-tree span.element-name {
     width: 100%;
     display: inline-block;

--- a/src/plugins/DevTools/DevTools.xml
+++ b/src/plugins/DevTools/DevTools.xml
@@ -43,7 +43,12 @@
             <t t-call="treeChildren"/>
         </t>
         <t t-else="">
-            <span t-if="props.vNode.value" t-on-click="onClickNode"
+            <span t-if="props.vNode.type == 'RANGE_START' or props.vNode.type == 'RANGE_END'"
+                t-on-click="onClickNode"
+                class="selectable-line range-node">
+                <t t-esc="repr"/>
+            </span>
+            <span t-elif="props.vNode.value" t-on-click="onClickNode"
                 class="selectable-line" t-att-class="{
                     bold: props.vNode.format.bold,
                     italic: props.vNode.format.italic,

--- a/src/plugins/DevTools/DevTools.xml
+++ b/src/plugins/DevTools/DevTools.xml
@@ -369,7 +369,8 @@
             }">Actions</button>
         </devtools-navbar>
         <t t-if="!state.closed">
-            <InspectorComponent isOpen="state.currentTab == 'inspector'"/>
+            <InspectorComponent isOpen="state.currentTab == 'inspector'"
+                t-ref="InspectorComponent"/>
             <ActionsComponent isOpen="state.currentTab == 'actions'"
                 t-ref="ActionsComponent"/>
         </t>

--- a/src/plugins/DevTools/components/DevToolsComponent.ts
+++ b/src/plugins/DevTools/components/DevToolsComponent.ts
@@ -23,10 +23,14 @@ export class DevToolsComponent extends OwlUIComponent<{}, DevToolsState> {
     handlers: PluginHandlers = {
         intents: {
             '*': 'addAction',
+            'render': 'render',
         },
     };
     commands = {
         addAction: this.addAction.bind(this),
+        render: (): void => {
+            this.render();
+        },
     };
     localStorage = ['closed', 'currentTab', 'height'];
     // For resizing/opening (see toggleClosed)

--- a/src/plugins/DevTools/components/DevToolsComponent.ts
+++ b/src/plugins/DevTools/components/DevToolsComponent.ts
@@ -23,14 +23,12 @@ export class DevToolsComponent extends OwlUIComponent<{}, DevToolsState> {
     handlers: PluginHandlers = {
         intents: {
             '*': 'addAction',
-            'render': 'render',
+            'render': 'onRender',
         },
     };
     commands = {
         addAction: this.addAction.bind(this),
-        render: (): void => {
-            this.render();
-        },
+        onRender: this.onRender.bind(this),
     };
     localStorage = ['closed', 'currentTab', 'height'];
     // For resizing/opening (see toggleClosed)
@@ -49,6 +47,20 @@ export class DevToolsComponent extends OwlUIComponent<{}, DevToolsState> {
         const actionsComponent = this.refs.ActionsComponent as ActionsComponent;
         if (actionsComponent) {
             actionsComponent.addAction(action);
+        }
+    }
+    /**
+     * On render the `vDocument`, rerender and select the range nodes.
+     */
+    onRender(): void {
+        this.render();
+        const inspectorComponent = this.refs.InspectorComponent as InspectorComponent;
+        if (inspectorComponent) {
+            const rangeNodes = this.env.editor.vDocument.rangeNodes;
+            inspectorComponent._selectNode(rangeNodes.start);
+            // In order for owl-framework to unfold the parents of start *and*
+            // of end, we need to select both, with a tick in between.
+            setTimeout(() => inspectorComponent._selectNode(rangeNodes.end), 0);
         }
     }
     /**

--- a/src/plugins/DevTools/components/TreeComponent.ts
+++ b/src/plugins/DevTools/components/TreeComponent.ts
@@ -107,6 +107,9 @@ export class TreeComponent extends OwlUIComponent<NodeProps, NodeState> {
         if (node.value) {
             return utils.toUnicode(node.value);
         }
+        if (node.type && node.type.startsWith('RANGE')) {
+            return node.type.endsWith('START') ? '【' : '】';
+        }
         if (node.type) {
             return node.type.toLowerCase();
         }


### PR DESCRIPTION
This implements a `setRange` flux:
1. User clicks in DOM
2. `EventNormalizer` interprets the click and sends a `CustomEvent`
3. `EventManager` interprets the `CustomEvent` and triggers an `Intent` (`'setRange'`, generated by the `ActionGenerator`) via the `Dispatcher`
4. `CorePlugin` picks up the `Intent` and matches the DOM nodes to their respective `VNodes`, moves the `Range VNodes` accordingly, and triggers a 'render' `Intent` via the `Dispatcher`.
5. After giving a chance to other plugins to react on it, `CorePlugin` picks up the action and triggers a rendering in the `Renderer`.
6. `Renderer` rerenders the tree and sets the range according to the position of the `Range VNodes`

TODO
* update the store AFTER the whole flux: requires a mechanism to recognize the end of the flux
* handle range on `BR` nodes properly. Currently the `Renderer` sets the range logically where it belongs, but that is not how the DOM works: it prefers following a set of rules inspired by Kamoulox to handle the range on consecutive `BR` nodes.