### PR TITLE
Add delete/backspace tests and fix related issues

### DIFF
--- a/packages/core/src/EventManager.ts
+++ b/packages/core/src/EventManager.ts
@@ -69,7 +69,14 @@ export class EventManager {
         // Get the VNodes matching the container.
         const containers = VDocumentMap.fromDom(container);
         // The reference is the offset-th match (eg.: text split into chars).
-        return [containers[offset], position];
+        const reference = containers[offset];
+        // When clicking on a trailing line break, we need to target after the
+        // line break. The DOM represents these as 2 <br> so this is a special
+        // case.
+        if (reference.type === 'LINE_BREAK' && !reference.nextSibling() && !container.nextSibling) {
+            position = RelativePosition.AFTER;
+        }
+        return [reference, position];
     }
     /**
      * Callback given to the normalizer.

--- a/packages/core/src/JWEditor.ts
+++ b/packages/core/src/JWEditor.ts
@@ -54,12 +54,12 @@ export class JWEditor {
      * @param parsingOptions
      */
     async start(parsingOptions?: ParsingOptions): Promise<void> {
+        // Parse the editable in the internal format of the editor.
+        this.vDocument = Parser.parse(this._originalEditable, parsingOptions);
+
         // Deep clone the given editable node in order to break free of any
         // handler that might have been previously registered.
         this.editable = this._originalEditable.cloneNode(true) as HTMLElement;
-
-        // Parse the editable in the internal format of the editor.
-        this.vDocument = Parser.parse(this.editable, parsingOptions);
 
         // The original editable node is hidden until the editor stops.
         this._originalEditable.style.display = 'none';

--- a/packages/core/src/JWEditor.ts
+++ b/packages/core/src/JWEditor.ts
@@ -5,7 +5,7 @@ import { Renderer } from './Renderer';
 import { VDocument } from './VDocument';
 import { OwlUI } from '../../owl-ui/src/OwlUI';
 import { CorePlugin } from './CorePlugin';
-import { ParsingOptions, Parser } from './Parser';
+import { Parser } from './Parser';
 import { DevTools } from '../../plugin-devtools/src/DevTools';
 
 export interface JWEditorConfig {
@@ -50,12 +50,10 @@ export class JWEditor {
 
     /**
      * Start the editor on the editable DOM node set on this editor instance.
-     *
-     * @param parsingOptions
      */
-    async start(parsingOptions?: ParsingOptions): Promise<void> {
+    async start(): Promise<void> {
         // Parse the editable in the internal format of the editor.
-        this.vDocument = Parser.parse(this._originalEditable, parsingOptions);
+        this.vDocument = Parser.parse(this._originalEditable);
 
         // Deep clone the given editable node in order to break free of any
         // handler that might have been previously registered.

--- a/packages/core/src/Parser.ts
+++ b/packages/core/src/Parser.ts
@@ -237,7 +237,9 @@ function _isAtSegmentBreak(node: Node, side: 'start' | 'end'): boolean {
     const sibling = node && node[siblingSide];
     const isAgainstAnotherSegment = sibling && _isSegment(sibling);
     const isAtEdgeOfOwnSegment = _isBlockEdge(node, side);
-    return isAgainstAnotherSegment || isAtEdgeOfOwnSegment;
+    // In the DOM, a space before a BR is rendered but a space after a BR isn't.
+    const isBeforeBR = side === 'end' && sibling && sibling.nodeName === 'BR';
+    return (isAgainstAnotherSegment && !isBeforeBR) || isAtEdgeOfOwnSegment;
 }
 /**
  * Return true if the node is a segment according to W3 formatting model.
@@ -268,7 +270,7 @@ function _isSegment(node: Node): boolean {
  * @param side of the block to check ('start' or 'end')
  */
 function _isBlockEdge(node: Node | Node, side: 'start' | 'end'): boolean {
-    const ancestorsUpToBlock = [];
+    const ancestorsUpToBlock: Node[] = [];
 
     // Move up to the first block ancestor
     let ancestor = node;

--- a/packages/core/src/Parser.ts
+++ b/packages/core/src/Parser.ts
@@ -89,19 +89,12 @@ function parseElementNode(currentContext: ParsingContext): ParsingContext {
     const context = { ...currentContext };
 
     const node = context.node;
-    // A <br/> with no siblings is there only to make its parent visible.
-    // Consume it since it was just parsed as its parent element node.
-    // TODO: do this less naively to account for formatting space.
-    if (node.childNodes.length === 1 && node.childNodes[0].nodeName === 'BR') {
-        context.node = node.childNodes[0];
-    }
-    // A trailing <br/> after another <br/> is there only to make its previous
-    // sibling visible. Consume it since it was just parsed as a single BR
-    // within our abstraction.
-    // TODO: do this less naively to account for formatting space.
-    if (node.nodeName === 'BR' && node.nextSibling && node.nextSibling.nodeName === 'BR') {
-        context.node = node.nextSibling;
-    }
+    const parsedNode: VNode = new VNode(
+        getNodeType(node),
+        node.nodeName,
+        undefined,
+        context.format[0],
+    );
     if (Format.tags.includes(context.node.nodeName)) {
         // Format nodes (e.g. B, I, U) are parsed differently than regular
         // elements since they are not represented by a proper VNode in our
@@ -115,14 +108,28 @@ function parseElementNode(currentContext: ParsingContext): ParsingContext {
             underline: format.underline || node.nodeName === 'U',
         });
     } else {
-        const parsedNode: VNode = new VNode(
-            getNodeType(node),
-            node.nodeName,
-            undefined,
-            context.format[0],
-        );
         VDocumentMap.set(parsedNode, node);
         context.parentVNode.append(parsedNode);
+    }
+    // A <br/> with no siblings is there only to make its parent visible.
+    // Consume it since it was just parsed as its parent element node.
+    // TODO: do this less naively to account for formatting space.
+    if (node.childNodes.length === 1 && node.childNodes[0].nodeName === 'BR') {
+        context.node = node.childNodes[0];
+        VDocumentMap.set(parsedNode, context.node);
+    }
+    // A trailing <br/> after another <br/> is there only to make its previous
+    // sibling visible. Consume it since it was just parsed as a single BR
+    // within our abstraction.
+    // TODO: do this less naively to account for formatting space.
+    if (
+        node.nodeName === 'BR' &&
+        node.nextSibling &&
+        node.nextSibling.nodeName === 'BR' &&
+        !node.nextSibling.nextSibling
+    ) {
+        context.node = node.nextSibling;
+        VDocumentMap.set(parsedNode, context.node);
     }
     return context;
 }

--- a/packages/core/src/Parser.ts
+++ b/packages/core/src/Parser.ts
@@ -2,7 +2,7 @@ import { VDocument } from './VDocument';
 import { Format } from '../../utils/src/Format';
 import { VDocumentMap } from './VDocumentMap';
 import { VNode, FormatType, VNodeType } from './VNode';
-import { RANGE_TAIL_CHAR, RANGE_HEAD_CHAR } from './VRange';
+import { RANGE_TAIL_CHAR, RANGE_HEAD_CHAR, RelativePosition } from './VRange';
 
 export interface ParsingOptions {
     parseTextualRange: boolean;
@@ -142,9 +142,11 @@ function parseTextNode(currentContext: ParsingContext): ParsingContext {
     for (let i = 0; i < text.length; i++) {
         const char = text.charAt(i);
         if (char === RANGE_TAIL_CHAR && currentContext.options.parseTextualRange) {
-            parentVNode.append(currentContext.vDocument.range.start);
+            const lastLeaf = parentVNode.lastLeaf();
+            currentContext.vDocument.range.setAnchor(lastLeaf, RelativePosition.AFTER);
         } else if (char === RANGE_HEAD_CHAR && currentContext.options.parseTextualRange) {
-            parentVNode.append(currentContext.vDocument.range.end);
+            const lastLeaf = parentVNode.lastLeaf();
+            currentContext.vDocument.range.setFocus(lastLeaf, RelativePosition.AFTER);
         } else {
             const parsedVNode = new VNode(VNodeType.CHAR, nodeName, char, { ...format });
             VDocumentMap.set(parsedVNode, node, i);

--- a/packages/core/src/VDocumentMap.ts
+++ b/packages/core/src/VDocumentMap.ts
@@ -59,8 +59,10 @@ export const VDocumentMap = {
         } else {
             fromDom.set(domNode, [vNode]);
         }
-        // Only if element is not a format
-        if (!Format.tags.includes(domNode.nodeName)) {
+        // Only if element is not a format and not already in the map to prevent
+        // overriding a VNode if it is representing by multiple Nodes. Only the
+        // first Node is mapped to the VNode.
+        if (!Format.tags.includes(domNode.nodeName) && !toDom.has(vNode)) {
             toDom.set(vNode, [domNode, offset]);
         }
     },

--- a/packages/core/src/VNode.ts
+++ b/packages/core/src/VNode.ts
@@ -1,6 +1,8 @@
 import { BasicHtmlRenderingEngine, RenderingEngine } from './BasicHtmlRenderingEngine';
 import { withRange, VDocument } from './VDocument';
 import { Predicate, isRange, isLeaf, not } from './../../utils/src/Predicates';
+import { RelativePosition } from './VRange';
+import { utils } from './../../utils/src/utils';
 
 export enum VNodeType {
     ROOT = 'ROOT',
@@ -91,6 +93,29 @@ export class VNode {
      */
     render<T>(to = 'html'): T {
         return this.renderingEngines[to].render(this) as T;
+    }
+    /**
+     * Locate where to set the range, when it targets this VNode, at a certain
+     * offset. This allows us to handle special cases.
+     *
+     * @param domNode
+     * @param offset
+     */
+    locateRange(domNode: Node, offset: number): [VNode, RelativePosition] {
+        // Position `BEFORE` is preferred over `AFTER`, unless the offset
+        // overflows the children list, in which case `AFTER` is needed.
+        let position = RelativePosition.BEFORE;
+        const domNodeLength = utils.nodeLength(domNode);
+        if (domNodeLength && offset >= domNodeLength) {
+            position = RelativePosition.AFTER;
+        }
+        // When clicking on a trailing line break, we need to target after the
+        // line break. The DOM represents these as 2 <br> so this is a special
+        // case. TODO: move this to LINE_BREAK node when it's implemented.
+        if (this.type === 'LINE_BREAK' && !this.nextSibling() && !domNode.nextSibling) {
+            position = RelativePosition.AFTER;
+        }
+        return [this, position];
     }
 
     //--------------------------------------------------------------------------

--- a/packages/core/src/VRange.ts
+++ b/packages/core/src/VRange.ts
@@ -192,9 +192,9 @@ export class VRange {
         return this;
     }
     /**
-     * Set the range's start point at the given location, targetting a
-     * `reference` VNode and specifying the `position` in reference to that
-     * VNode ('BEFORE', 'AFTER'), like in an `xpath`. If a direction is
+     * Set the range's start point (in traversal order) at the given location,
+     * targetting a `reference` VNode and specifying the `position` in reference
+     * to that VNode ('BEFORE', 'AFTER'), like in an `xpath`. If a direction is
      * specified, the range's start point will be the head of the range.
      * Return self.
      *
@@ -210,10 +210,10 @@ export class VRange {
         }
     }
     /**
-     * Set the range's end point at the given location, targetting a `reference`
-     * VNode and specifying the `position` in reference to that VNode ('BEFORE',
-     * 'AFTER'), like in an `xpath`. If a direction is specified, the range's
-     * end point will be the tail of the range.
+     * Set the range's end point (in traversal order) at the given location,
+     * targetting a `reference` VNode and specifying the `position` in reference
+     * to that VNode ('BEFORE', 'AFTER'), like in an `xpath`. If a direction is
+     * specified, the range's end point will be the tail of the range.
      * Return self.
      *
      * @param reference
@@ -226,6 +226,30 @@ export class VRange {
         } else {
             return this._setTail(reference, position);
         }
+    }
+    /**
+     * Set the start of the range by targetting a `reference` VNode and
+     * specifying the `position` in reference to that VNode ('BEFORE', 'AFTER'),
+     * like in an `xpath`. If no relative position if given, include the
+     * reference node in the selection. Return self.
+     *
+     * @param reference
+     * @param [position]
+     */
+    setAnchor(reference: VNode, position = RelativePosition.BEFORE): VRange {
+        return this._setTail(reference, position);
+    }
+    /**
+     * Set the end of the range by targetting a `reference` VNode and specifying
+     * the `position` in reference to that VNode ('BEFORE', 'AFTER'), like in an
+     * `xpath`. If no relative position if given, include the reference node in
+     * the selection. Return self.
+     *
+     * @param reference
+     * @param [position]
+     */
+    setFocus(reference: VNode, position = RelativePosition.AFTER): VRange {
+        return this._setHead(reference, position);
     }
     /**
      * Extend the range from its tail to the given location, targetting a
@@ -264,13 +288,13 @@ export class VRange {
     //--------------------------------------------------------------------------
 
     /**
-     * Set the start of the range by targetting a `reference` VNode and
-     * specifying the `position` in reference to that VNode ('BEFORE', 'AFTER'),
-     * like in an `xpath`. If no relative position if given, include the
-     * reference node in the selection. Return self.
+     * Set the end of the range by targetting a `reference` VNode and specifying
+     * the `position` in reference to that VNode ('BEFORE', 'AFTER'), like in an
+     * `xpath`. If no relative position if given, include the reference node in
+     * the selection. Return self.
      *
-     * @param position
      * @param reference
+     * @param [position]
      */
     _setTail(reference: VNode, position = RelativePosition.BEFORE): VRange {
         reference = reference.firstLeaf();
@@ -287,13 +311,13 @@ export class VRange {
         return this;
     }
     /**
-     * Set the end of the range by targetting a `reference` VNode and
-     * specifying the `position` in reference to that VNode ('BEFORE', 'AFTER'),
-     * like in an `xpath`. If no relative position if given, include the
-     * reference node in the selection. Return self.
+     * Set the end of the range by targetting a `reference` VNode and specifying
+     * the `position` in reference to that VNode ('BEFORE', 'AFTER'), like in an
+     * `xpath`. If no relative position if given, include the reference node in
+     * the selection. Return self.
      *
-     * @param position
      * @param reference
+     * @param [position]
      */
     _setHead(reference: VNode, position = RelativePosition.AFTER): VRange {
         reference = reference.lastLeaf();

--- a/packages/core/test/Parser.test.ts
+++ b/packages/core/test/Parser.test.ts
@@ -67,34 +67,6 @@ describe('utils', () => {
                     underline: false,
                 });
             });
-            it('should parse without range char', () => {
-                const element = document.createElement('div');
-                element.innerHTML = '<p>[a]</p>';
-                const vDocument = Parser.parse(element);
-
-                expect(vDocument.root.type).to.equal(VNodeType.ROOT);
-                expect(vDocument.root.children.length).to.equal(1);
-                const p = vDocument.root.children[0];
-                expect(p.type).to.equal(VNodeType.PARAGRAPH);
-                expect(p.children.length).to.equal(3);
-                expect(p.children[0].type).to.equal(VNodeType.CHAR);
-                expect(p.children[0].value).to.equal('[');
-                expect(p.children[1].value).to.equal('a');
-                expect(p.children[2].value).to.equal(']');
-            });
-            it('should parse with range', () => {
-                const element = document.createElement('div');
-                element.innerHTML = '<p>[a]</p>';
-                const vDocument = Parser.parse(element);
-
-                expect(vDocument.root.type).to.equal(VNodeType.ROOT);
-                expect(vDocument.root.children.length).to.equal(1);
-                const p = vDocument.root.children[0];
-                expect(p.type).to.equal(VNodeType.PARAGRAPH);
-                expect(p.children.length).to.equal(1);
-                expect(p.children[0].type).to.equal(VNodeType.CHAR);
-                expect(p.children[0].value).to.equal('a');
-            });
         });
     });
 });

--- a/packages/core/test/Parser.test.ts
+++ b/packages/core/test/Parser.test.ts
@@ -85,7 +85,7 @@ describe('utils', () => {
             it('should parse with range', () => {
                 const element = document.createElement('div');
                 element.innerHTML = '<p>[a]</p>';
-                const vDocument = Parser.parse(element, { parseTextualRange: true });
+                const vDocument = Parser.parse(element);
 
                 expect(vDocument.root.type).to.equal(VNodeType.ROOT);
                 expect(vDocument.root.children.length).to.equal(1);

--- a/packages/core/test/Renderer.test.ts
+++ b/packages/core/test/Renderer.test.ts
@@ -46,32 +46,32 @@ describe('utils', () => {
             });
         });
         describe('range', () => {
-            it('should render text range at the beginning', () => {
+            it('should render text range at the beginning', async () => {
                 const content = `<p>[a]bc</p>`;
-                testEditor({ contentBefore: content, contentAfter: content });
+                await testEditor({ contentBefore: content, contentAfter: content });
             });
-            it('should render text range at the end', () => {
+            it('should render text range at the end', async () => {
                 const content = `<p>ab[c]</p>`;
-                testEditor({ contentBefore: content, contentAfter: content });
+                await testEditor({ contentBefore: content, contentAfter: content });
             });
-            it('should render text range in the whole tag', () => {
+            it('should render text range in the whole tag', async () => {
                 const content = `<p>[abc]</p>`;
-                testEditor({ contentBefore: content, contentAfter: content });
+                await testEditor({ contentBefore: content, contentAfter: content });
             });
-            it('should render text range that is collapsed in the beginning', () => {
+            it('should render text range that is collapsed in the beginning', async () => {
                 const content = `<p>[]abc</p>`;
-                testEditor({ contentBefore: content, contentAfter: content });
+                await testEditor({ contentBefore: content, contentAfter: content });
             });
-            it('should render text range that is collapsed in the end', () => {
+            it('should render text range that is collapsed in the end', async () => {
                 const content = `<p>abc[]</p>`;
-                testEditor({ contentBefore: content, contentAfter: content });
+                await testEditor({ contentBefore: content, contentAfter: content });
             });
-            it('should render text range that is collapsed in the middle', () => {
+            it('should render text range that is collapsed in the middle', async () => {
                 const content = `<p>ab[]c</p>`;
-                testEditor({ contentBefore: content, contentAfter: content });
+                await testEditor({ contentBefore: content, contentAfter: content });
             });
-            it('should render the range outside the tag', () => {
-                testEditor({ contentBefore: '[<b>a</b>]', contentAfter: '<b>[a]</b>' });
+            it('should render the range outside the tag', async () => {
+                await testEditor({ contentBefore: '[<b>a</b>]', contentAfter: '<b>[a]</b>' });
             });
         });
     });

--- a/packages/core/test/Renderer.test.ts
+++ b/packages/core/test/Renderer.test.ts
@@ -71,7 +71,10 @@ describe('utils', () => {
                 await testEditor({ contentBefore: content, contentAfter: content });
             });
             it('should render the range outside the tag', async () => {
-                await testEditor({ contentBefore: '[<b>a</b>]', contentAfter: '<b>[a]</b>' });
+                await testEditor({
+                    contentBefore: '<p>[<b>a</b>]</p>',
+                    contentAfter: '<p><b>[a]</b></p>',
+                });
             });
         });
     });

--- a/packages/core/test/VDocument.test.ts
+++ b/packages/core/test/VDocument.test.ts
@@ -7,8 +7,8 @@ describe('stores', () => {
         describe('insertText', () => {
             describe('bold', () => {
                 describe('Range collapsed', () => {
-                    it('should insert char not bold when range in between two paragraphs', () => {
-                        testEditor({
+                    it('should insert char not bold when range in between two paragraphs', async () => {
+                        await testEditor({
                             contentBefore: '<p><b>a</b></p><p>[]</p><p><b>b</b></p>',
                             stepFunction: (editor: JWEditor) => {
                                 editor.vDocument.insertText('c');
@@ -17,8 +17,8 @@ describe('stores', () => {
                             contentAfter: '<p><b>a</b></p><p>c[]</p><p><b>b</b></p>',
                         });
                     });
-                    it('should insert char bold when the range in first position and next char is bold', () => {
-                        testEditor({
+                    it('should insert char bold when the range in first position and next char is bold', async () => {
+                        await testEditor({
                             contentBefore: '<b>[]a</b>',
                             stepFunction: (editor: JWEditor) => {
                                 editor.vDocument.insertText('b');
@@ -27,8 +27,8 @@ describe('stores', () => {
                             contentAfter: '<b>b[]a</b>',
                         });
                     });
-                    it('should insert char not bold when the range in first position and next char is not bold', () => {
-                        testEditor({
+                    it('should insert char not bold when the range in first position and next char is not bold', async () => {
+                        await testEditor({
                             contentBefore: '[]a',
                             stepFunction: (editor: JWEditor) => {
                                 editor.vDocument.insertText('b');
@@ -37,8 +37,8 @@ describe('stores', () => {
                             contentAfter: 'b[]a',
                         });
                     });
-                    it('should insert char bold when previous char is bold and the next is not bold', () => {
-                        testEditor({
+                    it('should insert char bold when previous char is bold and the next is not bold', async () => {
+                        await testEditor({
                             contentBefore: '<b>a[]</b>b',
                             stepFunction: (editor: JWEditor) => {
                                 editor.vDocument.insertText('c');
@@ -47,8 +47,8 @@ describe('stores', () => {
                             contentAfter: '<b>ac[]</b>b',
                         });
                     });
-                    it('should insert char not bold, when previous char is not bold, next is not bold', () => {
-                        testEditor({
+                    it('should insert char not bold, when previous char is not bold, next is not bold', async () => {
+                        await testEditor({
                             contentBefore: 'a[]b',
                             stepFunction: (editor: JWEditor) => {
                                 editor.vDocument.insertText('c');
@@ -57,8 +57,8 @@ describe('stores', () => {
                             contentAfter: 'ac[]b',
                         });
                     });
-                    it('should insert char bold when previous char is bold and the next is not bold', () => {
-                        testEditor({
+                    it('should insert char bold when previous char is bold and the next is not bold', async () => {
+                        await testEditor({
                             contentBefore: '<b>a</b>[]b',
                             stepFunction: (editor: JWEditor) => {
                                 editor.vDocument.insertText('c');
@@ -67,8 +67,8 @@ describe('stores', () => {
                             contentAfter: '<b>ac[]</b>b',
                         });
                     });
-                    it('should insert char not bold because char on a different parent should not be considered', () => {
-                        testEditor({
+                    it('should insert char not bold because char on a different parent should not be considered', async () => {
+                        await testEditor({
                             contentBefore: '<p><b>a</b></p><p>[]b</p>',
                             stepFunction: (editor: JWEditor) => {
                                 editor.vDocument.insertText('c');
@@ -80,8 +80,8 @@ describe('stores', () => {
                 });
 
                 describe('Range not collapsed', () => {
-                    it('should replace without bold when nothing bold between range and nothing bold outside range', () => {
-                        testEditor({
+                    it('should replace without bold when nothing bold between range and nothing bold outside range', async () => {
+                        await testEditor({
                             contentBefore: '[a]',
                             stepFunction: (editor: JWEditor) => {
                                 editor.vDocument.insertText('b');
@@ -89,7 +89,7 @@ describe('stores', () => {
                             },
                             contentAfter: 'b[]',
                         });
-                        testEditor({
+                        await testEditor({
                             contentBefore: 'a[b]c',
                             stepFunction: (editor: JWEditor) => {
                                 editor.vDocument.insertText('d');
@@ -98,8 +98,8 @@ describe('stores', () => {
                             contentAfter: 'ad[]c',
                         });
                     });
-                    it('should replace without bold when nothing bold between range and everything bold outside range', () => {
-                        testEditor({
+                    it('should replace without bold when nothing bold between range and everything bold outside range', async () => {
+                        await testEditor({
                             contentBefore: '<b>a</b>[b]<b>c</b>',
                             stepFunction: (editor: JWEditor) => {
                                 editor.vDocument.insertText('d');
@@ -108,8 +108,8 @@ describe('stores', () => {
                             contentAfter: '<b>a</b>d[]<b>c</b>',
                         });
                     });
-                    it('should replace with bold when anything inside the range is bold', () => {
-                        testEditor({
+                    it('should replace with bold when anything inside the range is bold', async () => {
+                        await testEditor({
                             contentBefore: '<b>[a</b>b]<b>c</b>',
                             stepFunction: (editor: JWEditor) => {
                                 editor.vDocument.insertText('d');
@@ -123,8 +123,8 @@ describe('stores', () => {
         });
         describe('applyFormat', () => {
             describe('Range collapsed', () => {
-                it('should make bold the next insertion', () => {
-                    testEditor({
+                it('should make bold the next insertion', async () => {
+                    await testEditor({
                         contentBefore: '[]a',
                         stepFunction: (editor: JWEditor) => {
                             const params: FormatParams = {
@@ -138,8 +138,8 @@ describe('stores', () => {
                         contentAfter: '<b>b[]</b>a',
                     });
                 });
-                it('should not make bold the next insertion when applyFormat 2 times', () => {
-                    testEditor({
+                it('should not make bold the next insertion when applyFormat 2 times', async () => {
+                    await testEditor({
                         contentBefore: '[]a',
                         stepFunction: (editor: JWEditor) => {
                             const params: FormatParams = {
@@ -154,8 +154,8 @@ describe('stores', () => {
                         contentAfter: 'b[]a',
                     });
                 });
-                it('should make bold the next insertion when applyFormat 1 time, after the first char', () => {
-                    testEditor({
+                it('should make bold the next insertion when applyFormat 1 time, after the first char', async () => {
+                    await testEditor({
                         contentBefore: 'a[]',
                         stepFunction: (editor: JWEditor) => {
                             const params: FormatParams = {
@@ -169,8 +169,8 @@ describe('stores', () => {
                         contentAfter: 'a<b>b[]</b>',
                     });
                 });
-                it('should not make bold the next insertion when applyFormat 2 times, after the first char', () => {
-                    testEditor({
+                it('should not make bold the next insertion when applyFormat 2 times, after the first char', async () => {
+                    await testEditor({
                         contentBefore: 'a[]',
                         stepFunction: (editor: JWEditor) => {
                             const params: FormatParams = {
@@ -185,8 +185,8 @@ describe('stores', () => {
                         contentAfter: 'ab[]',
                     });
                 });
-                it('should not make bold the next insertion when applyFormat 1 time after the first char that is bold', () => {
-                    testEditor({
+                it('should not make bold the next insertion when applyFormat 1 time after the first char that is bold', async () => {
+                    await testEditor({
                         contentBefore: '<b>a</b>[]',
                         stepFunction: (editor: JWEditor) => {
                             const params: FormatParams = {
@@ -200,8 +200,8 @@ describe('stores', () => {
                         contentAfter: '<b>a</b>b[]',
                     });
                 });
-                it('should make bold the next insertion when applyFormat 2 times after the first char that is bold', () => {
-                    testEditor({
+                it('should make bold the next insertion when applyFormat 2 times after the first char that is bold', async () => {
+                    await testEditor({
                         contentBefore: '<b>a</b>[]',
                         stepFunction: (editor: JWEditor) => {
                             const params: FormatParams = {
@@ -216,8 +216,8 @@ describe('stores', () => {
                         contentAfter: '<b>ab[]</b>',
                     });
                 });
-                it('should apply multiples format', () => {
-                    testEditor({
+                it('should apply multiples format', async () => {
+                    await testEditor({
                         contentBefore: '[]a',
                         stepFunction: (editor: JWEditor) => {
                             const formatBold: FormatParams = {
@@ -238,8 +238,8 @@ describe('stores', () => {
             });
 
             describe('Range not collapsed', () => {
-                it('should be bold when selected is not bold', () => {
-                    testEditor({
+                it('should be bold when selected is not bold', async () => {
+                    await testEditor({
                         contentBefore: 'a[b]c',
                         stepFunction: (editor: JWEditor) => {
                             const params: FormatParams = {
@@ -251,8 +251,8 @@ describe('stores', () => {
                         contentAfter: 'a[<b>b]</b>c',
                     });
                 });
-                it('should not be bold when selected is bold', () => {
-                    testEditor({
+                it('should not be bold when selected is bold', async () => {
+                    await testEditor({
                         contentBefore: 'a<b>[b]</b>c',
                         stepFunction: (editor: JWEditor) => {
                             const params: FormatParams = {
@@ -263,8 +263,8 @@ describe('stores', () => {
                         contentAfter: 'a[b]c',
                     });
                 });
-                it('should be bold when one of the selected is bold', () => {
-                    testEditor({
+                it('should be bold when one of the selected is bold', async () => {
+                    await testEditor({
                         contentBefore: 'a<b>[b</b>c]',
                         stepFunction: (editor: JWEditor) => {
                             const params: FormatParams = {

--- a/packages/core/test/VDocument.test.ts
+++ b/packages/core/test/VDocument.test.ts
@@ -2,6 +2,8 @@ import JWEditor from '../src/JWEditor';
 import { testEditor } from '../../utils/src/testUtils';
 import { FormatParams } from '../src/CorePlugin';
 
+const deleteForward = (editor: JWEditor): void => editor.execCommand('deleteForward');
+
 describe('stores', () => {
     describe('VDocument', () => {
         describe('insertText', () => {
@@ -274,6 +276,458 @@ describe('stores', () => {
                             editor.execCommand('applyFormat', params);
                         },
                         contentAfter: 'a[<b>bc]</b>',
+                    });
+                });
+            });
+        });
+        describe('deleteForward', () => {
+            describe('Range collapsed', () => {
+                describe('Basic', () => {
+                    it('should do nothing', async () => {
+                        await testEditor({
+                            contentBefore: '<p>[]</p>',
+                            stepFunction: deleteForward,
+                            // A <br> is automatically added to make the <p>
+                            // visible.
+                            contentAfter: '<p>[]<br></p>',
+                        });
+                        await testEditor({
+                            contentBefore: '<p>[<br>]</p>',
+                            stepFunction: deleteForward,
+                            // The <br> is there only to make the <p> visible.
+                            // It does not exist in VDocument and selecting it
+                            // has no meaning in the DOM.
+                            contentAfter: '<p>[]<br></p>',
+                        });
+                        await testEditor({
+                            contentBefore: '<p>abc[]</p>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<p>abc[]</p>',
+                        });
+                    });
+                    it('should delete the first character in a paragraph', async () => {
+                        await testEditor({
+                            contentBefore: '<p>[]abc</p>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<p>[]bc</p>',
+                        });
+                    });
+                    it('should delete a character within a paragraph', async () => {
+                        await testEditor({
+                            contentBefore: '<p>a[]bc</p>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<p>a[]c</p>',
+                        });
+                    });
+                    it('should delete the last character in a paragraph', async () => {
+                        await testEditor({
+                            contentBefore: '<p>ab[]c</p>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<p>ab[]</p>',
+                        });
+                        await testEditor({
+                            contentBefore: '<p>ab []c</p>',
+                            stepFunction: deleteForward,
+                            // The space should be converted to an unbreakable space
+                            // so it is visible.
+                            contentAfter: '<p>ab&nbsp;[]</p>',
+                        });
+                    });
+                    it('should merge a paragraph into an empty paragraph', async () => {
+                        await testEditor({
+                            contentBefore: '<p>[]<br></p><p>abc</p>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<p>[]abc</p>',
+                        });
+                    });
+                });
+                describe('Line breaks', () => {
+                    describe('Single', () => {
+                        it('should delete a leading line break', async () => {
+                            await testEditor({
+                                contentBefore: '<p>[]<br>abc</p>',
+                                stepFunction: deleteForward,
+                                contentAfter: '<p>[]abc</p>',
+                            });
+                            await testEditor({
+                                contentBefore: '<p>[]<br> abc</p>',
+                                stepFunction: deleteForward,
+                                // The space after the <br> is expected to be parsed
+                                // away, like it is in the DOM.
+                                contentAfter: '<p>[]abc</p>',
+                            });
+                        });
+                        it('should delete a line break within a paragraph', async () => {
+                            await testEditor({
+                                contentBefore: '<p>ab[]<br>cd</p>',
+                                stepFunction: deleteForward,
+                                contentAfter: '<p>ab[]cd</p>',
+                            });
+                            await testEditor({
+                                contentBefore: '<p>ab []<br>cd</p>',
+                                stepFunction: deleteForward,
+                                contentAfter: '<p>ab []cd</p>',
+                            });
+                            await testEditor({
+                                contentBefore: '<p>ab[]<br> cd</p>',
+                                stepFunction: deleteForward,
+                                // The space after the <br> is expected to be parsed
+                                // away, like it is in the DOM.
+                                contentAfter: '<p>ab[]cd</p>',
+                            });
+                        });
+                        it('should delete a trailing line break', async () => {
+                            await testEditor({
+                                contentBefore: '<p>abc[]<br><br></p>',
+                                stepFunction: deleteForward,
+                                contentAfter: '<p>abc[]</p>',
+                            });
+                            await testEditor({
+                                contentBefore: '<p>abc []<br><br></p>',
+                                stepFunction: deleteForward,
+                                contentAfter: '<p>abc&nbsp;[]</p>',
+                            });
+                        });
+                        it('should delete a character and a line break, emptying a paragraph', async () => {
+                            await testEditor({
+                                contentBefore: '<p>[]a<br><br></p><p>bcd</p>',
+                                stepFunction: (editor: JWEditor) => {
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                },
+                                contentAfter: '<p>[]<br></p><p>bcd</p>',
+                            });
+                        });
+                        it('should delete a character before a trailing line break', async () => {
+                            await testEditor({
+                                contentBefore: '<p>ab[]c<br><br></p>',
+                                stepFunction: deleteForward,
+                                contentAfter: '<p>ab[]<br><br></p>',
+                            });
+                        });
+                    });
+                    describe('Consecutive', () => {
+                        it('should merge a paragraph into a paragraph with 4 <br>', async () => {
+                            // 1
+                            await testEditor({
+                                contentBefore: '<p>ab</p><p><br><br><br><br>[]</p><p>cd</p>',
+                                stepFunction: deleteForward,
+                                contentAfter: '<p>ab</p><p><br><br><br>[]cd</p>',
+                                debug: true,
+                            });
+                            // 2-1
+                            await testEditor({
+                                contentBefore: '<p>ab</p><p><br><br><br>[]<br></p><p>cd</p>',
+                                stepFunction: deleteForward,
+                                // This should be identical to 1
+                                contentAfter: '<p>ab</p><p><br><br><br>[]cd</p>',
+                            });
+                        });
+                        it('should delete a trailing line break', async () => {
+                            // 3-1
+                            await testEditor({
+                                contentBefore: '<p>ab</p><p><br><br>[]<br><br></p><p>cd</p>',
+                                stepFunction: deleteForward,
+                                contentAfter: '<p>ab</p><p><br><br>[]<br></p><p>cd</p>',
+                            });
+                        });
+                        it('should delete a trailing line break, then merge a paragraph into a paragraph with 3 <br>', async () => {
+                            // 3-2
+                            await testEditor({
+                                contentBefore: '<p>ab</p><p><br><br>[]<br><br></p><p>cd</p>',
+                                stepFunction: (editor: JWEditor) => {
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                },
+                                contentAfter: '<p>ab</p><p><br><br>[]cd</p>',
+                            });
+                        });
+                        it('should delete a line break', async () => {
+                            // 4-1
+                            await testEditor({
+                                contentBefore: '<p>ab</p><p><br>[]<br><br><br></p><p>cd</p>',
+                                stepFunction: deleteForward,
+                                contentAfter: '<p>ab</p><p><br>[]<br><br></p><p>cd</p>',
+                            });
+                        });
+                        it('should delete two line breaks', async () => {
+                            // 4-2
+                            await testEditor({
+                                contentBefore: '<p>ab</p><p><br>[]<br><br><br></p><p>cd</p>',
+                                stepFunction: (editor: JWEditor) => {
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                },
+                                contentAfter: '<p>ab</p><p><br>[]<br></p><p>cd</p>',
+                            });
+                        });
+                        it('should delete two line breaks, then merge a paragraph into a paragraph with 2 <br>', async () => {
+                            // 4-3
+                            await testEditor({
+                                contentBefore: '<p>ab</p><p><br>[]<br><br><br></p><p>cd</p>',
+                                stepFunction: (editor: JWEditor) => {
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                },
+                                contentAfter: '<p>ab</p><p><br>[]cd</p>',
+                            });
+                        });
+                        it('should delete a line break', async () => {
+                            // 5-1
+                            await testEditor({
+                                contentBefore: '<p>ab</p><p>[]<br><br><br><br></p><p>cd</p>',
+                                stepFunction: deleteForward,
+                                contentAfter: '<p>ab</p><p>[]<br><br><br></p><p>cd</p>',
+                            });
+                        });
+                        it('should delete two line breaks', async () => {
+                            // 5-2
+                            await testEditor({
+                                contentBefore: '<p>ab</p><p>[]<br><br><br><br></p><p>cd</p>',
+                                stepFunction: (editor: JWEditor) => {
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                },
+                                contentAfter: '<p>ab</p><p>[]<br><br></p><p>cd</p>',
+                            });
+                        });
+                        it('should delete three line breaks (emptying a paragraph)', async () => {
+                            // 5-3
+                            await testEditor({
+                                contentBefore: '<p>ab</p><p>[]<br><br><br><br></p><p>cd</p>',
+                                stepFunction: (editor: JWEditor) => {
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                },
+                                contentAfter: '<p>ab</p><p>[]<br></p><p>cd</p>',
+                            });
+                        });
+                        it('should delete three line breaks, then merge a paragraph into an empty parargaph', async () => {
+                            // 5-4
+                            await testEditor({
+                                contentBefore: '<p>ab</p><p>[]<br><br><br><br></p><p>cd</p>',
+                                stepFunction: (editor: JWEditor) => {
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                },
+                                contentAfter: '<p>ab</p><p>[]cd</p>',
+                            });
+                        });
+                        it('should merge a paragraph with 4 <br> into a paragraph with text', async () => {
+                            // 6-1
+                            await testEditor({
+                                contentBefore: '<p>ab[]</p><p><br><br><br><br></p><p>cd</p>',
+                                stepFunction: deleteForward,
+                                contentAfter: '<p>ab[]<br><br><br><br></p><p>cd</p>',
+                            });
+                        });
+                        it('should merge a paragraph with 4 <br> into a paragraph with text, then delete a line break', async () => {
+                            // 6-2
+                            await testEditor({
+                                contentBefore: '<p>ab[]</p><p><br><br><br><br></p><p>cd</p>',
+                                stepFunction: (editor: JWEditor) => {
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                },
+                                contentAfter: '<p>ab[]<br><br><br></p><p>cd</p>',
+                            });
+                        });
+                        it('should merge a paragraph with 4 <br> into a paragraph with text, then delete two line breaks', async () => {
+                            // 6-3
+                            await testEditor({
+                                contentBefore: '<p>ab[]</p><p><br><br><br><br></p><p>cd</p>',
+                                stepFunction: (editor: JWEditor) => {
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                },
+                                contentAfter: '<p>ab[]<br><br></p><p>cd</p>',
+                            });
+                        });
+                        it('should merge a paragraph with 4 <br> into a paragraph with text, then delete three line breaks', async () => {
+                            // 6-4
+                            await testEditor({
+                                contentBefore: '<p>ab[]</p><p><br><br><br><br></p><p>cd</p>',
+                                stepFunction: (editor: JWEditor) => {
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                },
+                                contentAfter: '<p>ab[]</p><p>cd</p>',
+                            });
+                        });
+                        it('should merge a paragraph with 4 <br> into a paragraph with text, then delete three line breaks, then merge two paragraphs with text', async () => {
+                            // 6-5
+                            await testEditor({
+                                contentBefore: '<p>ab[]</p><p><br><br><br><br></p><p>cd</p>',
+                                stepFunction: (editor: JWEditor) => {
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                    deleteForward(editor);
+                                },
+                                contentAfter: '<p>ab[]cd</p>',
+                            });
+                        });
+                    });
+                });
+                describe('Formats', () => {
+                    it('should delete a character after a format node', async () => {
+                        await testEditor({
+                            contentBefore: '<p><b>abc[]</b>def</p>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<p><b>abc[]</b>ef</p>',
+                        });
+                        await testEditor({
+                            contentBefore: '<p><b>abc</b>[]def</p>',
+                            stepFunction: deleteForward,
+                            // The range is normalized so we only have one way
+                            // to represent a position.
+                            contentAfter: '<p><b>abc[]</b>ef</p>',
+                        });
+                    });
+                });
+                describe('Merging different types of elements', () => {
+                    it('should merge a paragraph with text into a heading1 with text', async () => {
+                        await testEditor({
+                            contentBefore: '<h1>ab[]</h1><p>cd</p>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<h1>ab[]cd</h1>',
+                        });
+                    });
+                    it('should merge an empty paragraph into a heading1 with text', async () => {
+                        await testEditor({
+                            contentBefore: '<h1>ab[]</h1><p><br></p>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<h1>ab[]</h1>',
+                        });
+                    });
+                });
+            });
+
+            describe('Range not collapsed', () => {
+                it('should delete part of the text within a paragraph', async () => {
+                    // Forward selection
+                    await testEditor({
+                        contentBefore: '<p>ab[cd]ef</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p>ab[]ef</p>',
+                    });
+                    // Backward selection
+                    await testEditor({
+                        contentBefore: '<p>ab]cd[ef</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p>ab[]ef</p>',
+                    });
+                });
+                it('should delete across two paragraphs', async () => {
+                    // Forward selection
+                    await testEditor({
+                        contentBefore: '<p>ab[cd</p><p>ef]gh</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p>ab[]gh</p>',
+                    });
+                    // Backward selection
+                    await testEditor({
+                        contentBefore: '<p>ab]cd</p><p>ef[gh</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p>ab[]gh</p>',
+                    });
+                });
+                it('should delete all the text in a paragraph', async () => {
+                    // Forward selection
+                    await testEditor({
+                        contentBefore: '<p>[abc]</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p>[]<br></p>',
+                    });
+                    // Backward selection
+                    await testEditor({
+                        contentBefore: '<p>]abc[</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p>[]<br></p>',
+                    });
+                });
+                it('should delete a complex selection accross format nodes and multiple paragraphs', async () => {
+                    // Forward selection
+                    await testEditor({
+                        contentBefore: '<p><b>ab[cd</b></p><p><b>ef<br/>gh</b>ij<i>kl]</i>mn</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p><b>ab[]</b>mn</p>',
+                    });
+                    await testEditor({
+                        contentBefore: '<p><b>ab[cd</b></p><p><b>ef<br/>gh</b>ij<i>k]l</i>mn</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p><b>ab[]</b><i>l</i>mn</p>',
+                    });
+                    // Backward selection
+                    await testEditor({
+                        contentBefore: '<p><b>ab]cd</b></p><p><b>ef<br/>gh</b>ij<i>kl[</i>mn</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p><b>ab[]</b>mn</p>',
+                    });
+                    await testEditor({
+                        contentBefore: '<p><b>ab]cd</b></p><p><b>ef<br/>gh</b>ij<i>k[l</i>mn</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p><b>ab[]</b><i>l</i>mn</p>',
+                    });
+                });
+                it('should delete all contents of a complex DOM with format nodes and multiple paragraphs', async () => {
+                    // Forward selection
+                    await testEditor({
+                        contentBefore: '<p><b>[abcd</b></p><p><b>ef<br/>gh</b>ij<i>kl</i>mn]</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p>[]<br></p>',
+                    });
+                    // Backward selection
+                    await testEditor({
+                        contentBefore: '<p><b>]abcd</b></p><p><b>ef<br/>gh</b>ij<i>kl</i>mn[</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<p>[]<br></p>',
+                    });
+                });
+                it('should delete a selection accross a heading1 and a paragraph', async () => {
+                    // Forward selection
+                    await testEditor({
+                        contentBefore: '<h1>ab [cd</h1><p>ef]gh</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<h1>ab []gh</h1>',
+                    });
+                    // Backward selection
+                    await testEditor({
+                        contentBefore: '<h1>ab ]cd</h1><p>ef[gh</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<h1>ab []gh</h1>',
+                    });
+                });
+                it('should delete a selection from the beginning of a heading1 with a format to the middle of a paragraph', async () => {
+                    // Forward selection
+                    await testEditor({
+                        contentBefore: '<h1><b>[abcd</b></h1><p>ef]gh</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<h1>[]gh</h1>',
+                    });
+                    await testEditor({
+                        contentBefore: '<h1>[<b>abcd</b></h1><p>ef]gh</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<h1>[]gh</h1>',
+                    });
+                    // Backward selection
+                    await testEditor({
+                        contentBefore: '<h1><b>]abcd</b></h1><p>ef[gh</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<h1>[]gh</h1>',
+                    });
+                    await testEditor({
+                        contentBefore: '<h1>]<b>abcd</b></h1><p>ef[gh</p>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<h1>[]gh</h1>',
                     });
                 });
             });

--- a/packages/core/test/VDocument.test.ts
+++ b/packages/core/test/VDocument.test.ts
@@ -246,8 +246,7 @@ describe('stores', () => {
                                 format: 'bold',
                             };
 
-                            editor.dispatcher.dispatch('applyFormat', params);
-                            editor.renderer.render(editor.vDocument, editor.editable);
+                            editor.execCommand('applyFormat', params);
                         },
                         contentAfter: 'a[<b>b]</b>c',
                     });
@@ -259,8 +258,7 @@ describe('stores', () => {
                             const params: FormatParams = {
                                 format: 'bold',
                             };
-                            editor.dispatcher.dispatch('applyFormat', params);
-                            editor.renderer.render(editor.vDocument, editor.editable);
+                            editor.execCommand('applyFormat', params);
                         },
                         contentAfter: 'a[b]c',
                     });
@@ -273,8 +271,7 @@ describe('stores', () => {
                                 format: 'bold',
                             };
 
-                            editor.dispatcher.dispatch('applyFormat', params);
-                            editor.renderer.render(editor.vDocument, editor.editable);
+                            editor.execCommand('applyFormat', params);
                         },
                         contentAfter: 'a[<b>bc]</b>',
                     });

--- a/packages/utils/src/testUtils.ts
+++ b/packages/utils/src/testUtils.ts
@@ -13,6 +13,7 @@ export interface TestEditorSpec {
     parsingOptions?: ParsingOptions;
     renderingOptions?: RenderOptions;
     stepFunction?: (editor: JWEditor) => void;
+    debug?: boolean;
 }
 
 /**
@@ -32,6 +33,11 @@ export function testEditor(spec: TestEditorSpec): void {
     document.body.appendChild(wrapper);
 
     const editor = new JWEditor(wrapper);
+    if (spec.debug === true) {
+        editor.loadConfig({
+            debug: true,
+        });
+    }
     editor.start(spec.parsingOptions);
     if (spec.stepFunction) {
         spec.stepFunction(editor);

--- a/packages/utils/src/testUtils.ts
+++ b/packages/utils/src/testUtils.ts
@@ -58,40 +58,61 @@ export function testEditor(spec: TestEditorSpec): void {
  * - `RANGE_TAIL_CHAR` in place for the selection start
  * - `RANGE_HEAD_CHAR` in place for the selection end
  *
- * Ths is used in the function `testEditor`.
- *
- * TODO: implement differently
+ * This is used in the function `testEditor`.
  */
 function _renderTextualRange(): void {
     const selection = document.getSelection();
 
-    const startContainer = selection.anchorNode;
-    const startOffset = selection.anchorOffset;
-    const endContainer = selection.focusNode;
-    const endOffset = selection.focusOffset;
-    const endValue = endContainer.nodeValue;
+    const start = _targetDeepest(selection.anchorNode, selection.anchorOffset);
+    const end = _targetDeepest(selection.focusNode, selection.focusOffset);
 
-    if (endContainer.nodeType === Node.TEXT_NODE) {
-        endContainer.nodeValue =
-            endValue.slice(0, endOffset) +
-            RANGE_HEAD_CHAR +
-            endValue.slice(endOffset, endValue.length);
-    } else {
-        endContainer.insertBefore(
-            document.createTextNode(RANGE_HEAD_CHAR),
-            endContainer.childNodes[endOffset + 1],
-        );
+    // If the range characters have to be inserted within the same parent and
+    // the start range character has to be before the end range character, the
+    // end offset needs to be adapted to account for the first insertion.
+    if (start.container === end.container && start.offset <= end.offset) {
+        end.offset++;
     }
-    if (startContainer.nodeType === Node.TEXT_NODE) {
-        const startValue = startContainer.nodeValue;
-        startContainer.nodeValue =
-            startValue.slice(0, startOffset) +
-            RANGE_TAIL_CHAR +
-            startValue.slice(startOffset, startValue.length);
+
+    _insertCharAt(RANGE_TAIL_CHAR, start.container, start.offset);
+    _insertCharAt(RANGE_HEAD_CHAR, end.container, end.offset);
+}
+
+/**
+ * Return the deepest child of a given container at a given offset, and its
+ * adapted offset.
+ *
+ * @param container
+ * @param offset
+ */
+function _targetDeepest(container: Node, offset: number): { container: Node; offset: number } {
+    while (container.hasChildNodes()) {
+        if (offset >= container.childNodes.length) {
+            container = container.lastChild;
+            offset = container.childNodes.length - 1;
+        } else {
+            container = container.childNodes[offset];
+            offset = 0;
+        }
+    }
+    return {
+        container: container as Node,
+        offset: offset,
+    };
+}
+
+/**
+ * Insert the given character at the given offset of the given container.
+ *
+ * @param char
+ * @param container
+ * @param offset
+ */
+function _insertCharAt(char: string, container: Node, offset: number): void {
+    if (container.nodeType === Node.TEXT_NODE) {
+        const startValue = container.nodeValue;
+        container.nodeValue =
+            startValue.slice(0, offset) + char + startValue.slice(offset, startValue.length);
     } else {
-        startContainer.insertBefore(
-            document.createTextNode(RANGE_TAIL_CHAR),
-            startContainer.childNodes[startOffset + 1],
-        );
+        container.parentNode.insertBefore(document.createTextNode(char), container);
     }
 }

--- a/packages/utils/src/testUtils.ts
+++ b/packages/utils/src/testUtils.ts
@@ -1,17 +1,11 @@
 import JWEditor from '../../core/src/JWEditor';
 import { expect } from 'chai';
-import { ParsingOptions } from '../../core/src/Parser';
-import { RANGE_HEAD_CHAR, RANGE_TAIL_CHAR } from '../../core/src/VRange';
-
-interface RenderOptions {
-    renderTextualRange: boolean;
-}
+import { RANGE_HEAD_CHAR, RANGE_TAIL_CHAR, Direction } from '../../core/src/VRange';
+import { DomRangeDescription } from '../../core/src/EventNormalizer';
 
 export interface TestEditorSpec {
     contentBefore: string;
     contentAfter: string;
-    parsingOptions?: ParsingOptions;
-    renderingOptions?: RenderOptions;
     stepFunction?: (editor: JWEditor) => void;
     debug?: boolean;
 }
@@ -22,15 +16,13 @@ export interface TestEditorSpec {
  * @param spec
  */
 export async function testEditor(spec: TestEditorSpec): Promise<void> {
-    if (!spec.renderingOptions) {
-        spec.renderingOptions = { renderTextualRange: true };
-    }
-    if (!spec.parsingOptions) {
-        spec.parsingOptions = { parseTextualRange: true };
-    }
     const wrapper = document.createElement('p');
     wrapper.innerHTML = spec.contentBefore;
+    const rangeDescription = _parseTextualRange(wrapper);
     document.body.appendChild(wrapper);
+    if (rangeDescription) {
+        _setRange(rangeDescription);
+    }
 
     const editor = new JWEditor(wrapper);
     if (spec.debug === true) {
@@ -38,12 +30,11 @@ export async function testEditor(spec: TestEditorSpec): Promise<void> {
             debug: true,
         });
     }
-    await editor.start(spec.parsingOptions);
+    await editor.start();
     if (spec.stepFunction) {
         spec.stepFunction(editor);
     }
-
-    if (spec.renderingOptions.renderTextualRange) {
+    if (rangeDescription) {
         _renderTextualRange();
     }
 
@@ -53,6 +44,118 @@ export async function testEditor(spec: TestEditorSpec): Promise<void> {
     wrapper.remove();
 }
 
+/**
+ * Return a description of a range from analysing the position of
+ * `RANGE_TAIL_CHAR` and `RANGE_HEAD_CHAR` characters within a test container.
+ * Also remove these from the test container.
+ */
+function _parseTextualRange(testContainer: Node): DomRangeDescription {
+    let startContainer: Node;
+    let endContainer: Node;
+    let startOffset: number;
+    let endOffset: number;
+    let direction = Direction.FORWARD;
+
+    let node = testContainer;
+    while (node && !(startContainer && endContainer)) {
+        let next: Node;
+        if (node.nodeType === Node.TEXT_NODE) {
+            // Look for range characters in the text content and remove them.
+            const startIndex = node.textContent.indexOf(RANGE_TAIL_CHAR);
+            node.textContent = node.textContent.replace(RANGE_TAIL_CHAR, '');
+            const endIndex = node.textContent.indexOf(RANGE_HEAD_CHAR);
+            node.textContent = node.textContent.replace(RANGE_HEAD_CHAR, '');
+
+            // Set the containers and offsets if we found the range characters.
+            if (startIndex !== -1) {
+                [startContainer, startOffset] = _toDomLocation(node, startIndex);
+                // If the end container was already found, change the range
+                // direction to BACKWARD.
+                if (endContainer) {
+                    direction = Direction.BACKWARD;
+                }
+            }
+            if (endIndex !== -1) {
+                [endContainer, endOffset] = _toDomLocation(node, endIndex);
+                // If the start range character is within the same parent and
+                // comes before the end range character, change the range
+                // direction to BACKWARD and adapt the startOffset to account
+                // for this end range character that was removed.
+                if (startContainer === endContainer && startOffset > endOffset) {
+                    direction = Direction.BACKWARD;
+                    startOffset--;
+                }
+            }
+
+            // Get the next node to check.
+            next = _nextNode(node);
+            // Remove the textual range node if it is empty.
+            if (!node.textContent.length) {
+                node.parentNode.removeChild(node);
+            }
+        } else {
+            next = _nextNode(node);
+        }
+        node = next;
+    }
+    if (startContainer && endContainer) {
+        return {
+            startContainer: startContainer,
+            startOffset: startOffset,
+            endContainer: endContainer,
+            endOffset: endOffset,
+            direction: direction,
+        };
+    }
+}
+/**
+ * Set a range in the DOM.
+ *
+ * @param range
+ */
+function _setRange(range: DomRangeDescription): void {
+    const domRange = document.createRange();
+    domRange.setStart(range.startContainer, range.startOffset);
+    domRange.collapse(true);
+    const selection = range.startContainer.ownerDocument.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(domRange);
+    selection.extend(range.endContainer, range.endOffset);
+}
+/**
+ * Return a node and an offset corresponding to an index within a text node.
+ *
+ * @param node
+ * @param index
+ */
+function _toDomLocation(node: Node, index: number): [Node, number] {
+    let container: Node;
+    let offset: number;
+    if (node.textContent.length) {
+        container = node;
+        offset = index;
+    } else {
+        container = node.parentNode;
+        offset = Array.from(node.parentNode.childNodes).indexOf(node as ChildNode);
+    }
+    return [container, offset];
+}
+/**
+ * Return the next node in traversal of the DOM tree.
+ *
+ * @param node
+ */
+function _nextNode(node: Node): Node {
+    let next: Node = node.firstChild || node.nextSibling;
+    if (!next) {
+        next = node;
+        while (next.parentNode && !next.nextSibling) {
+            next = next.parentNode;
+        }
+        next = next && next.nextSibling;
+    }
+    return next;
+}
 /**
  * Insert in the DOM:
  * - `RANGE_TAIL_CHAR` in place for the selection start

--- a/packages/utils/src/testUtils.ts
+++ b/packages/utils/src/testUtils.ts
@@ -5,7 +5,7 @@ import { DomRangeDescription } from '../../core/src/EventNormalizer';
 
 export interface TestEditorSpec {
     contentBefore: string;
-    contentAfter: string;
+    contentAfter?: string;
     stepFunction?: (editor: JWEditor) => void;
     debug?: boolean;
 }
@@ -37,8 +37,9 @@ export async function testEditor(spec: TestEditorSpec): Promise<void> {
     if (rangeDescription) {
         _renderTextualRange();
     }
-
-    expect(editor.editable.innerHTML).to.deep.equal(spec.contentAfter);
+    if (spec.contentAfter) {
+        expect(editor.editable.innerHTML).to.deep.equal(spec.contentAfter);
+    }
 
     editor.stop();
     wrapper.remove();

--- a/packages/utils/src/testUtils.ts
+++ b/packages/utils/src/testUtils.ts
@@ -21,7 +21,7 @@ export interface TestEditorSpec {
  *
  * @param spec
  */
-export function testEditor(spec: TestEditorSpec): void {
+export async function testEditor(spec: TestEditorSpec): Promise<void> {
     if (!spec.renderingOptions) {
         spec.renderingOptions = { renderTextualRange: true };
     }
@@ -38,7 +38,7 @@ export function testEditor(spec: TestEditorSpec): void {
             debug: true,
         });
     }
-    editor.start(spec.parsingOptions);
+    await editor.start(spec.parsingOptions);
     if (spec.stepFunction) {
         spec.stepFunction(editor);
     }

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -15,6 +15,16 @@ export const utils = {
         return string;
     },
     /**
+     * Return the length of a DOM Node.
+     *
+     * @param node
+     */
+    nodeLength(node: Node): number {
+        const isTextNode = node.nodeType === Node.TEXT_NODE;
+        const content = isTextNode ? node.nodeValue : node.childNodes;
+        return content.length;
+    },
+    /**
      * Take a collection of nodes and return a regular array
      * with the same contents.
      */

--- a/packages/utils/test/testUtils.test.ts
+++ b/packages/utils/test/testUtils.test.ts
@@ -4,10 +4,10 @@ describe('core', () => {
     describe('utils', () => {
         describe('testUtils', () => {
             describe('testEditor()', () => {
-                it('content should be the same (without range)', () => {
+                it('content should be the same (without range)', async () => {
                     let content;
                     content = 'a';
-                    testEditor({
+                    await testEditor({
                         contentBefore: content,
                         contentAfter: content,
                         renderingOptions: {
@@ -16,7 +16,7 @@ describe('core', () => {
                     });
 
                     content = '<b>a</b>';
-                    testEditor({
+                    await testEditor({
                         contentBefore: content,
                         contentAfter: content,
                         renderingOptions: {

--- a/packages/utils/test/testUtils.test.ts
+++ b/packages/utils/test/testUtils.test.ts
@@ -1,4 +1,7 @@
+import { expect } from 'chai';
 import { testEditor } from '../src/testUtils';
+import { VNodeType } from '../../core/src/VNode';
+import JWEditor from '../../core/src/JWEditor';
 
 describe('core', () => {
     describe('utils', () => {
@@ -16,6 +19,21 @@ describe('core', () => {
                     await testEditor({
                         contentBefore: content,
                         contentAfter: content,
+                    });
+                });
+                it('should parse with range', () => {
+                    testEditor({
+                        contentBefore: '<p>[a]</p>',
+                        stepFunction: (editor: JWEditor) => {
+                            const vDocument = editor.vDocument;
+                            expect(vDocument.root.type).to.equal(VNodeType.ROOT);
+                            expect(vDocument.root.children.length).to.equal(1);
+                            const p = vDocument.root.children[0];
+                            expect(p.type).to.equal(VNodeType.PARAGRAPH);
+                            expect(p.children.length).to.equal(1);
+                            expect(p.children[0].type).to.equal(VNodeType.CHAR);
+                            expect(p.children[0].value).to.equal('a');
+                        },
                     });
                 });
             });

--- a/packages/utils/test/testUtils.test.ts
+++ b/packages/utils/test/testUtils.test.ts
@@ -10,18 +10,12 @@ describe('core', () => {
                     await testEditor({
                         contentBefore: content,
                         contentAfter: content,
-                        renderingOptions: {
-                            renderTextualRange: false,
-                        },
                     });
 
                     content = '<b>a</b>';
                     await testEditor({
                         contentBefore: content,
                         contentAfter: content,
-                        renderingOptions: {
-                            renderTextualRange: false,
-                        },
                     });
                 });
             });


### PR DESCRIPTION
This converts all currently relevant delete/backspace tests from we3. Below is the list
all tests that are not yet relevant, as well as two skipped tests.
All issues revealed by these tests are fixed with this PR.

![Here are the tests](https://i.imgur.com/iS6DTE0.png)

1. [Forward](#forward)
    1. [Skipped](#f-skipped)
        1. [Two function calls -> redundant](#f-s-tfc)
    2. [To convert later](#f-todo)
        1. [Classes](#f-t-classes)
        2. [PRE](#f-t-pre)
        3. [Lists](#f-t-lists)
        4. [Tables](#f-t-tables)
        5. [SPAN](#f-t-span)
        6. [Pictograms](#f-t-pictograms)
        7. [HR](#f-t-hr)
        8. [Integration](#f-t-integration)
2. [Backward](#backward)
    1. [Skipped](#b-skipped)
        1. [Two function calls -> redundant](#b-s-tfc)
    2. [To convert later](#b-todo)
        1. [Classes](#b-t-classes)
        2. [PRE](#b-t-pre)
        3. [Lists](#b-t-lists)
        4. [Tables](#b-t-tables)
        5. [SPAN](#b-t-span)
        6. [Pictograms](#b-t-pictograms)
        7. [HR](#b-t-hr)
        8. [Integration](#b-t-integration)

# Forward<a name="forward"></a>
Note: These were tests for the delete key in we3. When implementing one, always make sure to also implement its inverse in backward tests.

## Skipped<a name="f-skipped"></a>

### Two function calls -> redundant<a name="f-s-tfc"></a>
```javascript
{
    name: "in p: DELETE within text",
    content: "<p>dom t◆o edit</p>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<p>dom t◆ edit</p>",
},
{
    name: "in h1 (empty-p after): 2x DELETE at end",
    content: "<h1>dom to edit◆</h1><p><br/></p>",
    steps: [{
        key: 'DELETE',
    }, {
        key: 'DELETE',
    }],
    test: "<h1>dom to edit◆</h1>",
},
```

## To convert later<a name="f-todo"></a>
(when their related feature is implemented)

### Classes<a name="f-t-classes"></a>
```javascript
{
    name: "in empty-p.a (p after): DELETE",
    content: '<p class="a"><br/>◆</p><p>dom to edit</p>',
    steps: [{
        key: 'DELETE',
    }],
    test: '<p class="a">◆dom to edit</p>',
},
{
    name: "in empty-p.a (p after): DELETE (2)",
    content: '<p class="a"><br/>◆</p><p>dom to edit</p>',
    steps: [{
        key: 'DELETE',
    }],
    test: '<p class="a">◆dom to edit</p>',
},
{
    name: "in p > span.a (div > span.a after): DELETE at end (must do nothing)",
    content: '<p><span class="a">dom to◆</span></p><div><span class="a">edit</span></div>',
    steps: [{
        key: 'DELETE',
    }],
    test: '<p><span class="a">dom to◆</span></p><div><span class="a">edit</span></div>',
},
```

### PRE<a name="f-t-pre"></a>
```javascript
{
    name: "in pre: DELETE within text, with space at beginning",
    content: "<pre>     dom t◆o edit</pre>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<pre>     dom t◆ edit</pre>",
},
{
    name: "in pre: DELETE within text, with one space at beginning",
    content: "<pre> dom t◆o edit</pre>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<pre> dom t◆ edit</pre>",
},
{
    name: "in pre: DELETE within text, with space at end",
    content: "<pre>dom t◆o edit     </pre>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<pre>dom t◆ edit     </pre>",
},
{
    name: "in pre: DELETE within text, with one space at end",
    content: "<pre>dom t◆o edit </pre>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<pre>dom t◆ edit </pre>",
},
{
    name: "in pre: DELETE within text, with space at beginning and end",
    content: "<pre>     dom t◆o edit     </pre>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<pre>     dom t◆ edit     </pre>",
},
{
    name: "in pre: DELETE within text, with one space at beginning and one at end",
    content: "<pre> dom t◆o edit </pre>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<pre> dom t◆ edit </pre>",
},
```

### Lists<a name="f-t-lists"></a>
```javascript
{
    name: "in empty-li (no other li): DELETE (must do nothing)",
    content: "<ul><li><br/>◆</li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<ul><li>▶<br/>◀</li></ul>",
},
{
    name: "from p to li > p: DELETE on whole list",
    content: "<p>dom not to edit▶</p><ul><li><p>dom to edit◀</p></li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<p>dom not to edit◆</p>",
},
{
    name: "in empty-li (no other li): DELETE -> 'a' (must write into it)",
    content: "<ul><li><br/>◆</li></ul>",
    steps: [{
        key: 'DELETE',
    }, {
        key: 'a',
    }],
    test: "<ul><li>a◆</li></ul>",
},
{
    name: "in li (li after): DELETE at end (must move contents of second li to carret)",
    content: "<ul><li>dom to&nbsp;◆</li><li>edit</li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<ul><li>dom to ◆edit</li></ul>",
},
{
    name: "in li (li after): DELETE -> 'a' at end (must move contents of second li to carret, then write)",
    content: "<ul><li>dom to&nbsp;◆</li><li>edit</li></ul>",
    steps: [{
        key: 'DELETE',
    }, {
        key: 'a',
    }],
    test: "<ul><li>dom to a◆edit</li></ul>",
},
{
    name: "in li > p: DELETE before single character",
    content: "<ul><li><p>◆a</p></li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<ul><li><p>▶<br/>◀</p></li></ul>",
},
{
    name: "in li > p: DELETE -> 'a' before single character",
    content: "<ul><li><p>◆a</p></li></ul>",
    steps: [{
        key: 'DELETE',
    }, {
        key: 'a',
    }],
    test: "<ul><li><p>a◆</p></li></ul>",
},
{
    name: "in li > p (p after): DELETE at end",
    content: "<ul><li><p>toto</p></li><li><p>xxx◆</p><p>yyy</p></li><li><p>tutu</p></li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<ul><li><p>toto</p></li><li><p>xxx◆yyy</p></li><li><p>tutu</p></li></ul>",
},
{
    name: "in li > p (b before - p after): DELETE at end",
    content: "<ul><li><p>toto</p></li><li><p><b>x</b>xx◆</p><p><b>y</b>yy</p></li><li><p>tutu</p></li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<ul><li><p>toto</p></li><li><p><b>x</b>xx◆<b>y</b>yy</p></li><li><p>tutu</p></li></ul>",
},
{
    name: "in li > p (p.o_default_snippet_text after): DELETE at end",
    content: '<ul><li><p>toto</p></li><li><p>xxx◆</p><p class="o_default_snippet_text">yyy</p></li><li><p>tutu</p></li></ul>',
    steps: [{
        key: 'DELETE',
    }],
    test: "<ul><li><p>toto</p></li><li><p>xxx◆yyy</p></li><li><p>tutu</p></li></ul>",
},
{
    name: "in indented-ul > li: DELETE at end (must do nothing)",
    content: "<ul><li><ul><li>dom to edit◆</li></ul></li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: '<ul><li class="o_indent"><ul><li>dom to edit◆</li></ul></li></ul>',
},
{
    name: "in indented-ul > li: DELETE at end -> 'a' at end (must write)",
    content: "<ul><li><ul><li>dom to edit◆</li></ul></li></ul>",
    steps: [{
        key: 'DELETE',
    }, {
        key: 'a',
    }],
    test: '<ul><li class="o_indent"><ul><li>dom to edita◆</li></ul></li></ul>',
},
{
    name: "in indented-ul > li (non-indented-li after): DELETE at end",
    content: "<ul><li><ul><li>dom to edit◆</li></ul></li><li>dom to edit</li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: '<ul><li class="o_indent"><ul><li>dom to edit◆dom to edit</li></ul></li></ul>',
},
{
    name: "in ul > li (indented-li after): DELETE at end",
    content: "<ul><li>dom to edit◆</li><li><ul><li>dom to edit</li></ul></li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<ul><li>dom to edit◆dom to edit</li></ul>",
},
{
    name: "in li: DELETE on partial selection",
    content: "<ul><li>d▶om to ◀edit</li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<ul><li>d◆edit</li></ul>",
},
{
    name: "across 2 li: DELETE on partial selection",
    content: "<ul><li>d▶om to edit</li><li>dom to ◀edit</li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<ul><li>d◆edit</li></ul>",
},
{
    name: "in li: DELETE on selection of all contents",
    content: "<ul><li>▶dom to edit◀</li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<ul><li>▶<br/>◀</li></ul>",
},
{
    name: "in li: DELETE -> 'a' on selection of all contents",
    content: "<ul><li>▶dom to edit◀</li></ul>",
    steps: [{
        key: 'DELETE',
    }, {
        key: 'a',
    }],
    test: "<ul><li>a◆</li></ul>",
},
{
    name: "in li: DELETE after character, before p",
    content: "<ul><li>a</li><li>b◆<p>c</p></li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<ul><li>a</li><li><p>b◆c</p></li></ul>",
},
{
    name: "in ol > li (ul > li after): DELETE at end",
    content: "<ol><li>a◆</li></ol><ul><li>b</li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<ol><li>a◆b</li></ol>",
},
{
    name: "in ol > li (ul > li > p after): DELETE at end",
    content: "<ol><li>a◆</li></ol><ul><li><p>b</p></li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<ol><li>a◆b</li></ol>",
},
{
    name: "in ol > li > p (ul > li after): DELETE at end",
    content: "<ol><li><p>a◆</p></li></ol><ul><li>b</li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<ol><li><p>a◆b</p></li></ol>",
},
{
    name: "in ol > li > p (ul > li > p after): DELETE at end",
    content: "<ol><li><p>a◆</p></li></ol><ul><li><p>b</p></li></ul>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<ol><li><p>a◆b</p></li></ol>",
},
{
    name: "in p (ul after): DELETE at end (must bring contents of first li to end of p)",
    content: "<p>dom to edit◆&nbsp;</p><ul><li><p>&nbsp; dom to edit</p></li><li><p>dom not to edit</p></li></ul>",
    steps: [{
        key: 'DELETE',
    }, {
        key: 'DELETE',
    }, {
        key: 'DELETE',
    }, {
        key: 'DELETE',
    }],
    test: "<p>dom to edit◆dom to edit</p><ul><li><p>dom not to edit</p></li></ul>",
},
{
    name: "in li > p (p after ul): DELETE at end",
    content: '<ul><li><p>node to merge with◆</p></li></ul><p>node to merge</p>',
    steps: [{
        key: 'DELETE',
    }],
    test: '<ul><li><p>node to merge with◆node to merge</p></li></ul>',
},
{
    name: "in li > p (i before - p > b after): DELETE at end",
    content: '<ul><li><p><i>node to merge</i> with◆</p></li></ul><p><b>node</b> to merge</p>',
    steps: [{
        key: 'DELETE',
    }],
    test: '<ul><li><p><i>node to merge</i> with◆<b>node</b> to merge</p></li></ul>',
},
{
    name: "in li > p > i (b before - p > b after): DELETE at end",
    content: '<ul><li><p><b>node to </b><i>merge with◆</i></p></li></ul><p><b>node</b> to merge</p>',
    steps: [{
        key: 'DELETE',
    }],
    test: '<ul><li><p><b>node to </b><i>merge with◆</i><b>node</b> to merge</p></li></ul>',
},
```

### Tables<a name="f-t-tables"></a>
```javascript
{
    name: "in empty-td (td after): DELETE -> 'a' at start",
    content: '<table class="table table-bordered"><tbody><tr><td><p><br/></p></td><td><p><br/>◆</p></td></tr></tbody></table>',
    steps: [{
        key: 'DELETE',
    }, {
        key: 'a',
    }],
    test: '<table class="table table-bordered"><tbody><tr><td><p><br/></p></td><td><p>a◆</p></td></tr></tbody></table>',
},
{
    name: "in td (td after): 2x DELETE -> 'a' after first character",
    content: '<table class="table table-bordered"><tbody><tr><td><p>d◆om to edit</p></td><td><p>dom not to edit</p></td></tr></tbody></table>',
    steps: [{
        key: 'DELETE',
    }, {
        key: 'DELETE',
    }, {
        key: 'a',
    }],
    test: '<table class="table table-bordered"><tbody><tr><td><p>da◆ to edit</p></td><td><p>dom not to edit</p></td></tr></tbody></table>',
},
{
    name: "in td: DELETE within text",
    content: '<table class="table table-bordered"><tbody><tr><td><p>dom ◆to edit</p></td></tr></tbody></table>',
    steps: [{
        key: 'DELETE',
    }],
    test: '<table class="table table-bordered"><tbody><tr><td><p>dom ◆o edit</p></td></tr></tbody></table>',
},
```

### SPAN<a name="f-t-span"></a>
```javascript
{
    name: "in complex-dom (span > b -> ENTER): DELETE",
    content: "<p><span><b>dom◆</b></span><br/><span><b>to edit</b></span></p>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<p><span><b>dom◆to edit</b></span></p>",
},
{
    name: "in p.a > span.b (p.c > span.b after): DELETE at end",
    content: "<p class=\"a\"><span class=\"b\">dom to&nbsp;◆</span></p><p class=\"c\"><span class=\"b\">edit</span></p>",
    steps: [{
        key: 'DELETE',
    }],
    test: "<p class=\"a\"><span class=\"b\">dom to ◆edit</span></p>",
},
```

### Pictograms<a name="f-t-pictograms"></a>
```javascript
{
    name: "in p (span.fa after): DELETE",
    content: '<p>aaa◆<span class="fa fa-star"></span>bbb</p>',
    steps: [{
        key: 'DELETE',
    }],
    test: '<p>aaa◆bbb</p>',
},
```

### HR<a name="f-t-hr"></a>
```javascript
{
    name: "in p (hr after): DELETE",
    content: '<p>aaa◆</p><hr><p>bbb</p>',
    steps: [{
        key: 'DELETE',
    }],
    test: '<p>aaa◆</p><p>bbb</p>',
},
```

### Integration<a name="f-t-integration"></a>
```javascript
{
    name: "in p: DELETE -> 'a' within text, before \\w\\s",
    content: "<p>do◆m t</p>",
    steps: [{
        key: 'DELETE',
    }, {
        key: 'a',
    }],
    test: "<p>doa◆ t</p>",
},
{
    name: "in p: DELETE -> 'a' on selection of all contents",
    content: "<p>▶dom to edit◀</p>",
    steps: [{
        key: 'DELETE',
    }, {
        key: 'a',
    }],
    test: "<p>a◆</p>",
},
```

# Backward<a name="backward"></a>
Note: These were tests for the backspace key in we3. When implementing one,
always make sure to also implement its inverse in forward tests.

## Skipped<a name="b-skipped"></a>

### Two function calls -> redundant<a name="b-s-tfc"></a>
```javascript
{
    name: "in p: 2x BACKSPACE within text",
    content: "<p>dom t◆o edit</p>",
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'BACKSPACE',
    }],
    test: "<p>dom◆o edit</p>",
},
{
    name: "in p: 2x BACKSPACE to empty a p with text",
    content: "<p>a</p><p>bc◆</p><p>d</p>",
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'BACKSPACE',
    }],
    test: "<p>a</p><p>▶<br/>◀</p><p>d</p>",
},
{
    name: "in empty-p (h1 before): 2x BACKSPACE",
    content: "<h1>dom to edit</h1><p><br>◆</p>",
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'BACKSPACE',
    }],
    test: "<h1>dom to edi◆</h1>",
},
```

## To convert later

### Classes<a name="b-t-classes"></a>
```javascript
{
    name: "in p (empty-p.a before): BACKSPACE",
    content: '<p class="a"><br></p><p>◆dom to edit</p>',
    steps: [{
        key: 'BACKSPACE',
    }],
    test: '<p class="a">◆dom to edit</p>',
},
{
    name: "in p (p > span.a before - span.b after): BACKSPACE at beginning (must attach them)",
    content: '<p><span class="a">dom to</span></p><p><span class="b">◆edit</span></p>',
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<p><span class=\"a\">dom to</span><span class=\"b\">◆edit</span></p>",
},
{
    name: "in p (p > span.a before - span.a after): BACKSPACE (must merge them)",
    content: '<p><span class="a">dom to</span></p><p><span class="a">◆edit</span></p>',
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<p><span class=\"a\">dom to◆edit</span></p>",
},
{
    name: "in p (div > span.a before - span.a after): BACKSPACE at beginning (must do nothing)",
    content: "<div><p><span class=\"a\">dom to&nbsp;</span></p></div><p><span class=\"a\">◆edit</span></p>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<div><p><span class=\"a\">dom to&nbsp;</span></p></div><p><span class=\"a\">◆edit</span></p>",
},
{
    name: "in p.c (p.a > span.b before - span.b after): BACKSPACE at beginning",
    content: '<p class="a"><span class="b">dom to</span></p><p class="c"><span class="b">◆edit</span></p>',
    steps: [{
        key: 'BACKSPACE',
    }],
    test: '<p class="a"><span class="b">dom to◆edit</span></p>',
},
```

### PRE<a name="b-t-pre"></a>
{
    name: "in pre: BACKSPACE within text, with space at beginning",
    content: "<pre>     dom t◆o edit</pre>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<pre>     dom ◆o edit</pre>",
},
{
    name: "in pre: BACKSPACE within text, with one space at beginning",
    content: "<pre> dom t◆o edit</pre>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<pre> dom ◆o edit</pre>",
},
{
    name: "in pre: BACKSPACE within text, with space at end",
    content: "<pre>dom t◆o edit     </pre>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<pre>dom ◆o edit     </pre>",
},
{
    name: "in pre: BACKSPACE within text, with one space at end",
    content: "<pre>dom t◆o edit </pre>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<pre>dom ◆o edit </pre>",
},
{
    name: "in pre: BACKSPACE within text, with space at beginning and end",
    content: "<pre>     dom t◆o edit     </pre>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<pre>     dom ◆o edit     </pre>",
},
{
    name: "in pre: BACKSPACE within text, with one space at beginning and one at end",
    content: "<pre> dom t◆o edit </pre>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<pre> dom ◆o edit </pre>",
},
```

### Lists<a name="b-t-lists"></a>
{
    name: "from p to ul > li: BACKSPACE on whole list",
    content: "<p>dom not to edit▶</p><ul><li><p>dom to edit◀</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<p>dom not to edit◆</p>",
},
{
    name: "in ul > second-li > p: BACKSPACE at end",
    content: "<ul><li><p>dom to</p></li><li><p>edit◆</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ul><li><p>dom to</p></li><li><p>edi◆</p></li></ul>",
},
{
    name: "in ul > second-li > empty-p: BACKSPACE at beginning",
    content: "<ul><li><p><br></p></li><li><p><br>◆</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ul><li><p>▶<br/>◀</p></li></ul>",
},
{
    name: "in ul > indented-li (no other li - p before): BACKSPACE at beginning",
    content: "<p>dom to</p><ul><ul><li>◆edit</li></ul></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<p>dom to</p><ul><li>◆edit</li></ul>",
},
{
    name: "in ul > indented-li (no other li - p before): BACKSPACE -> 'a' at beginning",
    content: "<p>dom to</p><ul><ul><li>◆edit</li></ul></ul>",
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'a',
    }],
    test: "<p>dom to</p><ul><li>a◆edit</li></ul>",
},
{
    name: "in ul > indented-li (no other li - none before): BACKSPACE at beginning",
    content: "<ul><ul><li>◆dom to edit</li></ul></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ul><li>◆dom to edit</li></ul>",
},
{
    name: "in li: BACKSPACE on partial selection",
    content: "<ul><li>d▶om to ◀edit</li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ul><li>d◆edit</li></ul>",
},
{
    name: "across 2 li: BACKSPACE on partial selection",
    content: "<ul><li>d▶om to edit</li><li>dom to ◀edit</li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ul><li>d◆edit</li></ul>",
},
{
    name: "in li (no other li): BACKSPACE on selection of all contents",
    content: "<ul><li>▶dom to edit◀</li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ul><li>▶<br/>◀</li></ul>",
},
{
    name: "in li (no other li): BACKSPACE -> 'a' on selection of all contents",
    content: "<ul><li>▶dom to edit◀</li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'a',
    }],
    test: "<ul><li>a◆</li></ul>",
},
{
    name: "in empty-li: BACKSPACE (must remove list)",
    content: "<ul><li><br>◆</li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<p>▶<br/>◀</p>",
},
{
    name: "in empty-li (no other li - empty-p before): BACKSPACE -> 'a'",
    content: "<p><br></p><ul><li><br>◆</li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'a',
    }],
    test: "<p>a◆</p>",
},
{
    name: "in empty-li (no other li - p before): BACKSPACE",
    content: "<p>toto</p><ul><li><br>◆</li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<p>toto</p><p>▶<br/>◀</p>",
},
{
    name: "in li (no other li - p before): BACKSPACE at start",
    content: "<p>toto</p><ul><li>◆&nbsp;<img src='/web_editor/static/src/img/transparent.png'></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<p>toto</p><p>◆&nbsp;<img src=\"/web_editor/static/src/img/transparent.png\"/></p>",
},
{
    name: "in empty-indented-li (other li - no other indented-li): BACKSPACE",
    content: "<ul><li><p>toto</p></li><ul><li><br>◆</li></ul><li><p>tutu</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ul><li><p>toto</p></li><li>▶<br/>◀</li><li><p>tutu</p></li></ul>",
},
{
    name: "in empty-indented-li (other li - other indented-li): BACKSPACE",
    content: "<ul><li><p>toto</p></li><ul><li><br>◆</li><li><br></li></ul><li><p>tutu</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: '<ul><li><p>toto</p></li><li>▶<br/>◀</li><li class="o_indent"><ul><li><br/></li></ul></li><li><p>tutu</p></li></ul>',
},
{
    name: "in empty-indented-li (no other li, no other indented-li): BACKSPACE",
    content: "<ul><ul><li><br>◆</li></ul></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ul><li>▶<br/>◀</li></ul>",
},
{
    name: "in indented-li (other li, other indented-li): BACKSPACE at start",
    content: "<ul><li><p>toto</p></li><li><ul><li><p>◆xxx</p></li><li><p>yyy</p></li></ul></li><li><p>tutu</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: '<ul><li><p>toto</p></li><li><p>◆xxx</p></li><li class="o_indent"><ul><li><p>yyy</p></li></ul></li><li><p>tutu</p></li></ul>',
},
{
    name: "in second li > p: BACKSPACE at start",
    content: "<ul><li><p>toto</p></li><li><p>◆xxx</p></li><li><p>tutu</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ul><li><p>toto◆xxx</p></li><li><p>tutu</p></li></ul>",
},
{
    name: "in second li > p (p after, within li): BACKSPACE at start",
    content: "<ul><li><p>toto</p></li><li><p>◆xxx</p><p>yyy</p></li><li><p>tutu</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ul><li><p>toto◆xxx</p><p>yyy</p></li><li><p>tutu</p></li></ul>",
},
{
    name: "in li > second-p: BACKSPACE at start",
    content: "<ul><li><p>toto</p></li><li><p>xxx</p><p>◆yyy</p></li><li><p>tutu</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ul><li><p>toto</p></li><li><p>xxx◆yyy</p></li><li><p>tutu</p></li></ul>",
},
{
    name: "in li (li after): BACKSPACE at start, with spaces",
    content: "<p>abc&nbsp;</p><ul><li><p>&nbsp; ◆def</p></li><li><p>dom not to edit</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'BACKSPACE',
    }, {
        key: 'BACKSPACE',
    }, {
        key: 'BACKSPACE',
    }],
    test: "<p>abc&nbsp;◆def</p><ul><li><p>dom not to edit</p></li></ul>",
    // todo: handle remove nbsp (not handled because no change triggered in "abc&nbsp;" so no rules applied)
},
{
    name: "in li > p: BACKSPACE after single character",
    content: "<ul><li><p>a◆</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ul><li><p>▶<br/>◀</p></li></ul>",
},
{
    name: "in li > p: BACKSPACE -> 'a' after single character",
    content: "<ul><li><p>a◆</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'a',
    }],
    test: "<ul><li><p>a◆</p></li></ul>",
},
{
    name: "in li > p > b: BACKSPACE on whole b",
    content: "<ul><li><p>a<b>▶bcd◀</b>e</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ul><li><p>a◆e</p></li></ul>",
},
{
    name: "in li (two empty li's before): BACKSPACE at start",
    content: "<ul><li><br/></li><li><br/></li><li>◆kl</li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ul><li><br/></li><li>◆kl</li></ul>",
},
{
    name: "in ul > li (ol > li before): BACKSPACE at end",
    content: "<ol><li>a</li></ol><ul><li>◆b</li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ol><li>a◆b</li></ol>",
},
{
    name: "in ul > li > p (ol > li before): BACKSPACE at end",
    content: "<ol><li>a</li></ol><ul><li><p>◆b</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ol><li>a◆b</li></ol>",
},
{
    name: "in ul > li (ol > li > p before): BACKSPACE at end",
    content: "<ol><li><p>a</p></li></ol><ul><li>◆b</li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ol><li><p>a◆b</p></li></ol>",
},
{
    name: "in ul > li > p (ol > li > p before): BACKSPACE at end",
    content: "<ol><li><p>a</p></li></ol><ul><li><p>◆b</p></li></ul>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<ol><li><p>a◆b</p></li></ol>",
},
{
    name: "in p (ul before): BACKSPACE at start",
    content: '<ul><li><p>node to merge with</p></li></ul><p>◆node to merge</p>',
    steps: [{
        key: 'BACKSPACE',
    }],
    test: '<ul><li><p>node to merge with◆node to merge</p></li></ul>',
},
{
    name: "in p > b (ul before, i after): BACKSPACE at start",
    content: '<ul><li><p>node to merge with</p></li></ul><p><b>◆node</b><i>to merge</i></p>',
    steps: [{
        key: 'BACKSPACE',
    }],
    test: '<ul><li><p>node to merge with<b>◆node</b><i>to merge</i></p></li></ul>',
},
{
    name: "in p > b (ul > i before, i after): BACKSPACE at start",
    content: '<ul><li><p><i>node to merge with</i></p></li></ul><p><b>◆node</b><i>to merge</i></p>',
    steps: [{
        key: 'BACKSPACE',
    }],
    test: '<ul><li><p><i>node to merge with</i><b>◆node</b><i>to merge</i></p></li></ul>',
},
```

### Tables<a name="b-t-tables"></a>
```javascript
{
    name: "in empty-td (td before): BACKSPACE -> 'a' at start",
    content: '<table class="table table-bordered"><tbody><tr><td><p><br></p></td><td><p><br>◆</p></td></tr></tbody></table>',
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'a',
    }],
    test: '<table class="table table-bordered"><tbody><tr><td><p><br/></p></td><td><p>a◆</p></td></tr></tbody></table>',
},
{
    name: "in td (td before): 2x BACKSPACE -> 'a' after first character",
    content: '<table class="table table-bordered"><tbody><tr><td><p>dom not to edit</p></td><td><p>d◆om to edit</p></td></tr></tbody></table>',
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'BACKSPACE',
    }, {
        key: 'a',
    }],
    test: '<table class="table table-bordered"><tbody><tr><td><p>dom not to edit</p></td><td><p>a◆om to edit</p></td></tr></tbody></table>',
},
{
    name: "in td (no other td): BACKSPACE within text",
    content: '<table class="table table-bordered"><tbody><tr><td><p>dom t◆o edit</p></td></tr></tbody></table>',
    steps: [{
        key: 'BACKSPACE',
    }],
    test: '<table class="table table-bordered"><tbody><tr><td><p>dom ◆o edit</p></td></tr></tbody></table>',
},
{
    name: "in complex-dom (empty-td (td before) -> 2x SHIFT-ENTER): 3x BACKSPACE -> 'a'",
    content: '<table class="table table-bordered"><tbody><tr><td><p>dom not to edit</p></td><td><p><br><br><br>◆</p></td></tr></tbody></table>',
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'BACKSPACE',
    }, {
        key: 'BACKSPACE',
    }, {
        key: 'a',
    }],
    test: '<table class="table table-bordered"><tbody><tr><td><p>dom not to edit</p></td><td><p>a◆</p></td></tr></tbody></table>',
},
{
    name: "in h1: BACKSPACE on full selection -> 'a'",
    content: '<h1>▶dom to delete◀</h1>',
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'a',
    }],
    test: '<h1>a◆</h1>',
},
{
    name: "in h1: BACKSPACE on full selection -> BACKSPACE -> 'a'",
    content: '<h1>▶dom to delete◀</h1>',
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'BACKSPACE',
    }, {
        key: 'a',
    }],
    test: '<h1>a◆</h1>',
},
{
    name: "in h1: BACKSPACE on full selection -> DELETE -> 'a'",
    content: '<h1>▶dom to delete◀</h1>',
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'DELETE',
    }, {
        key: 'a',
    }],
    test: '<h1>a◆</h1>',
},
```

### SPAN<a name="b-t-span"></a>
```javascript
{
    name: "in complex-dom (span > b -> ENTER in contents): BACKSPACE",
    content: "<p><span><b>dom<br></b></span><br><span><b>◆&nbsp;to edit</b></span></p>",
    steps: [{
        key: 'BACKSPACE',
    }],
    test: "<p><span><b>dom<br/>◆&nbsp;to edit</b></span></p>",
},
{
    name: "in complex-dom (span > b -> ENTER in contents): 2 x BACKSPACE",
    content: "<p><span><b>dom<br></b></span><br><span><b>a◆ to edit</b></span></p>",
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'BACKSPACE',
    }],
    test: "<p><span><b>dom<br/>◆&nbsp;to edit</b></span></p>",
},
```

### Pictograms<a name="b-t-pictograms"></a>
```javascript
{
    name: "in p: BACKSPACE after i.fa (voidoid)",
    content: '<p>aaa<i class="fa fa-star"></i>◆bbb</p>',
    steps: [{
        key: 'BACKSPACE',
    }],
    test: '<p>aaa◆bbb</p>',
}, {
    name: "in p: BACKSPACE on selected i.fa (voidoid)",
    content: '<p>aaa▶<i class="fa fa-star"></i>◀bbb</p>',
    steps: [{
        key: 'BACKSPACE',
    }],
    test: '<p>aaa◆bbb</p>',
}, {
    name: "in p: BACKSPACE before i.fa (voidoid)",
    content: '<p>aaa◆<i class="fa fa-star"></i>bbb</p>',
    steps: [{
        key: 'BACKSPACE',
    }],
    test: '<p>aa◆<i class="fa fa-star"></i>bbb</p>',
},
```

### HR<a name="b-t-hr"></a>
```javascript
{
    name: "in p (hr before): BACKSPACE",
    content: '<p>aaa</p><hr><p>◆bbb</p>',
    steps: [{
        key: 'BACKSPACE',
    }],
    test: '<p>aaa</p><p>◆bbb</p>',
},
```

### Integration<a name="b-t-integration"></a>
```javascript
{
    name: "in p: BACKSPACE -> 'a' at end, after space-char",
    content: "<p>dom t◆</p>",
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'a',
    }],
    test: "<p>dom a◆</p>",
},
{
    name: "in p: BACKSPACE -> 'a' on selection of all contents",
    content: "<p>▶dom to edit◀</p>",
    steps: [{
        key: 'BACKSPACE',
    }, {
        key: 'a',
    }],
    test: "<p>a◆</p>",
},
```
