### PR TITLE
[POC] VNode: handle anchors

### DIFF
--- a/examples/utils/jabberwocky.ts
+++ b/examples/utils/jabberwocky.ts
@@ -3,7 +3,21 @@ export const jabberwocky = {
         const title = document.createElement('h1');
         title.appendChild(document.createTextNode('Jabberwocky'));
         const subtitle = document.createElement('h3');
-        subtitle.appendChild(document.createTextNode('by Lewis Carroll'));
+
+        const anchorA = document.createElement('a');
+        anchorA.setAttribute('href', 'https://en.wikipedia.org/wiki/Jabberwocky');
+        anchorA.setAttribute('target', '_blank');
+        anchorA.appendChild(document.createTextNode('by '));
+        subtitle.appendChild(anchorA);
+        const anchorB = document.createElement('a');
+        anchorB.setAttribute('href', 'https://en.wikipedia.org/wiki/Jabberwocky');
+        anchorB.appendChild(document.createTextNode('Lewis'));
+        subtitle.appendChild(anchorB);
+        const anchorC = document.createElement('a');
+        anchorC.setAttribute('href', 'https://en.wikipedia.org/wiki/Lewis_Carroll');
+        anchorC.appendChild(document.createTextNode(' Carroll'));
+        subtitle.appendChild(anchorC);
+
         const p = document.createElement('p');
         const i = document.createElement('i');
         p.appendChild(i);

--- a/examples/utils/jabberwocky.ts
+++ b/examples/utils/jabberwocky.ts
@@ -1,80 +1,9 @@
+import template from './jabberwocky.xml';
+
 export const jabberwocky = {
     init: function(container: HTMLElement): HTMLElement {
-        const title = document.createElement('h1');
-        title.appendChild(document.createTextNode('Jabberwocky'));
-        const subtitle = document.createElement('h3');
-
-        const anchorA = document.createElement('a');
-        anchorA.setAttribute('href', 'https://en.wikipedia.org/wiki/Jabberwocky');
-        anchorA.setAttribute('target', '_blank');
-        anchorA.appendChild(document.createTextNode('by '));
-        subtitle.appendChild(anchorA);
-        const anchorB = document.createElement('a');
-        anchorB.setAttribute('href', 'https://en.wikipedia.org/wiki/Jabberwocky');
-        anchorB.appendChild(document.createTextNode('Lewis'));
-        subtitle.appendChild(anchorB);
-        const anchorC = document.createElement('a');
-        anchorC.setAttribute('href', 'https://en.wikipedia.org/wiki/Lewis_Carroll');
-        anchorC.appendChild(document.createTextNode(' Carroll'));
-        subtitle.appendChild(anchorC);
-
-        const p = document.createElement('p');
-        const i = document.createElement('i');
-        p.appendChild(i);
-        const content = getContent();
-        content.split('\n').forEach(line => {
-            const textNode = document.createTextNode(line);
-            const br = document.createElement('br');
-            i.appendChild(textNode);
-            i.appendChild(br);
-        });
-
+        container.innerHTML = template;
         container.style.textAlign = 'center';
-        container.appendChild(title);
-        container.appendChild(subtitle);
-        container.appendChild(p);
-
         return container;
     },
-
-    read: function(): string {
-        return getContent();
-    },
 };
-
-function getContent(): string {
-    return `’Twas brillig, and the slithy toves
-            Did gyre and gimble in the wabe:
-            All mimsy were the borogoves,
-            And the mome raths outgrabe.
-
-            “Beware the Jabberwock, my son!
-            The jaws that bite, the claws that catch!
-            Beware the Jubjub bird, and shun
-            The frumious Bandersnatch!”
-
-            He took his vorpal sword in hand;
-            Long time the manxome foe he sought—
-            So rested he by the Tumtum tree
-            And stood awhile in thought.
-
-            And, as in uffish thought he stood,
-            The Jabberwock, with eyes of flame,
-            Came whiffling through the tulgey wood,
-            And burbled as it came!
-
-            One, two! One, two! And through and through
-            The vorpal blade went snicker-snack!
-            He left it dead, and with its head
-            He went galumphing back.
-
-            “And hast thou slain the Jabberwock?
-            Come to my arms, my beamish boy!
-            O frabjous day! Callooh! Callay!”
-            He chortled in his joy.
-
-            ’Twas brillig, and the slithy toves
-            Did gyre and gimble in the wabe:
-            All mimsy were the borogoves,
-            And the mome raths outgrabe.`;
-}

--- a/examples/utils/jabberwocky.xml
+++ b/examples/utils/jabberwocky.xml
@@ -1,0 +1,43 @@
+<h1>Jabberwocky</h1
+><h3
+    ><a href="https://en.wikipedia.org/wiki/Jabberwocky" target="_blank">by </a
+    ><a href="https://en.wikipedia.org/wiki/Jabberwocky">Lewis</a
+    ><a href="https://en.wikipedia.org/wiki/Lewis_Carroll"> Carroll</a
+></h3
+><p
+    ><i>’Twas brillig, and the slithy toves<br/
+    >Did gyre and gimble in the wabe:<br/
+    >All mimsy were the borogoves,<br/
+    >And the mome raths outgrabe.<br/
+    ><br/
+    >“Beware the Jabberwock, my son!<br/
+    >The jaws that bite, the claws that catch!<br/
+    >Beware the Jubjub bird, and shun<br/
+    >The frumious Bandersnatch!”<br/
+    ><br/
+    >He took his vorpal sword in hand;<br/
+    >Long time the manxome foe he sought—<br/
+    >So rested he by the Tumtum tree<br/
+    >And stood awhile in thought.<br/
+    ><br/
+    >And, as in uffish thought he stood,<br/
+    >The Jabberwock, with eyes of flame,<br/
+    >Came whiffling through the tulgey wood,<br/
+    >And burbled as it came!<br/
+    ><br/
+    >One, two! One, two! And through and through<br/
+    >The vorpal blade went snicker-snack!<br/
+    >He left it dead, and with its head<br/
+    >He went galumphing back.<br/
+    ><br/
+    >“And hast thou slain the Jabberwock?<br/
+    >Come to my arms, my beamish boy!<br/
+    >O frabjous day! Callooh! Callay!”<br/
+    >He chortled in his joy.<br/
+    ><br/
+    >’Twas brillig, and the slithy toves<br/
+    >Did gyre and gimble in the wabe:<br/
+    >All mimsy were the borogoves,<br/
+    >And the mome raths outgrabe.<br/
+    ></i
+></p>

--- a/src/core/stores/VNode.ts
+++ b/src/core/stores/VNode.ts
@@ -15,13 +15,20 @@ export enum VNodeType {
     HEADING6 = 'HEADING6',
     CHAR = 'CHAR',
     LINE_BREAK = 'LINE_BREAK',
+    UNKNOWN = 'UNKNOWN',
 }
 
 export interface VNodeProperties {
     atomic: boolean;
 }
 
+export interface AnchorProperties {
+    url: URL;
+    target?: string;
+}
+
 export interface FormatType {
+    anchor?: AnchorProperties | null;
     bold?: boolean;
     italic?: boolean;
     underlined?: boolean;
@@ -45,11 +52,12 @@ export class VNode {
     };
     _childrenMap: Map<VNode, number> = new Map<VNode, number>();
 
-    constructor(type: VNodeType, originalTag = '', value?: string, format?: FormatType) {
+    constructor(type = VNodeType.UNKNOWN, originalTag = '', value?: string, format?: FormatType) {
         this.type = type;
         this.originalTag = originalTag;
         this.value = value;
         this.format = format || {
+            anchor: null,
             bold: false,
             italic: false,
             underlined: false,

--- a/src/core/utils/Format.ts
+++ b/src/core/utils/Format.ts
@@ -1,4 +1,5 @@
 const formatToTag = {
+    anchor: 'A',
     bold: 'B',
     italic: 'I',
     underline: 'U',

--- a/src/core/utils/Parser.ts
+++ b/src/core/utils/Parser.ts
@@ -1,4 +1,4 @@
-import { VNode, VNodeType, FormatType } from '../stores/VNode';
+import { VNode, VNodeType, FormatType, AnchorProperties } from '../stores/VNode';
 import { VDocument } from '../stores/VDocument';
 import { Format } from './Format';
 import { VDocumentMap } from './VDocumentMap';
@@ -41,6 +41,19 @@ function parseNode(context: ParsingContext): ParsingContext {
     }
 }
 
+function getAnchorInfo(node: DOMElement): AnchorProperties {
+    if (node.nodeName !== 'A') {
+        return null;
+    }
+    const info: AnchorProperties = {
+        url: new URL(node.getAttribute('href')),
+    };
+    if (node.getAttribute('target')) {
+        info.target = node.getAttribute('target');
+    }
+    return info;
+}
+
 /**
  * Return the `VNodeType` of the given DOM node.
  *
@@ -77,13 +90,14 @@ function getNodeType(node: Node): VNodeType {
 function parseElementNode(context: ParsingContext): ParsingContext {
     const node = context.node;
     if (Format.tags.includes(context.node.nodeName)) {
-        // Format nodes (e.g. B, I, U) are parsed differently than regular
+        // Format nodes (e.g. A, B, I, U) are parsed differently than regular
         // elements since they are not represented by a proper VNode in our
         // internal representation but by the format of its children.
         // For the parsing, encountering a format node generates a new format
         // context which inherits from the previous one.
         const format = context.format.length ? context.format[0] : {};
         context.format.unshift({
+            anchor: format.anchor || getAnchorInfo(node as DOMElement),
             bold: format.bold || node.nodeName === 'B',
             italic: format.italic || node.nodeName === 'I',
             underlined: format.underlined || node.nodeName === 'U',

--- a/src/core/utils/Renderer.ts
+++ b/src/core/utils/Renderer.ts
@@ -138,7 +138,20 @@ export class Renderer {
      * @param b
      */
     _isSameFormat(a: VNode, b: VNode): boolean {
-        return Object.keys(a.format).every(k => a.format[k] === b.format[k]);
+        return Object.keys(a.format).every(k => {
+            if (k === 'anchor') {
+                const anchorA = a.format[k];
+                const anchorB = b.format[k];
+                if (anchorA && anchorB) {
+                    return (
+                        anchorA.url.href === anchorB.url.href && anchorA.target === anchorB.target
+                    );
+                } else {
+                    return anchorA == anchorB;
+                }
+            }
+            return a.format[k] === b.format[k];
+        });
     }
     /**
      * Return a tuple containing a <br> element's parent and the offset on which
@@ -269,6 +282,12 @@ export class Renderer {
         Object.keys(vNode.format).forEach(type => {
             if (vNode.format[type]) {
                 const formatNode = document.createElement(Format.toTag(type));
+                if (type === 'anchor') {
+                    formatNode.setAttribute('href', vNode.format.anchor.url.href);
+                    if (vNode.format.anchor.target) {
+                        formatNode.setAttribute('target', vNode.format.anchor.target);
+                    }
+                }
                 renderedFormats.push(formatNode);
                 parent.appendChild(formatNode);
                 // Update the parent so the text is inside the format node.

--- a/src/plugins/DevTools/DevTools.css
+++ b/src/plugins/DevTools/DevTools.css
@@ -23,6 +23,10 @@ jw-devtools.closed {
     max-height: 31px;
 }
 
+jw-devtools .anchor {
+    color: blue;
+}
+
 jw-devtools .bold {
     font-weight: bold;
 }

--- a/src/plugins/DevTools/DevTools.xml
+++ b/src/plugins/DevTools/DevTools.xml
@@ -52,6 +52,7 @@
             </span>
             <span t-elif="props.vNode.value" t-on-click="onClickNode"
                 class="selectable-line" t-att-class="{
+                    anchor: props.vNode.format.anchor != null,
                     bold: props.vNode.format.bold,
                     italic: props.vNode.format.italic,
                     underlined: props.vNode.format.underlined,
@@ -62,6 +63,7 @@
             <t t-else="">
                 <span class="element-name selectable-line" t-on-click="onClickNode"
                     t-att-class="{
+                        anchor: props.vNode.format.anchor != null,
                         bold: props.vNode.format.bold,
                         italic: props.vNode.format.italic,
                         underlined: props.vNode.format.underlined,
@@ -156,6 +158,12 @@
                         <td>format</td>
                         <td>
                             <ol style="list-style-type: none">
+                                <li t-if="props.vNode.format.anchor !== null">
+                                    Anchor to
+                                    <a t-attf-href="props.vNode.format.anchor.url.href"><t t-esc="props.vNode.format.anchor.url.href"/></a>
+                                    <t t-if="props.vNode.format.anchor.target"> (target:
+                                    <t t-esc="props.vNode.format.anchor.target"/>)</t>
+                                </li>
                                 <li t-if="props.vNode.format.bold">Bold</li>
                                 <li t-if="props.vNode.format.italic">Italic</li>
                                 <li t-if="props.vNode.format.underlined">Underlined</li>

--- a/src/plugins/DevTools/components/PathComponent.ts
+++ b/src/plugins/DevTools/components/PathComponent.ts
@@ -5,6 +5,9 @@ export class PathComponent extends OwlUIComponent<{}> {
     getNodeRepr(vNode: VNode): string {
         const name: string = (vNode.type && vNode.type.toLowerCase()) || '?';
         let format = '';
+        if (vNode.format.anchor !== null) {
+            format += '.a';
+        }
         if (vNode.format.bold) {
             format += '.b';
         }


### PR DESCRIPTION
This is by no means comprehensive but it's a proposal for handling anchors.

Caveats:
- Maybe the property should be put somewhere else that on `format` but I don't have a better suggestion for the moment.
- Having the info of the anchor on each character nodes makes us duplicate quite a bit of information. Could that have a palpable effect on performance? That question stands also for classes and inline styles which would logically be implemented in the same way also formats. On the other hand, proceeding in this way simplifies a lot of behavior, especially if it can be generalized to all kind of inline properties/tags.