### PR TITLE
[ADD] Core: handle paragraph formatting

### DIFF
--- a/src/core/stores/VDocument.ts
+++ b/src/core/stores/VDocument.ts
@@ -49,6 +49,32 @@ export class VDocument {
         nextSiblings.forEach(sibling => duplicatedParent.append(sibling));
     }
     /**
+     * Change the selection's paragraph formatting. If there is no selection,
+     * first select the parent of the range nodes.
+     *
+     * Examples:
+     *
+     * - `<paragraph>te◆xt</paragraph>` =>
+     *   `changeType(VNodeType.HEADING1)` =>
+     *   `<heading1>▶text◀</heading1>`
+     *
+     * - `<heading1>te▶xt</heading1><heading2>te◀xt</heading2>`=>
+     *   `changeType(VNodeType.PARAGRAPH)` =>
+     *   `<paragraph>te▶xt</paragraph><paragraph>te◀xt</paragraph>`
+     *
+     * @param type
+     */
+    formatParagraph(type: VNodeType): void {
+        if (this.range.isCollapsed()) {
+            this.range.select(this.range.start.parent, this.range.end.parent);
+        }
+        new Set(this.range.selectedLeaves.map(node => node.parent)).forEach(parent => {
+            // TODO: this suffices for the moment, but it will not be enough
+            // anymore once we introduce the VNode class extensions.
+            parent.type = type;
+        });
+    }
+    /**
      * Insert something at range.
      *
      * @param node

--- a/src/core/stores/VNode.ts
+++ b/src/core/stores/VNode.ts
@@ -39,7 +39,7 @@ const atomicTypes = [
 let id = 0;
 
 export class VNode {
-    readonly type: VNodeType;
+    type: VNodeType;
     format: FormatType;
     readonly id = id;
     parent: VNode | null = null;

--- a/src/core/stores/VRange.ts
+++ b/src/core/stores/VRange.ts
@@ -98,6 +98,13 @@ export class VRange {
         });
         return selectedNodes;
     }
+    /**
+     * Return a list of all the leaves implied in the selection between the
+     * first range node to the last (non-included).
+     */
+    get selectedLeaves(): VNode[] {
+        return this.selectedNodes.filter(node => !node.children.length);
+    }
 
     //--------------------------------------------------------------------------
     // Private

--- a/src/core/types/Intents.ts
+++ b/src/core/types/Intents.ts
@@ -1,4 +1,5 @@
 import { VRangeDescription } from '../stores/VRange';
+import { VNodeType } from '../stores/VNode';
 
 // Specialized intents
 
@@ -13,6 +14,14 @@ export interface KeydownPayload extends ActionPayload {
 }
 export interface KeydownIntent extends Intent {
     payload: KeydownPayload;
+}
+
+// Change type
+export interface FormatParagraphPayload extends KeydownPayload {
+    value: VNodeType;
+}
+export interface FormatParagraphIntent extends Intent {
+    payload: FormatParagraphPayload;
 }
 
 // Insert

--- a/src/core/utils/CorePlugin.ts
+++ b/src/core/utils/CorePlugin.ts
@@ -1,13 +1,20 @@
 import { JWPlugin } from '../JWPlugin';
 import JWEditor from '../JWEditor';
 import { RelativePosition, VRangeDescription, Direction } from '../stores/VRange';
-import { InsertIntent, RangeIntent, FormatIntent, KeydownIntent } from '../types/Intents';
+import {
+    InsertIntent,
+    RangeIntent,
+    FormatIntent,
+    KeydownIntent,
+    FormatParagraphIntent,
+} from '../types/Intents';
 import { VNode, VNodeType } from '../stores/VNode';
 
 export class CorePlugin extends JWPlugin {
     editor: JWEditor;
     handlers = {
         intents: {
+            formatParagraph: 'formatParagraph',
             enter: 'enter',
             insert: 'insert',
             deleteBackward: 'deleteBackward',
@@ -21,6 +28,7 @@ export class CorePlugin extends JWPlugin {
         deleteBackward: this.deleteBackward.bind(this),
         deleteForward: this.deleteForward.bind(this),
         enter: this.enter.bind(this),
+        formatParagraph: this.formatParagraph.bind(this),
         insert: this.insert.bind(this),
         navigate: this.navigate.bind(this),
         selectAll: this.selectAll.bind(this),
@@ -35,6 +43,15 @@ export class CorePlugin extends JWPlugin {
     // Public
     //--------------------------------------------------------------------------
 
+    /**
+     * Change the type of the selection. If there is no selection, change the
+     * type of the range nodes' parent.
+     *
+     * @param intent
+     */
+    formatParagraph(intent: FormatParagraphIntent): void {
+        this.editor.vDocument.formatParagraph(intent.payload.value);
+    }
     /**
      * Handle the (shift+) enter key.
      *

--- a/src/core/utils/EventManager.ts
+++ b/src/core/utils/EventManager.ts
@@ -9,6 +9,37 @@ export interface EventManagerOptions {
     dispatch?: DispatchFunction;
 }
 
+const ctrlAltShortcuts = {
+    '&': {
+        name: 'formatParagraph',
+        value: VNodeType.HEADING1,
+    },
+    'é': {
+        name: 'formatParagraph',
+        value: VNodeType.HEADING2,
+    },
+    '"': {
+        name: 'formatParagraph',
+        value: VNodeType.HEADING3,
+    },
+    "'": {
+        name: 'formatParagraph',
+        value: VNodeType.HEADING4,
+    },
+    '(': {
+        name: 'formatParagraph',
+        value: VNodeType.HEADING5,
+    },
+    '§': {
+        name: 'formatParagraph',
+        value: VNodeType.HEADING6,
+    },
+    'à': {
+        name: 'formatParagraph',
+        value: VNodeType.PARAGRAPH,
+    },
+};
+
 export class EventManager {
     editable: HTMLElement;
     options: EventManagerOptions;
@@ -125,8 +156,19 @@ export class EventManager {
                 ) {
                     name = 'applyFormat';
                     payload = { format: 'underline' };
-                } else {
-                    return;
+                } else if (
+                    payload.ctrlKey &&
+                    payload.altKey &&
+                    !payload.shiftKey &&
+                    !payload.metaKey
+                ) {
+                    // CTRL+ALT shortcuts
+                    // TODO: research use payload.code (Digit[0-6]) instead of
+                    // payload.key
+                    if (Object.keys(ctrlAltShortcuts).includes(payload.key)) {
+                        name = ctrlAltShortcuts[payload.key].name;
+                        payload.value = ctrlAltShortcuts[payload.key].value;
+                    }
                 }
         }
         return ActionGenerator.intent({


### PR DESCRIPTION
Let examples speak:
```xml
<paragraph>te◆xt</paragraph>
```
=> CTRL+ALT+DIGIT1 =>
```typescript
changeType(VNodeType.HEADING1)
```
=>
```xml
<heading1>▶text◀</heading1>
```

and

```xml
<heading1>te▶xt</heading1>
<heading2>te◀xt</heading2>
```
=> CTRL+ALT+DIGIT0 =>
```typescript
changeType(VNodeType.PARAGRAPH)
```
=>
```xml
<paragraph>te▶xt</paragraph>
<paragraph>te◀xt</paragraph>
```