### PR TITLE
[FIX] EventNormalizer: bind events to ownerDocument

### DIFF
--- a/src/core/utils/EventNormalizer.ts
+++ b/src/core/utils/EventNormalizer.ts
@@ -69,7 +69,7 @@ export class EventNormalizer {
         this.editable = editable as DOMElement;
         this._eventCallback = eventCallback;
 
-        const document = window.top.document;
+        const document = this.editable.ownerDocument;
         this._bindEvent(document, 'selectionchange', this._onSelectionChange);
         this._bindEvent(document, 'click', this._onClick);
         this._bindEvent(document, 'touchend', this._onClick);


### PR DESCRIPTION
... instead of the top window's document (which fails with iframes and shadow doms)