### PR TITLE
[ADD] Utils: add predicates library

### DIFF
--- a/src/core/stores/VDocument.ts
+++ b/src/core/stores/VDocument.ts
@@ -1,11 +1,8 @@
 import { VNode, VNodeType, FormatType, FORMAT_TYPES } from './VNode';
 import { VRange } from './VRange';
+import { isChar } from '../utils/Predicates';
 
 export let withRange = false;
-
-function isChar(node): boolean {
-    return node.type === VNodeType.CHAR;
-}
 
 export class VDocument {
     root: VNode;

--- a/src/core/stores/VRange.ts
+++ b/src/core/stores/VRange.ts
@@ -1,5 +1,6 @@
 import { VNode, VNodeType } from './VNode';
 import { VDocument } from './VDocument';
+import { isRange } from '../utils/Predicates';
 
 export enum Direction {
     BACKWARD = 'BACKWARD',
@@ -109,7 +110,7 @@ export class VRange {
      * @param [edge] range node on which to collapse
      */
     collapse(edge = this._tail): VRange {
-        if (!edge.isRange()) {
+        if (!isRange(edge)) {
             edge = this._tail;
         }
         if (edge === this._tail) {

--- a/src/core/utils/Predicates.ts
+++ b/src/core/utils/Predicates.ts
@@ -1,0 +1,40 @@
+import { VNode, VNodeType } from '../stores/VNode';
+
+export type Predicate = (node: VNode) => boolean;
+
+/**
+ * Return a function that is the logical opposite of the given predicate.
+ *
+ * @param node node to check
+ */
+export function not(predicate: Predicate): Predicate {
+    return (node: VNode): boolean => !predicate(node);
+}
+
+/**
+ * Return true if the given node is a range node.
+ *
+ * @param node node to check
+ */
+export function isRange(node: VNode): boolean {
+    return node.type === VNodeType.RANGE_TAIL || node.type === VNodeType.RANGE_HEAD;
+}
+
+/**
+ * Return true if the given node is a character node.
+ *
+ * @param node node to check
+ */
+export function isChar(node: VNode): boolean {
+    return node.type === VNodeType.CHAR;
+}
+
+/**
+ * Return true if the given node is a leaf in the VDocument, that is a node that
+ * has no children.
+ *
+ * @param node node to check
+ */
+export function isLeaf(node: VNode): boolean {
+    return !node.hasChildren();
+}

--- a/src/core/utils/Renderer.ts
+++ b/src/core/utils/Renderer.ts
@@ -3,6 +3,7 @@ import { Format } from './Format';
 import { VDocumentMap } from './VDocumentMap';
 import { VRange, RelativePosition } from '../stores/VRange';
 import { VDocument } from '../stores/VDocument';
+import { isRange, isChar } from './Predicates';
 
 interface RenderingContext {
     currentVNode?: VNode; // Current VNode rendered at this step.
@@ -53,12 +54,12 @@ export class Renderer {
      * @param b
      */
     _isSameTextNode(a: VNode, b: VNode): boolean {
-        if (a.isRange() || b.isRange()) {
+        if (isRange(a) || isRange(b)) {
             // A Range node is always considered to be part of the same text
             // node as another node in the sense that the text node must not
             // be broken up just because it contains the range.
             return true;
-        } else if (a.type !== VNodeType.CHAR || b.type !== VNodeType.CHAR) {
+        } else if (!isChar(a) || !isChar(b)) {
             // Nodes that are not valid in a text node must end the text node.
             return false;
         } else {
@@ -142,7 +143,7 @@ export class Renderer {
         const charNodes = [firstChar];
         while (next && this._isSameTextNode(firstChar, next)) {
             context.currentVNode = next;
-            if (next.type === VNodeType.CHAR) {
+            if (isChar(next)) {
                 charNodes.push(next);
                 if (next.value === ' ' && text[text.length - 1] === ' ') {
                     // Browsers don't render consecutive space chars otherwise.
@@ -220,7 +221,7 @@ export class Renderer {
      * @param context
      */
     _renderVNode(context: RenderingContext): RenderingContext {
-        if (context.currentVNode.type === VNodeType.CHAR) {
+        if (isChar(context.currentVNode)) {
             context = this._renderTextNode(context);
         } else {
             context = this._renderElement(context);

--- a/src/plugins/DevTools/components/TreeComponent.ts
+++ b/src/plugins/DevTools/components/TreeComponent.ts
@@ -4,6 +4,7 @@ import { OwlUIComponent } from '../../../ui/OwlUIComponent';
 import { useState } from 'owl-framework/src/hooks';
 import { Direction, VRangeDescription } from '../../../core/stores/VRange';
 import { ActionGenerator } from '../../../core/actions/ActionGenerator';
+import { isRange } from '../../../core/utils/Predicates';
 
 interface NodeProps {
     isRoot: boolean;
@@ -127,7 +128,7 @@ export class TreeComponent extends OwlUIComponent<NodeProps> {
         if (node.value) {
             return utils.toUnicode(node.value);
         }
-        if (node.isRange()) {
+        if (isRange(node)) {
             return node.type === VNodeType.RANGE_TAIL ? '[' : ']';
         }
         if (node.type && node.type === VNodeType.LINE_BREAK) {


### PR DESCRIPTION
To avoid having too much isWhatever functions on the VNode class and
to be able to use them as traversal predicates directly, without having
to use a useless arrow function like node => node.isWhatever().

Note: I had to extract `VNodeType` out of `VNode` because`VNode` depended on `Predicates` to implement its method but `Predicates` depended on `VNode` because it needed `VNodeType`.