### PR TITLE
[ADD] Core: handle keymaps

### DIFF
--- a/examples/index/index.ts
+++ b/examples/index/index.ts
@@ -5,8 +5,21 @@ import './index.css';
 const editor = new JWEditor();
 jabberwocky.init(editor.editable);
 
+// Example custom keymap extending the default keymap:
+editor.keyMap.set({
+    'Ctrl+Alt+K': {
+        name: 'insertText',
+        arguments: { value: 'Do cats eat bats? Do bats eat cats?' },
+    },
+    'Ctrl+Alt+V': {
+        name: 'insertText',
+        arguments: { value: '⚔' },
+    },
+});
+
 editor.loadConfig({
     debug: true,
+    // To add a complete custom keymap, add it here: `keyMap: keyMap`.
 });
 
 editor.start();

--- a/packages/core/src/DefaultKeyMap.ts
+++ b/packages/core/src/DefaultKeyMap.ts
@@ -1,0 +1,20 @@
+const map = new Map();
+map.set('Ctrl+B', {
+    name: 'applyFormat',
+    arguments: {
+        format: 'bold',
+    },
+});
+map.set('Ctrl+I', {
+    name: 'applyFormat',
+    arguments: {
+        format: 'italic',
+    },
+});
+map.set('Ctrl+U', {
+    name: 'applyFormat',
+    arguments: {
+        format: 'underline',
+    },
+});
+export const defaultKeyMap = map;

--- a/packages/core/src/EventManager.ts
+++ b/packages/core/src/EventManager.ts
@@ -1,21 +1,28 @@
 import { EventNormalizer, DomRangeDescription } from './EventNormalizer';
 import { LineBreakNode } from './VNodes/LineBreakNode';
 import JWEditor from './JWEditor';
+import { CommandConfig, KeyMapping } from './KeyMapping';
 
 interface SetRangeParams {
     domRange: DomRangeDescription;
 }
 
+interface EventManagerOptions {
+    keyMap?: KeyMapping;
+}
+
 export class EventManager {
     editor: JWEditor;
     eventNormalizer: EventNormalizer;
+    keyMap: KeyMapping;
 
-    constructor(editor: JWEditor) {
+    constructor(editor: JWEditor, options: EventManagerOptions = {}) {
         this.editor = editor;
         this.eventNormalizer = new EventNormalizer(
             editor.editable,
             this._onNormalizedEvent.bind(this),
         );
+        this.keyMap = options.keyMap;
     }
 
     //--------------------------------------------------------------------------
@@ -27,6 +34,7 @@ export class EventManager {
      */
     _onNormalizedEvent(customEvent: CustomEvent): void {
         const payload = customEvent.detail;
+        let shortcutMatch: CommandConfig;
         switch (customEvent.type) {
             case 'enter':
                 if (customEvent.detail.shiftKey) {
@@ -45,32 +53,15 @@ export class EventManager {
                 // TODO: keydown should be matched with existing shortcuts. If
                 // it matches an command shortcut, trigger the corresponding
                 // command, otherwise do not trigger any command.
-                if (
-                    payload.ctrlKey &&
-                    !payload.altKey &&
-                    !payload.shiftKey &&
-                    !payload.metaKey &&
-                    payload.key === 'b'
-                ) {
-                    return this.editor.execCommand('applyFormat', { format: 'bold' });
-                } else if (
-                    payload.ctrlKey &&
-                    !payload.altKey &&
-                    !payload.shiftKey &&
-                    !payload.metaKey &&
-                    payload.key === 'i'
-                ) {
-                    return this.editor.execCommand('applyFormat', { format: 'italic' });
-                } else if (
-                    payload.ctrlKey &&
-                    !payload.altKey &&
-                    !payload.shiftKey &&
-                    !payload.metaKey &&
-                    payload.key === 'u'
-                ) {
-                    return this.editor.execCommand('applyFormat', { format: 'underline' });
+
+                // TODO: use payload.code (Digit[0-6]) instead of
+                // payload.key
+                if (this.keyMap) {
+                    shortcutMatch = this.keyMap.fromKeypress(payload);
+                    if (shortcutMatch) {
+                        this.editor.execCommand(shortcutMatch.name, shortcutMatch.arguments);
+                    }
                 }
-                // TODO: keydown should be matched with existing shortcuts.
                 return;
             }
             default:

--- a/packages/core/src/EventNormalizer.ts
+++ b/packages/core/src/EventNormalizer.ts
@@ -877,8 +877,8 @@ export class EventNormalizer {
         compiledEvent.type = compiledEvent.type || ev.type;
         compiledEvent.key = ev.key;
         compiledEvent.altKey = ev.altKey;
-        compiledEvent.ctrlKey = ev.ctrlKey;
-        compiledEvent.metaKey = ev.metaKey;
+        // Meta key not supported: we consider it equivalent to Ctrl key.
+        compiledEvent.ctrlKey = ev.ctrlKey || ev.metaKey;
         compiledEvent.shiftKey = ev.shiftKey;
     }
     /**

--- a/packages/core/src/JWEditor.ts
+++ b/packages/core/src/JWEditor.ts
@@ -52,46 +52,6 @@ export class JWEditor {
         this.editable = editable;
     }
 
-    /**
-     * Start the editor on the editable DOM node set on this editor instance.
-     */
-    async start(): Promise<void> {
-        // Parse the editable in the internal format of the editor.
-        this.vDocument = this.parser.parse(this._originalEditable);
-
-        // Deep clone the given editable node in order to break free of any
-        // handler that might have been previously registered.
-        this.editable = this._originalEditable.cloneNode(true) as HTMLElement;
-
-        // The original editable node is hidden until the editor stops.
-        this._originalEditable.style.display = 'none';
-        // Cloning the editable node might lead to duplicated id.
-        this.editable.id = this._originalEditable.id;
-        this._originalEditable.removeAttribute('id');
-
-        // The cloned editable element is then added to the main editor element
-        // which is itself added to the DOM.
-        this.editable.classList.add('jw-editable');
-        this.editable.setAttribute('contenteditable', 'true');
-        this.el.appendChild(this.editable);
-        document.body.appendChild(this.el);
-
-        // CorePlugin is a special mandatory plugin that handles the matching
-        // between the core commands and the VDocument.
-        this.addPlugin(CorePlugin);
-
-        // Init the event manager now that the cloned editable is in the DOM.
-        this.eventManager = new EventManager(this, {
-            keyMap: this.keyMap,
-        });
-
-        this.renderer.render(this.vDocument, this.editable);
-
-        if (this.debugger) {
-            await this.debugger.start();
-        }
-    }
-
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
@@ -129,6 +89,46 @@ export class JWEditor {
         }
         if (config.keyMap) {
             this.keyMap = new KeyMapping(config.keyMap);
+        }
+    }
+
+    /**
+     * Start the editor on the editable DOM node set on this editor instance.
+     */
+    async start(): Promise<void> {
+        // Parse the editable in the internal format of the editor.
+        this.vDocument = this.parser.parse(this._originalEditable);
+
+        // Deep clone the given editable node in order to break free of any
+        // handler that might have been previously registered.
+        this.editable = this._originalEditable.cloneNode(true) as HTMLElement;
+
+        // The original editable node is hidden until the editor stops.
+        this._originalEditable.style.display = 'none';
+        // Cloning the editable node might lead to duplicated id.
+        this.editable.id = this._originalEditable.id;
+        this._originalEditable.removeAttribute('id');
+
+        // The cloned editable element is then added to the main editor element
+        // which is itself added to the DOM.
+        this.editable.classList.add('jw-editable');
+        this.editable.setAttribute('contenteditable', 'true');
+        this.el.appendChild(this.editable);
+        document.body.appendChild(this.el);
+
+        // CorePlugin is a special mandatory plugin that handles the matching
+        // between the core commands and the VDocument.
+        this.addPlugin(CorePlugin);
+
+        // Init the event manager now that the cloned editable is in the DOM.
+        this.eventManager = new EventManager(this, {
+            keyMap: this.keyMap,
+        });
+
+        this.renderer.render(this.vDocument, this.editable);
+
+        if (this.debugger) {
+            await this.debugger.start();
         }
     }
 

--- a/packages/core/src/JWEditor.ts
+++ b/packages/core/src/JWEditor.ts
@@ -7,10 +7,12 @@ import { OwlUI } from '../../owl-ui/src/OwlUI';
 import { CorePlugin } from './CorePlugin';
 import { Parser } from './Parser';
 import { DevTools } from '../../plugin-devtools/src/DevTools';
+import { KeyMapping, KeyMap } from './KeyMapping';
 
 export interface JWEditorConfig {
     debug?: boolean;
     theme?: string;
+    keyMap?: KeyMap;
 }
 
 export class JWEditor {
@@ -19,6 +21,7 @@ export class JWEditor {
     editable: HTMLElement;
     dispatcher: Dispatcher;
     eventManager: EventManager;
+    keyMap: KeyMapping = new KeyMapping();
     pluginsRegistry: JWPlugin[];
     renderer: Renderer;
     vDocument: VDocument;
@@ -78,7 +81,9 @@ export class JWEditor {
         this.addPlugin(CorePlugin);
 
         // Init the event manager now that the cloned editable is in the DOM.
-        this.eventManager = new EventManager(this);
+        this.eventManager = new EventManager(this, {
+            keyMap: this.keyMap,
+        });
 
         this.renderer.render(this.vDocument, this.editable);
 
@@ -121,6 +126,9 @@ export class JWEditor {
         if (config.debug) {
             this.debugger = new OwlUI(this);
             this.debugger.addPlugin(DevTools);
+        }
+        if (config.keyMap) {
+            this.keyMap = new KeyMapping(config.keyMap);
         }
     }
 

--- a/packages/core/src/KeyMapping.ts
+++ b/packages/core/src/KeyMapping.ts
@@ -1,0 +1,78 @@
+import { defaultKeyMap } from './DefaultKeyMap';
+
+export interface Keypress {
+    key: string;
+    ctrlKey?: boolean;
+    altKey?: boolean;
+    shiftKey?: boolean;
+}
+export interface CommandConfig {
+    name: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    arguments: Record<string, any>;
+}
+export type ShortcutIdentifier = string; // format: /[Ctrl+][Alt+][Shift+]key/
+export type KeyMap = Map<ShortcutIdentifier, CommandConfig>;
+
+export class KeyMapping {
+    keyMap: KeyMap = new Map();
+    constructor(customKeyMap?: KeyMap) {
+        const map = customKeyMap || defaultKeyMap;
+        map.forEach((value, key) => this.set(key, value));
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return the intent information corresponding to the given keypress
+     * information, if any.
+     *
+     * @param keypress
+     */
+    fromKeypress(keypress: Keypress): CommandConfig {
+        return this.keyMap.get(this._keypressToIdentifier(keypress));
+    }
+    /**
+     * Set one or more new shortcuts in the map.
+     *
+     * @param shortcut
+     * @param commandConfig
+     */
+    set(shortcuts: Record<ShortcutIdentifier, CommandConfig>): void;
+    set(shortcut: ShortcutIdentifier, commandConfig?: CommandConfig): void;
+    set(
+        shortcut: Record<ShortcutIdentifier, CommandConfig> | ShortcutIdentifier,
+        commandConfig?: CommandConfig,
+    ): void {
+        if (typeof shortcut === 'object') {
+            Object.keys(shortcut).forEach(key => this.set(key, shortcut[key]));
+        } else {
+            this.keyMap.set(shortcut.toUpperCase(), commandConfig);
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Convert information about a keypress to a shortcut identifier.
+     *
+     * @param keypress
+     */
+    _keypressToIdentifier(keypress: Keypress): string {
+        let identifier = '';
+        if (keypress.ctrlKey) {
+            identifier += 'Ctrl+';
+        }
+        if (keypress.altKey) {
+            identifier += 'Alt+';
+        }
+        if (keypress.shiftKey) {
+            identifier += 'Shift+';
+        }
+        return (identifier + keypress.key).toUpperCase();
+    }
+}


### PR DESCRIPTION
To add a custom keymap:
```typescript
const keyMap: Map<string, IntentInformation> = new Map();
// add shortcuts to the map...
// eg:
keyMap.set('Ctrl+Alt+K', {
    name: 'insertText',
    arguments: { value: 'Do cats eat bats? Do bats eat cats?' },
});
keyMap.set('Ctrl+Alt+V', {
    name: 'insertText',
    arguments: { value: '⚔' },
});

// before editor start:
editor.loadConfig({ keyMap: keyMap });
```

Or to add or replace shortcuts on the existing keyMap, replace everything above with:
```typescript
editor.keyMap.set({
    'Ctrl+Alt+K': {
        name: 'insertText',
        arguments: { value: 'Do cats eat bats? Do bats eat cats?' },
    },
    'Ctrl+Alt+V': {
        name: 'insertText',
        arguments: { value: '⚔' },
    },
});
```

Note: The META key is not technically supported - we consider it is equivalent to the CTRL key.