### PR TITLE
[IMP] Unfold node in debugger

### DIFF
--- a/src/plugins/DevTools/DevTools.xml
+++ b/src/plugins/DevTools/DevTools.xml
@@ -10,6 +10,7 @@
                         <TreeComponent
                             vNode="env.editor.vDocument.contents"
                             isRoot="true"
+                            selectedPath="state.selectedPath"
                             selectedID="state.selectedNode.id"/>
                     </devtools-tree>
                 </mainpane-contents>
@@ -72,6 +73,7 @@
                 t-foreach="props.vNode.children" t-as="child"
                 t-key="child.id"
                 vNode="child"
+                selectedPath="props.selectedPath"
                 selectedID="props.selectedID"/>
         </div>
     </t>

--- a/src/plugins/DevTools/components/TreeComponent.ts
+++ b/src/plugins/DevTools/components/TreeComponent.ts
@@ -5,6 +5,7 @@ import { OwlUIComponent } from '../../../ui/OwlUIComponent';
 interface NodeProps {
     isRoot: boolean;
     vNode: VNode;
+    selectedPath: VNode[];
 }
 
 interface NodeState {
@@ -30,6 +31,21 @@ export class TreeComponent extends OwlUIComponent<NodeProps, NodeState> {
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
+
+    /**
+     * Update `state.folded` when `props.selectedPath` changes if `props.vNode`
+     * is in `props.selectedPath`, unless it is the last item.
+     */
+    async willUpdateProps(nextProps: NodeProps): Promise<void> {
+        // The selected node itself should stay folded even when selected. Only
+        // the nodes in the path leading to it should actually be unfolded. By
+        // construction, the last item of `selected path` is always the selected
+        // node itself so it can safely be omitted from the check.
+        const path = nextProps.selectedPath.slice(0, -1);
+        if (path.some(node => node.id === nextProps.vNode.id)) {
+            this.state.folded = false;
+        }
+    }
 
     /**
      * Handle a click event on a node of the tree: toggle its fold on click its


### PR DESCRIPTION
When a node is selected (e. g. from the sidebar), unfold all the
components (TreeComponent) if it's node is present in the selected path.