### PR TITLE
[POC] Renderer: set Range with Range Nodes

### DIFF
--- a/src/core/JWEditor.ts
+++ b/src/core/JWEditor.ts
@@ -62,12 +62,12 @@ export class JWEditor {
         // plugin because it needs to behave like one. In other words it must
         // listen to Actions and react to them within the dispatching loop,
         // thereby giving a chance to other plugins to react as well.
-        // Given its specificity, it requires that we pass it the vDocument
+        // Given its specificity, it requires that we pass it the editor
         // instance so we instantiate it here to pass that through the
         // constructor.
         // TODO: when the memory slice system is introduced, this special case
         // will not be required anymore.
-        const corePlugin = new CorePlugin(this.dispatcher, this.vDocument);
+        const corePlugin = new CorePlugin(this);
         this._registerPlugin(corePlugin);
 
         // Init the event manager now that the cloned editable is in the DOM.
@@ -78,7 +78,7 @@ export class JWEditor {
         });
 
         // Render the contents of `vDocument`
-        this.renderer = new Renderer();
+        this.renderer = new Renderer(this.vDocument.range);
         this.renderer.render(this.vDocument.root, this.editable);
     }
 

--- a/src/core/dispatcher/Dispatcher.ts
+++ b/src/core/dispatcher/Dispatcher.ts
@@ -1,3 +1,5 @@
+import { ActionGenerator } from '../actions/ActionGenerator';
+
 export type HandlerToken = string;
 export type Handlers = Record<HandlerToken, ActionHandler>;
 export type DispatcherRegistry = Record<ActionIdentifier, Handlers>;
@@ -24,10 +26,14 @@ export class Dispatcher {
      */
     dispatch(action: Action): void {
         const handlers: Handlers = this._getHandlers(action.id);
-        Object.keys(handlers).forEach((handlerToken: HandlerToken): void => {
+        const handlerTokens = Object.keys(handlers);
+        handlerTokens.forEach((handlerToken: HandlerToken): void => {
             handlers[handlerToken](action); // TODO: use return value to retrigger
         });
-        if (!Object.keys(handlers).length) {
+        // Render when done dispatching
+        if (handlerTokens.length && action.name !== 'render') {
+            this.dispatch(ActionGenerator.intent({ name: 'render' }));
+        } else if (!handlerTokens.length) {
             console.warn(`No plugin is listening to the ${action.type} "${action.name}".`);
         }
     }

--- a/src/core/stores/Range.ts
+++ b/src/core/stores/Range.ts
@@ -1,8 +1,0 @@
-type Direction = 'ltr' | 'rtl';
-export interface Range {
-    startContainer: DOMElement;
-    startOffset: number;
-    endContainer: DOMElement;
-    endOffset: number;
-    direction: Direction;
-}

--- a/src/core/stores/VDocument.ts
+++ b/src/core/stores/VDocument.ts
@@ -1,8 +1,11 @@
 import { VNode } from './VNode';
+import { VRange, RelativePosition } from './VRange';
 
 export class VDocument {
     root: VNode;
+    range = new VRange();
     constructor(root: VNode) {
         this.root = root;
+        this.range.setStart(RelativePosition.BEFORE, this.root.firstLeaf).collapse();
     }
 }

--- a/src/core/stores/VRange.ts
+++ b/src/core/stores/VRange.ts
@@ -1,0 +1,94 @@
+import { VNode, VNodeType } from './VNode';
+
+export enum RangeDirection {
+    BACKWARD = 'BACKWARD',
+    FORWARD = 'FORWARD',
+}
+export enum RelativePosition {
+    BEFORE = 'BEFORE',
+    AFTER = 'AFTER',
+}
+export interface TargetLocation {
+    reference: VNode;
+    relativePosition: RelativePosition;
+}
+export interface VRangeLocation {
+    start: TargetLocation;
+    end: TargetLocation;
+    direction: RangeDirection;
+}
+
+export class VRange {
+    readonly _start = new VNode(VNodeType.RANGE_START);
+    readonly _end = new VNode(VNodeType.RANGE_END);
+    direction: RangeDirection;
+    constructor(direction: RangeDirection = RangeDirection.FORWARD) {
+        this.direction = direction;
+    }
+    /**
+     * Collapse the range. Return self.
+     *
+     * @param [onEnd] true to collapse on the end range
+     */
+    collapse(onEnd = false): VRange {
+        if (onEnd) {
+            return this.setStart(RelativePosition.BEFORE, this._end);
+        } else {
+            return this.setEnd(RelativePosition.AFTER, this._start);
+        }
+    }
+    /**
+     * Move the range to the given location. If no end location is given,
+     * collapse on the start location. A location is given by targetting a
+     * reference VNode and specifying the position in reference to that VNode
+     * ('BEFORE', 'AFTER'), like in an `xpath`. Return self.
+     *
+     * @param start
+     * @param [end]
+     */
+    move(start: TargetLocation, end?: TargetLocation): VRange {
+        this.setStart(start.relativePosition, start.reference);
+        const sameReferences = !end || end.reference.id === start.reference.id;
+        const samePositions = !end || end.relativePosition === start.relativePosition;
+        if (sameReferences && samePositions) {
+            return this.collapse();
+        } else {
+            return this.setEnd(end.relativePosition, end.reference);
+        }
+    }
+    /**
+     * Change the range's direction (forward or backward). Return self.
+     *
+     * @param direction
+     */
+    setDirection(direction: RangeDirection): VRange {
+        this.direction = direction;
+        return this;
+    }
+    /**
+     * Set the start of the range by targetting a `reference` VNode and
+     * specifying the `position` in reference to that VNode ('BEFORE', 'AFTER'),
+     * like in an `xpath`. Return self.
+     *
+     * @param position
+     * @param reference
+     */
+    setStart(position: RelativePosition, reference: VNode): VRange {
+        const methodName = position === RelativePosition.BEFORE ? 'before' : 'after';
+        reference[methodName](this._start);
+        return this;
+    }
+    /**
+     * Set the start of the range by targetting a `reference` VNode and
+     * specifying the `position` in reference to that VNode ('BEFORE', 'AFTER'),
+     * like in an `xpath`. Return self.
+     *
+     * @param position
+     * @param reference
+     */
+    setEnd(position: RelativePosition, reference: VNode): VRange {
+        const methodName = position === RelativePosition.BEFORE ? 'before' : 'after';
+        reference[methodName](this._end);
+        return this;
+    }
+}

--- a/src/core/utils/CorePlugin.ts
+++ b/src/core/utils/CorePlugin.ts
@@ -1,26 +1,51 @@
 import { JWPlugin } from '../JWPlugin';
-import { VDocument } from '../stores/VDocument';
+import JWEditor from '../JWEditor';
+import { VRangeLocation, RangeDirection } from '../stores/VRange';
 
 export class CorePlugin extends JWPlugin {
-    vDocument: VDocument;
+    editor: JWEditor;
     handlers = {
         intents: {
             remove: 'onRemoveIntent', // names are just to show relationships here
+            render: 'render',
+            setRange: 'navigate',
         },
     };
     commands = {
+        navigate: this.navigate.bind(this),
         onRemoveIntent: this.removeSide,
+        render: this.render.bind(this),
     };
-    constructor(dispatcher, vDocument) {
-        super(dispatcher);
-        this.vDocument = vDocument;
+    constructor(editor) {
+        super(editor.dispatcher);
+        this.editor = editor;
     }
 
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
 
-    removeSide(intent: Action): void {
+    removeSide(intent: Intent): void {
         console.log('REMOVE SIDE:' + intent);
+    }
+    /**
+     * Navigate to a given Range (in the payload of the Intent).
+     *
+     * @param intent
+     */
+    navigate(intent: Intent): void {
+        const range: VRangeLocation = intent.payload['vRangeToSet'];
+        if (range.direction === RangeDirection.FORWARD) {
+            this.editor.vDocument.range.move(range.start, range.end);
+        } else {
+            this.editor.vDocument.range.move(range.end, range.start);
+        }
+        this.editor.vDocument.range.setDirection(range.direction);
+    }
+    /**
+     * Render the `vDocument`.
+     */
+    render(): void {
+        this.editor.renderer.render(this.editor.vDocument.root, this.editor.editable);
     }
 }

--- a/src/core/utils/CorePlugin.ts
+++ b/src/core/utils/CorePlugin.ts
@@ -1,6 +1,6 @@
 import { JWPlugin } from '../JWPlugin';
 import JWEditor from '../JWEditor';
-import { VRangeLocation, RangeDirection } from '../stores/VRange';
+import { VRangeLocation, RangeDirection, RelativePosition } from '../stores/VRange';
 
 export class CorePlugin extends JWPlugin {
     editor: JWEditor;
@@ -8,6 +8,7 @@ export class CorePlugin extends JWPlugin {
         intents: {
             remove: 'onRemoveIntent', // names are just to show relationships here
             render: 'render',
+            selectAll: 'navigate',
             setRange: 'navigate',
         },
     };
@@ -34,7 +35,12 @@ export class CorePlugin extends JWPlugin {
      * @param intent
      */
     navigate(intent: Intent): void {
-        const range: VRangeLocation = intent.payload['vRangeToSet'];
+        let range: VRangeLocation;
+        if (intent.name === 'selectAll') {
+            range = this._getRangeAll();
+        } else {
+            range = intent.payload['vRangeToSet'];
+        }
         if (range.direction === RangeDirection.FORWARD) {
             this.editor.vDocument.range.move(range.start, range.end);
         } else {
@@ -47,5 +53,23 @@ export class CorePlugin extends JWPlugin {
      */
     render(): void {
         this.editor.renderer.render(this.editor.vDocument.root, this.editor.editable);
+    }
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    _getRangeAll(): VRangeLocation {
+        return {
+            start: {
+                reference: this.editor.vDocument.root.firstLeaf,
+                relativePosition: RelativePosition.BEFORE,
+            },
+            end: {
+                reference: this.editor.vDocument.root.lastLeaf,
+                relativePosition: RelativePosition.AFTER,
+            },
+            direction: RangeDirection.FORWARD,
+        };
     }
 }

--- a/src/core/utils/EventManager.ts
+++ b/src/core/utils/EventManager.ts
@@ -1,6 +1,8 @@
-import { EventNormalizer } from './EventNormalizer';
+import { EventNormalizer, DomRangeToSet } from './EventNormalizer';
 import { DispatchFunction } from '../dispatcher/Dispatcher';
 import { ActionGenerator } from '../actions/ActionGenerator';
+import { TargetLocation, VRangeLocation, RelativePosition } from '../stores/VRange';
+import { VDocumentMap } from './VDocumentMap';
 
 export interface EventManagerOptions {
     dispatch?: DispatchFunction;
@@ -22,6 +24,60 @@ export class EventManager {
     //--------------------------------------------------------------------------
 
     /**
+     * Convert the DOM values for a range to set to VRange locations in the
+     * CustomEvent's payload.
+     *
+     * @param range
+     */
+    _convertRange(range: DomRangeToSet): VRangeLocation {
+        return {
+            start: this._getTargetLocation(range.startContainer, range.startOffset),
+            end: this._getTargetLocation(range.endContainer, range.endOffset),
+            direction: range.direction,
+        };
+    }
+    /**
+     * Return a position in the `VDocument` as an object containing a reference
+     * node (`ref`) and a position (`position`: 'BEFORE' or 'AFTER' the
+     * reference VNode). The position is always given on the leaf.
+     *
+     * @param container
+     * @param offset
+     */
+    _getTargetLocation(container: DOMElement | Node, offset: number): TargetLocation {
+        // Move to deepest child of container
+        while (container.hasChildNodes()) {
+            container = container.childNodes[offset];
+            offset = 0;
+        }
+        // Get the VNodes matching the container
+        const containers = VDocumentMap.fromDom(container);
+        // The reference is the offset-th match (eg.: text split into chars)
+        const location: TargetLocation = {
+            reference: containers[offset],
+            relativePosition: RelativePosition.BEFORE,
+        };
+        // At the end of a text node (eg.: 'text', offset 4 -> we target AFTER
+        // the char at index 3 (containers[4] does not exist).
+        if (container.nodeType === Node.TEXT_NODE && !location.reference) {
+            location.reference = containers[containers.length - 1];
+            location.relativePosition = RelativePosition.AFTER;
+        }
+        return this._makeLocationDeepest(location);
+    }
+    /**
+     * Move the position to its deepest first descendent.
+     *
+     * @param location
+     */
+    _makeLocationDeepest(location: TargetLocation): TargetLocation {
+        while (location.reference.children.length) {
+            location.reference = location.reference.firstChild;
+            location.relativePosition = RelativePosition.BEFORE;
+        }
+        return location;
+    }
+    /**
      * Match the received signal with the corresponding user intention, based on
      * the user's configuration and context.
      * TODO: this is just a stub
@@ -30,14 +86,18 @@ export class EventManager {
      * @returns {Action}
      */
     _matchIntent(customEvent: CustomEvent): Intent {
+        let payload = customEvent.detail;
         switch (customEvent.type) {
-            case 'remove':
-            // todo: return a 'remove' action of type 'intent', with the right payload
+            case 'setRange':
+                payload = Object.assign({}, payload, {
+                    vRangeToSet: this._convertRange(payload['domRangeToSet']),
+                });
+                break;
         }
         return ActionGenerator.intent({
             name: customEvent.type,
             origin: 'EventManager',
-            payload: customEvent.detail,
+            payload: payload,
         });
     }
     /**

--- a/src/core/utils/EventNormalizer.ts
+++ b/src/core/utils/EventNormalizer.ts
@@ -1,3 +1,5 @@
+import { RangeDirection } from '../stores/VRange';
+
 const navigationKey = new Set([
     'ArrowUp',
     'ArrowDown',
@@ -9,13 +11,12 @@ const navigationKey = new Set([
     'Home',
 ]);
 
-type Direction = 'ltr' | 'rtl';
-interface Range {
+export interface DomRangeToSet {
     readonly startContainer: DOMElement;
     readonly startOffset: number;
     readonly endContainer: DOMElement;
     readonly endOffset: number;
-    readonly direction: Direction;
+    readonly direction: RangeDirection;
     origin?: string; // origin of the Range change
 }
 
@@ -445,17 +446,19 @@ export class EventNormalizer {
      *
      * @private
      */
-    _getRange(): Range {
+    _getRange(): DomRangeToSet {
         const selection = this.editable.ownerDocument.getSelection();
 
         if (!selection || selection.rangeCount === 0) {
+            const direction =
+                this.editable.dir === 'ltr' ? RangeDirection.FORWARD : RangeDirection.BACKWARD;
             // No selection means no range so a fake one is created
             return {
                 startContainer: this.editable,
                 startOffset: 0,
                 endContainer: this.editable,
                 endOffset: 0,
-                direction: this.editable.dir as Direction,
+                direction: direction,
             };
         } else {
             // The direction of the range is sorely missing from the DOM api
@@ -471,7 +474,7 @@ export class EventNormalizer {
                 startOffset: nativeRange.startOffset,
                 endContainer: nativeRange.endContainer as DOMElement,
                 endOffset: nativeRange.endOffset,
-                direction: ltr ? 'ltr' : 'rtl',
+                direction: ltr ? RangeDirection.FORWARD : RangeDirection.BACKWARD,
             };
         }
     }
@@ -574,16 +577,16 @@ export class EventNormalizer {
         // their corresponding indices in the previous DOM.
         const insertPreviousStart = insertStart;
         const insertPreviousEnd = insertEnd + previousLength - currentLength;
-        const insertionRange: Range = {
+        const insertionRange: DomRangeToSet = {
             startContainer: previousNodes[insertPreviousStart].origin,
             startOffset: previous.offsets[insertPreviousStart],
             endContainer: previousNodes[insertPreviousEnd].origin,
             endOffset: previous.offsets[insertPreviousEnd],
-            direction: 'rtl',
+            direction: RangeDirection.BACKWARD,
             origin: 'composition',
         };
 
-        this._triggerEvent('setRange', { value: insertionRange });
+        this._triggerEvent('setRange', { domRangeToSet: insertionRange });
         this._triggerEvent('insert', { value: insertedText, elements: ev.elements });
     }
     /**
@@ -603,7 +606,7 @@ export class EventNormalizer {
             const range = this._getRange();
             range.origin = ev.key;
             // TODO: nagivation word/line ?
-            this._triggerEvent('setRange', { value: range, elements: ev.elements });
+            this._triggerEvent('setRange', { domRangeToSet: range, elements: ev.elements });
         }
     }
     /**
@@ -611,7 +614,7 @@ export class EventNormalizer {
      *
      * @param range
      */
-    _isSelectAll(range: Range): boolean {
+    _isSelectAll(range: DomRangeToSet): boolean {
         let startContainer = range.startContainer;
         let startOffset = range.startOffset;
         let endContainer = range.endContainer;
@@ -702,7 +705,9 @@ export class EventNormalizer {
             // container. The editable node is supposed to be visible.
             return true;
         }
-        const style = window.getComputedStyle(el);
+        const style = window.getComputedStyle(
+            el.nodeType === Node.TEXT_NODE ? el.parentElement : el,
+        );
         if (style.display === 'none' || style.visibility === 'hidden') {
             return false;
         }
@@ -891,8 +896,10 @@ export class EventNormalizer {
             const target = this._mousedownInEditable.target as Element;
             this._mousedownInEditable = null;
             if (ev.target instanceof Element) {
-                let range: Range = this._getRange();
+                let range: DomRangeToSet = this._getRange();
                 if (!target.contains(range.startContainer) && target === ev.target) {
+                    const direction =
+                        document.dir === 'ltr' ? RangeDirection.FORWARD : RangeDirection.BACKWARD;
                     range = {
                         startContainer: target as DOMElement,
                         startOffset: 0,
@@ -901,12 +908,12 @@ export class EventNormalizer {
                             target.nodeType === Node.ELEMENT_NODE
                                 ? target.childNodes.length
                                 : target.nodeValue.length,
-                        direction: document.dir as Direction,
+                        direction: direction,
                         origin: 'pointer',
                     };
                 }
                 if (this._rangeHasChanged) {
-                    this._triggerEvent('setRange', { value: range });
+                    this._triggerEvent('setRange', { domRangeToSet: range });
                 }
             }
         }, 0);

--- a/src/core/utils/EventNormalizer.ts
+++ b/src/core/utils/EventNormalizer.ts
@@ -705,6 +705,10 @@ export class EventNormalizer {
             // container. The editable node is supposed to be visible.
             return true;
         }
+        // A <br> element with no next sibling is never visible.
+        if (el.tagName === 'BR' && !el.nextSibling) {
+            return false;
+        }
         const style = window.getComputedStyle(
             el.nodeType === Node.TEXT_NODE ? el.parentElement : el,
         );
@@ -925,6 +929,13 @@ export class EventNormalizer {
      * @param {Event} ev
      */
     _onSelectionChange(): void {
+        if (this._rangeHasChanged) {
+            // This should disappear once the "diff" system is introduced.
+            // Right now it is required so as to avoid an infinite loop when
+            // selectAll triggers a new range set... and the selection changes
+            // every time.
+            return;
+        }
         this._rangeHasChanged = true;
         // do nothing, wait for mouseup !
         if (this._mousedownInEditable || this.editable.style.display === 'none') {

--- a/src/core/utils/Renderer.ts
+++ b/src/core/utils/Renderer.ts
@@ -1,14 +1,34 @@
 import { VNode, VNodeType } from '../stores/VNode';
 import { Format } from './Format';
 import { VDocumentMap } from './VDocumentMap';
+import { VRange, RangeDirection } from '../stores/VRange';
 
 type ParentElement = Element | DocumentFragment;
+type ContainerToSet = 'start' | 'end' | DOMElement | Node;
+interface RangeToSet {
+    startContainer?: ContainerToSet;
+    endContainer?: ContainerToSet;
+    startOffset?: 'end' | number;
+    endOffset?: 'end' | number;
+}
+interface ComputedRange {
+    startContainer: DOMElement | Node;
+    endContainer: DOMElement | Node;
+    startOffset: number;
+    endOffset: number;
+}
 interface RenderingContext {
-    vNode?: VNode;
-    parentElement?: ParentElement;
+    vNode?: VNode; // The VNode to render
+    parentElement?: ParentElement; // The parent in which to render the VNode
+    lastRendered?: DOMElement | Node; // The last element that was rendered
+    range?: RangeToSet; // The range that will eventually have to be set
 }
 
 export class Renderer {
+    range: VRange;
+    constructor(range: VRange) {
+        this.range = range;
+    }
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
@@ -23,16 +43,80 @@ export class Renderer {
         target.innerHTML = ''; // TODO: update instead of recreate
         VDocumentMap.clear(); // TODO: update instead of recreate
         const fragment: DocumentFragment = document.createDocumentFragment();
+        let context: RenderingContext = {};
+
+        // Render every child of `root` in `fragment` and update the context at
+        // every step
         root.children.forEach(child => {
-            this._renderVNode(child, fragment);
+            const rangeToSet = context && context.range;
+            Object.assign(context, {
+                vNode: child,
+                parentElement: fragment,
+                range: rangeToSet || {},
+            });
+            context = this._renderVNode(context);
         });
         target.appendChild(fragment);
+
+        // Set the new range, base on the accumulated context
+        const computedRange = this._computeRange(context.range, fragment);
+        this._setRange(computedRange, target);
     }
 
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
 
+    /**
+     * Compute the DOM Range to set, based on potentially relative positions
+     * ('start', 'end').
+     *
+     * @param range
+     * @param rendered
+     */
+    _computeRange(range: RangeToSet, rendered: DocumentFragment): ComputedRange {
+        const startContainer = this._computeContainer(range.startContainer, rendered);
+        const endContainer = range.endContainer
+            ? this._computeContainer(range.endContainer, rendered)
+            : startContainer;
+        const startOffset = this._computeOffset(range.startOffset, startContainer);
+        const endOffset =
+            typeof range.endOffset === 'undefined'
+                ? startOffset
+                : this._computeOffset(range.endOffset, endContainer);
+        return {
+            startContainer: startContainer,
+            startOffset: startOffset,
+            endContainer: endContainer,
+            endOffset: endOffset,
+        };
+    }
+    /**
+     * Compute a container, based on a potentially relative position ('start', 'end').
+     *
+     * @param container
+     * @param rendered
+     */
+    _computeContainer(container: ContainerToSet, rendered: DocumentFragment): DOMElement | Node {
+        if (typeof container === 'string') {
+            return this._toLeaf(rendered, container === 'start' ? 'first' : 'last');
+        } else {
+            return container;
+        }
+    }
+    /**
+     * Compute an offset, based on a potentially relative position ('end').
+     *
+     * @param offset
+     * @param computedContainer
+     */
+    _computeOffset(offset: 'end' | number, computedContainer: DOMElement | Node): number {
+        if (offset === 'end') {
+            return this._nodeLength(computedContainer);
+        } else {
+            return offset;
+        }
+    }
     /**
      * Return true if `a` has the same format properties as `b`.
      *
@@ -43,27 +127,41 @@ export class Renderer {
         return Object.keys(a.format).every(k => a.format[k] === b.format[k]);
     }
     /**
-     * Return the next rendering context, based on the given vNode. This
+     * Return a tuple containing a <br> element's parent and the offset on which
+     * to set the range in order to target the BR (namely, the index of the
+     * BR + 1).
+     *
+     * @param br
+     */
+    _moveToParentOfBR(br: Node | DOMElement): [DOMElement | Node, number] {
+        let offset = 1; // always AFTER the BR
+        Array.from(br.parentElement.childNodes).some(child => {
+            if (child.isSameNode(br)) {
+                return true;
+            }
+            offset++;
+        });
+        return [br.parentElement, offset];
+    }
+    /**
+     * Return the next rendering context, based on the given context. This
      * includes the next VNode to render and the next parent element to render
      * it into.
      *
-     * @param vNode
+     * @param context
      */
-    _nextRenderingContext(vNode: VNode): RenderingContext {
+    _nextRenderingContext(context: RenderingContext): RenderingContext {
+        const vNode = context.vNode;
+        let newVNode: VNode;
+        let newParent: ParentElement;
         if (vNode.children.length) {
             // Render the first child with the current node as parent, if any.
-            return {
-                vNode: vNode.children[0],
-                // Text node cannot have children, therefore parent is Element, not Node
-                parentElement: VDocumentMap.toDom(vNode) as DOMElement,
-            };
+            newVNode = vNode.children[0];
+            newParent = VDocumentMap.toDom(vNode) as ParentElement;
         } else if (vNode.nextSibling) {
             // Render the siblings of the current node with the same parent, if any.
-            return {
-                vNode: vNode.nextSibling,
-                // Text node cannot have children, therefore parent is Element, not Node
-                parentElement: VDocumentMap.toDom(vNode.parent) as DOMElement,
-            };
+            newVNode = vNode.nextSibling;
+            newParent = VDocumentMap.toDom(vNode.parent) as ParentElement;
         } else {
             // Render the next ancestor sibling in the ancestor tree, if any.
             let ancestor = vNode.parent;
@@ -74,37 +172,80 @@ export class Renderer {
             // At this point, the found ancestor has a sibling. If no ancestor
             // having a sibling could be found, the tree has been fully rendered.
             if (ancestor) {
-                return {
-                    vNode: ancestor.nextSibling,
-                    // Text node cannot have children, therefore parent is Element, not Node
-                    parentElement: VDocumentMap.toDom(ancestor.parent) as DOMElement,
-                };
+                newVNode = ancestor.nextSibling;
+                newParent = VDocumentMap.toDom(ancestor.parent) as ParentElement;
             }
         }
-        return {};
+        return Object.assign(context, {
+            vNode: newVNode,
+            parentElement: newParent,
+        });
     }
     /**
-     * Create the element matching this vNode and append it.
+     * Return the length of a DOM node.
      *
-     * @param vNode
-     * @param parent
+     * @param domNode
      */
-    _renderElement(vNode: VNode, parent: ParentElement): RenderingContext {
-        const element = vNode.render<HTMLElement>('html');
-        parent.appendChild(element);
-        VDocumentMap.set(element, vNode);
-        return {
-            vNode: vNode,
-            parentElement: parent,
-        };
+    _nodeLength(domNode: DOMElement | Node): number {
+        if (domNode.nodeType === Node.TEXT_NODE) {
+            return domNode.textContent.length;
+        } else {
+            return domNode.childNodes.length;
+        }
+    }
+    /**
+     * Create the element matching this context's vNode and append it.
+     *
+     * @param context
+     */
+    _renderElement(context: RenderingContext): RenderingContext {
+        const element = context.vNode.render<HTMLElement>('html');
+        context.parentElement.appendChild(element);
+        VDocumentMap.set(element, context.vNode);
+        return Object.assign(context, {
+            vNode: context.vNode,
+            parentElement: context.parentElement,
+            lastRendered: element,
+        });
+    }
+    /**
+     * Render a Range node: update the range to set.
+     *
+     * @param context
+     * @param [offset] default: 0
+     */
+    _renderRangeNode(context: RenderingContext, offset = 0): RenderingContext {
+        let container: ContainerToSet;
+        if (context.lastRendered) {
+            if (context.lastRendered.nodeName === 'BR') {
+                // In the case where the last rendered element was a <br>, we
+                // need to target its parent at offset == BR.index + 1 for the
+                // browser to show the range where expected.
+                [container, offset] = this._moveToParentOfBR(context.lastRendered);
+            } else {
+                // The range will be set on the last rendered element.
+                container = context.lastRendered;
+            }
+        } else {
+            // If no node was created yet, target the very beginning of the
+            // editable container.
+            container = 'start';
+        }
+        // Update the context.
+        const isStart = context.vNode.type.endsWith('START');
+        context.range[isStart ? 'startContainer' : 'endContainer'] = container;
+        context.range[isStart ? 'startOffset' : 'endOffset'] = offset;
+        return context;
     }
     /**
      * Render a text node, based on consecutive char nodes.
      *
-     * @param vNode
-     * @param parent
+     * @param context
      */
-    _renderTextNode(vNode: VNode, parent: ParentElement): RenderingContext {
+    _renderTextNode(context: RenderingContext): RenderingContext {
+        let vNode = context.vNode;
+        let parent = context.parentElement;
+
         // If the node has a format, render the format nodes first.
         const renderedFormats = [];
         Object.keys(vNode.format).forEach(type => {
@@ -118,44 +259,133 @@ export class Renderer {
         });
 
         // Consecutive compatible char nodes are rendered as a single text node.
+        // If range nodes are encountered while collecting the char nodes,
+        // collect information about their location so we can update the range
+        // to set once the text node is rendered.
         let text = vNode.value;
-        let next = vNode.nextSibling;
         const charNodes = [vNode];
-        while (next && next.type === VNodeType.CHAR && this._isSameFormat(vNode, next)) {
-            charNodes.push(next);
-            text += next.value;
-            vNode = next;
-            next = vNode.nextSibling;
-        }
+        const rangeNodes: ({ node: VNode; offset: number })[] = [];
+        vNode = vNode.nextSiblings((sibling: VNode, previous: VNode) => {
+            if (sibling.type === VNodeType.CHAR && this._isSameFormat(previous, sibling)) {
+                // Collect text.
+                charNodes.push(sibling);
+                text += sibling.value;
+            } else if (sibling.type.startsWith('RANGE')) {
+                // Collect information about the range node's location.
+                rangeNodes.push({
+                    node: sibling,
+                    offset: charNodes.length,
+                });
+            } else {
+                // No more consecutive char nodes: return the last char node to
+                // update the value of `vNode`.
+                return true;
+            }
+        });
+
+        // Create and append the text node, update the VDocumentMap.
         const renderedNode = document.createTextNode(text);
         parent.appendChild(renderedNode);
         charNodes.forEach(charNode => {
             VDocumentMap.set(renderedNode, charNode);
             renderedFormats.forEach(formatNode => VDocumentMap.set(formatNode, charNode));
         });
-        return {
+
+        // Update the context.
+        const newContext = Object.assign({}, context, {
             vNode: vNode,
             parentElement: parent,
-        };
+            lastRendered: renderedNode,
+        });
+
+        // If range nodes were encountered while collecting char nodes, render
+        // them and update the context.
+        rangeNodes.forEach(rangeNode => {
+            const rangeContext = Object.assign({}, newContext, { vNode: rangeNode.node });
+            const updatedContext = this._renderRangeNode(rangeContext, rangeNode.offset);
+            Object.assign(newContext, {
+                range: updatedContext.range,
+            });
+        });
+        return newContext;
     }
     /**
      * Render a VNode and trigger the rendering of the next one, recursively.
      *
-     * @param vNode
-     * @param parent
+     * @param context
      */
-    _renderVNode(vNode: VNode, parent: ParentElement): void {
-        let context: RenderingContext;
-        if (vNode.type === VNodeType.CHAR) {
-            context = this._renderTextNode(vNode, parent);
+    _renderVNode(context: RenderingContext): RenderingContext {
+        const contextCopy = Object.assign({}, context);
+        if (context.vNode.type === VNodeType.CHAR) {
+            context = this._renderTextNode(contextCopy);
+        } else if (context.vNode.type.startsWith('RANGE')) {
+            context = this._renderRangeNode(contextCopy);
         } else {
-            context = this._renderElement(vNode, parent);
+            context = this._renderElement(contextCopy);
         }
 
-        context = this._nextRenderingContext(context.vNode);
+        context = this._nextRenderingContext(context);
 
         if (context.vNode && context.parentElement) {
-            this._renderVNode(context.vNode, context.parentElement);
+            this._renderVNode(context);
         }
+
+        return context;
+    }
+    /**
+     * Compute and set a new range in the DOM.
+     *
+     * @param range the range to set
+     * @param target the target in which to set the range
+     */
+    _setRange(range: ComputedRange, target: Element): void {
+        if (this.range.direction === RangeDirection.FORWARD) {
+            this._setRangeForward(range, target);
+        } else {
+            this._setRangeBackward(range, target);
+        }
+    }
+    /**
+     * Set a new backward range in the DOM.
+     *
+     * @param computedRange
+     * @param target
+     */
+    _setRangeBackward(computedRange: ComputedRange, target: Element): void {
+        const domRange: Range = target.ownerDocument.createRange();
+        const selection = document.getSelection();
+        domRange.setEnd(computedRange.startContainer, computedRange.startOffset);
+        domRange.collapse(false);
+        selection.removeAllRanges();
+        selection.addRange(domRange);
+        selection.extend(computedRange.endContainer, computedRange.endOffset);
+    }
+    /**
+     * Set a new forward range in the DOM.
+     *
+     * @param computedRange
+     * @param target
+     */
+    _setRangeForward(computedRange: ComputedRange, target: Element): void {
+        const domRange: Range = target.ownerDocument.createRange();
+        const selection = document.getSelection();
+        domRange.setStart(computedRange.startContainer, computedRange.startOffset);
+        domRange.setEnd(computedRange.endContainer, computedRange.endOffset);
+        selection.removeAllRanges();
+        selection.addRange(domRange);
+    }
+    /**
+     * Move a DOM node to its first/last leaf.
+     *
+     * @param domNode
+     * @param side ('first' or 'last')
+     */
+    _toLeaf(domNode: DOMElement | Node, side: 'first' | 'last'): DOMElement | Node {
+        const edgeChild = side === 'first' ? 'firstChild' : 'lastChild';
+        let leaf: DOMElement | Node = domNode;
+        while (leaf && leaf[edgeChild]) {
+            leaf = leaf[edgeChild];
+        }
+        return leaf;
     }
 }

--- a/src/plugins/DevTools/DevTools.css
+++ b/src/plugins/DevTools/DevTools.css
@@ -143,6 +143,10 @@ devtools-tree > devtools-node.root > span.element-name {
     box-sizing: border-box;
 }
 
+devtools-tree devtools-node > span.range-node {
+    color: red;
+}
+
 devtools-tree span.element-name {
     width: 100%;
     display: inline-block;

--- a/src/plugins/DevTools/DevTools.xml
+++ b/src/plugins/DevTools/DevTools.xml
@@ -43,7 +43,14 @@
             <t t-call="treeChildren"/>
         </t>
         <t t-else="">
-            <span t-if="props.vNode.value" t-on-click="onClickNode"
+            <span t-if="props.vNode.type == 'RANGE_START' or props.vNode.type == 'RANGE_END'"
+                t-on-click="onClickNode"
+                class="selectable-line range-node" t-att-class="{
+                    selected: props.selectedID == props.vNode.id,
+                }">
+                <t t-esc="repr"/>
+            </span>
+            <span t-elif="props.vNode.value" t-on-click="onClickNode"
                 class="selectable-line" t-att-class="{
                     bold: props.vNode.format.bold,
                     italic: props.vNode.format.italic,

--- a/src/plugins/DevTools/DevTools.xml
+++ b/src/plugins/DevTools/DevTools.xml
@@ -371,7 +371,8 @@
             }">Actions</button>
         </devtools-navbar>
         <t t-if="!state.closed">
-            <InspectorComponent isOpen="state.currentTab == 'inspector'"/>
+            <InspectorComponent isOpen="state.currentTab == 'inspector'"
+                t-ref="InspectorComponent"/>
             <ActionsComponent isOpen="state.currentTab == 'actions'"
                 t-ref="ActionsComponent"/>
         </t>

--- a/src/plugins/DevTools/DevTools.xml
+++ b/src/plugins/DevTools/DevTools.xml
@@ -287,7 +287,8 @@
                         <t t-esc="key"/>
                     </td>
                     <td>
-                        <t t-if="value and key == 'range'" t-call="payloadRange"/>
+                        <t t-if="value and key == 'domRangeToSet'" t-call="payloadRange"/>
+                        <t t-elif="value and key == 'vRangeToSet'" t-call="payloadVRange"/>
                         <t t-else=""><t t-esc="formatPayloadValue(value)"/></t>
                     </td>
                 </tr>
@@ -295,7 +296,7 @@
         </table>
     </t>
 
-    <!-- ACTIONS.Payload.range -->
+    <!-- ACTIONS.Payload.domRangeToSet -->
     <t t-name="payloadRange">
         <table>
             <tbody>
@@ -306,6 +307,33 @@
                     </td>
                     <td>
                         <t t-esc="formatPayloadValue(value)"/>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </t>
+
+    <!-- ACTIONS.Payload.vRangeToSet -->
+    <t t-name="payloadVRange">
+        <table>
+            <tbody>
+                <tr t-foreach="Object.keys(value)" t-as="rangeKey" t-key="rangeKey_index">
+                    <t t-set="value" t-value="value[rangeKey]"/>
+                    <td>
+                        <t t-esc="rangeKey"/>
+                    </td>
+                    <td>
+                        <t t-if="rangeKey == 'direction'">
+                            <t t-esc="value"/>
+                        </t>
+                        <t t-elif="rangeKey == 'start' or rangeKey == 'end'">
+                            <t t-esc="value.relativePosition"/> <t
+                            t-esc="value.reference.id"/> (<t
+                            t-esc="value.reference.value or value.reference.type"/>)
+                        </t>
+                        <t t-else="">
+                            <t t-esc="formatPayloadValue(value)"/>
+                        </t>
                     </td>
                 </tr>
             </tbody>

--- a/src/plugins/DevTools/DevTools.xml
+++ b/src/plugins/DevTools/DevTools.xml
@@ -99,6 +99,20 @@
 
     <!-- INSPECTOR.Info -->
     <devtools-info t-name="InfoComponent">
+        <devtools-navbar>
+            <button t-on-click="openTab('vNode')" t-att-class="{
+                selected: state.currentTab == 'vNode',
+            }">VNode</button>
+            <button t-on-click="openTab('selection')" t-att-class="{
+                selected: state.currentTab == 'selection',
+            }">Selection</button>
+        </devtools-navbar>
+        <t t-call="infoVNode" t-if="state.currentTab == 'vNode'"/>
+        <t t-call="infoSelection" t-if="state.currentTab == 'selection'"/>
+    </devtools-info>
+
+    <!-- INSPECTOR.Info.vNode -->
+    <t t-name="infoVNode">
         <div class="about">
             <span class="type">VNode</span> <t t-esc="props.vNode.type or &quot;?&quot;"/>
             <t t-if="props.vNode.value">:
@@ -193,7 +207,33 @@
                 </tbody>
             </table>
         </div>
-    </devtools-info>
+    </t>
+
+    <!-- INSPECTOR.Info.selection -->
+    <t t-name="infoSelection">
+        <div class="about">
+            <span class="type">VRange</span> Selection
+        </div>
+        <div class="properties">
+            <div class="divider">👤 About me</div>
+            <table>
+                <tbody>
+                    <tr>
+                        <td>direction</td>
+                        <td><t t-esc="state.range.direction"/></td>
+                    </tr>
+                    <tr>
+                        <td>start</td>
+                        <td><t t-esc="reprStart"/></td>
+                    </tr>
+                    <tr>
+                        <td>end</td>
+                        <td><t t-esc="reprEnd"/></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </t>
 
     <!-- ACTIONS -->
     <devtools-panel class="actions" t-name="ActionsComponent"

--- a/src/plugins/DevTools/components/DevToolsComponent.ts
+++ b/src/plugins/DevTools/components/DevToolsComponent.ts
@@ -25,10 +25,14 @@ export class DevToolsComponent extends OwlUIComponent<{}> {
     handlers: PluginHandlers = {
         intents: {
             '*': 'addAction',
+            'render': 'render',
         },
     };
     commands = {
         addAction: this.addAction.bind(this),
+        render: (): void => {
+            this.render();
+        },
     };
     localStorage = ['closed', 'currentTab', 'height'];
     // For resizing/opening (see toggleClosed)

--- a/src/plugins/DevTools/components/InfoComponent.ts
+++ b/src/plugins/DevTools/components/InfoComponent.ts
@@ -1,7 +1,32 @@
 import { VNode } from '../../../core/stores/VNode';
 import { OwlUIComponent } from '../../../ui/OwlUIComponent';
+import { VRange } from '../../../core/stores/VRange';
+import { useState } from 'owl-framework/src/hooks';
 
+interface InfoState {
+    currentTab: string;
+    range: VRange;
+}
 export class InfoComponent extends OwlUIComponent<{}> {
+    state: InfoState = useState({
+        currentTab: 'vNode',
+        range: this.env.editor.vDocument.range,
+    });
+    localStorage = ['currentTab'];
+    /**
+     * Open the tab with the given `tabName`
+     *
+     * @param {string} tabName
+     */
+    openTab(tabName: string): void {
+        this.state.currentTab = tabName;
+    }
+    get reprEnd(): string {
+        return this._repr(this.state.range._end);
+    }
+    get reprStart(): string {
+        return this._repr(this.state.range._start);
+    }
     /**
      * Trigger a 'node-selected' custom event
      * with the given `vNode` to select it
@@ -12,5 +37,21 @@ export class InfoComponent extends OwlUIComponent<{}> {
         this.trigger('node-selected', {
             vNode: vNode,
         });
+    }
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    _repr(rangeNode): string {
+        const next = rangeNode.nextSibling;
+        const prev = rangeNode.previousSibling;
+        if (next) {
+            return `BEFORE ${next.id} (${next.value || next.type})`;
+        } else if (prev) {
+            return `AFTER ${prev.id} (${prev.value || prev.type})`;
+        } else {
+            return 'unknown';
+        }
     }
 }

--- a/src/plugins/DevTools/components/InspectorComponent.ts
+++ b/src/plugins/DevTools/components/InspectorComponent.ts
@@ -14,10 +14,10 @@ interface InspectorState {
 
 export class InspectorComponent extends OwlUIComponent<{}> {
     static components = { InfoComponent, PathComponent, TreeComponent };
-    state: InspectorState = {
+    state: InspectorState = useState({
         selectedNode: this.env.editor.vDocument.root,
         selectedPath: this._getPath(this.env.editor.vDocument.root),
-    };
+    });
 
     /**
      * Handle keyboard navigation in DevTools (arrows to move in the tree)

--- a/src/plugins/DevTools/components/TreeComponent.ts
+++ b/src/plugins/DevTools/components/TreeComponent.ts
@@ -108,6 +108,9 @@ export class TreeComponent extends OwlUIComponent<NodeProps> {
         if (node.value) {
             return utils.toUnicode(node.value);
         }
+        if (node.type && node.type.startsWith('RANGE')) {
+            return node.type.endsWith('START') ? '【' : '】';
+        }
         if (node.type) {
             return node.type.toLowerCase();
         }


### PR DESCRIPTION
This is the second part of a split of https://github.com/odoo-dev/jabberwock/pull/7 into two PRs.

This implements a `setRange` flux:
1. User clicks in DOM
2. `EventNormalizer` interprets the click and sends a `CustomEvent`
3. `EventManager` interprets the `CustomEvent` and triggers an `Intent`
   (`'setRange'`, generated by the `ActionGenerator`) via the
   `Dispatcher`
4. `CorePlugin` picks up the `Intent` and matches the DOM nodes to their
   respective `VNodes`, moves the `Range VNodes` accordingly
5. `Dispatcher` triggers a rendering in the `Renderer`.
6. `Renderer` rerenders the tree and sets the range according to the
   position of the `Range VNodes`

TODO
* update the store AFTER the whole flux: requires a mechanism to
  recognize the end of the flux
* handle range on consecutive `BR` nodes.