### PR TITLE
[IMP] Core: add ability to parameterize the range for the commands

### DIFF
--- a/packages/core/src/VDocument.ts
+++ b/packages/core/src/VDocument.ts
@@ -1,6 +1,7 @@
 import { VNode, VNodeType, FormatType, FORMAT_TYPES } from './VNode';
-import { VRange } from './VRange';
+import { VRange, Direction, RangePosition } from './VRange';
 import { isChar } from '../../utils/src/Predicates';
+import { RangeFromTo } from './CorePlugin';
 
 export let withRange = false;
 
@@ -21,28 +22,82 @@ export class VDocument {
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
+    /**
+     * Execute a callback with a specified or unspecified range.
+     *
+     * 1. If `rangeParam` is unspecified, the callback will uses the current vDocument range
+     * (i.e. `vDocument.range`).
+     *
+     * 2. If `rangeParam` is of type `Range`, execute the callback with that range.
+     *
+     * 3. If `rangeParam` is of type `RangeFromTo`:
+     *     1. Create a fake range
+     *     2. Execute the callback with that fake range as argument
+     *     3. Remove the fake range from the vDocument once the callback terminate to be
+     *        garbage collected.
+     */
+    async withCustomRange(
+        rangeParam: VRange | RangeFromTo | null,
+        callback: (range: VRange) => void,
+    ): Promise<void> {
+        if (rangeParam instanceof VRange) {
+            callback(rangeParam);
+        } else if (rangeParam === null || rangeParam === undefined) {
+            callback(this.range);
+        } else {
+            const rangeFromTo: RangeFromTo = { ...rangeParam };
+            if (!rangeFromTo.end) {
+                rangeFromTo.end = rangeFromTo.start;
+            }
 
+            // 3.1. Create fake range.
+            const fakeRange = new VRange(Direction.FORWARD);
+            if (rangeFromTo.startPosition && rangeFromTo.startPosition === RangePosition.AFTER) {
+                rangeFromTo.start.after(fakeRange.start);
+            } else {
+                rangeFromTo.start.before(fakeRange.start);
+            }
+            if (rangeFromTo.endPosition && rangeFromTo.endPosition === RangePosition.AFTER) {
+                rangeFromTo.end.after(fakeRange.end);
+            } else {
+                rangeFromTo.end.before(fakeRange.end);
+            }
+
+            // 3.2. Execute the callback with that fake range as argument.
+            await callback(fakeRange);
+
+            // 3.3. Remove the fake range from the vDocument to be garbage collected.
+            fakeRange.start.remove();
+            fakeRange.end.remove();
+        }
+    }
     /**
      * Insert a paragraph break.
+     * @param [rangeFromTo] The range to use. If not specified, uses current vDocument range.
      */
-    insertParagraphBreak(): void {
-        // Remove the contents of the selection if needed.
-        if (!this.range.isCollapsed()) {
-            this.deleteSelection();
-        }
-        this.range.start.parent.splitAt(this.range.start);
+    insertParagraphBreak(rangeFromTo?: RangeFromTo): void {
+        this.withCustomRange(rangeFromTo, (range: VRange) => {
+            // Remove the contents of the selection if needed.
+            if (!range.isCollapsed()) {
+                this.deleteSelection(range);
+            }
+            range.start.parent.splitAt(range.start);
+        });
     }
     /**
      * Insert something at range.
      *
      * @param node
+     * @param [rangeFromTo] The range to use. If not specified, uses current vDocument range.
      */
-    insert(node: VNode): void {
-        // Remove the contents of the selection if needed.
-        if (!this.range.isCollapsed()) {
-            this.deleteSelection();
-        }
-        this.range.start.before(node);
+    insert(node: VNode, rangeFromTo?: RangeFromTo): void {
+        this.withCustomRange(rangeFromTo, (range: VRange) => {
+            // Remove the contents of the selection if needed.
+            if (!range.isCollapsed()) {
+                this.deleteSelection(range);
+            }
+            range.start.before(node);
+        });
     }
     /**
      * Insert text at range.
@@ -54,37 +109,44 @@ export class VDocument {
      * range.
      *
      * @param text
+     * @param [rangeFromTo] The range to use. If not specified, uses current vDocument range.
      */
-    insertText(text: string): void {
-        const format = this._getCurrentFormat();
-        if (!this.range.isCollapsed()) {
-            // Remove the contents of the selection if needed.
-            this.deleteSelection();
-        }
-        // Split the text into CHAR nodes and insert them at the range.
-        const characters = text.split('');
-        characters.forEach(char => {
-            const vNode = new VNode(VNodeType.CHAR, '#text', char, format);
-            this.range.start.before(vNode);
+    insertText(text: string, rangeFromTo?: RangeFromTo): void {
+        this.withCustomRange(rangeFromTo, range => {
+            const format = this._getCurrentFormat(range);
+            if (!range.isCollapsed()) {
+                // Remove the contents of the selection if needed.
+                this.deleteSelection(range);
+            }
+            // Split the text into CHAR nodes and insert them at the range.
+            const characters = text.split('');
+            characters.forEach(char => {
+                const vNode = new VNode(VNodeType.CHAR, '#text', char, format);
+                range.start.before(vNode);
+            });
+            if (range === this.range) {
+                this.formatCache = null;
+            }
         });
-        this.formatCache = null;
     }
 
     /**
      * Get the format for the next insertion.
+     *
+     * @param range The range to format.
      */
-    _getCurrentFormat(): FormatType {
+    _getCurrentFormat(range: VRange): FormatType {
         let format: FormatType = {};
         if (this.formatCache) {
             return this.formatCache;
-        } else if (this.range.isCollapsed()) {
-            const charToCopyFormat = this.range.start.previousSibling(isChar) ||
-                this.range.start.nextSibling(isChar) || {
+        } else if (range.isCollapsed()) {
+            const charToCopyFormat = range.start.previousSibling(isChar) ||
+                range.start.nextSibling(isChar) || {
                     format: {},
                 };
             format = { ...charToCopyFormat.format };
         } else {
-            const selectedChars = this.range.selectedNodes.filter(isChar);
+            const selectedChars = range.selectedNodes.filter(isChar);
             FORMAT_TYPES.forEach(formatName => {
                 format[formatName] = selectedChars.some(char => char.format[formatName]);
             });
@@ -95,13 +157,19 @@ export class VDocument {
     /**
      * Truncate the tree by removing the selected nodes and merging their
      * orphaned children into the parent of the first removed node.
+     *
+     * @param range The range to format.
      */
-    deleteSelection(): void {
+    deleteSelection(range: VRange): void {
         VDocument.withRange(() => {
-            const nodes = this.range.selectedNodes;
+            // Filter out the range nodes because we never want to remove
+            // a range node from a selection.
+            const nodes = range.selectedNodes.filter(
+                node => node.type !== VNodeType.RANGE_TAIL && node.type !== VNodeType.RANGE_HEAD,
+            );
             if (!nodes.length) return;
-            this.range.collapse(this.range.start); // Reset the direction of the range.
-            let reference = this.range.end;
+            range.collapse(range.start); // Reset the direction of the range.
+            let reference = range.end;
             nodes.forEach(vNode => {
                 // If the node has children, merge it with the container of the
                 // range. Children of the merged node that should be truncated
@@ -144,29 +212,34 @@ export class VDocument {
      *
      * If the range is collapsed, set the format on the range so we know in the next insert
      * which format should be used.
+     *
+     * @param formatName The name of the format to use. (e. g. 'bold', 'italic', 'underline')
+     * @param [rangeFromTo] The range to use. If not specified, uses current vDocument range.
      */
-    applyFormat(formatName: string): void {
-        if (this.range.isCollapsed()) {
-            if (!this.formatCache) {
-                this.formatCache = this._getCurrentFormat();
-            }
-            this.formatCache[formatName] = !this.formatCache[formatName];
-        } else {
-            const selectedChars = this.range.selectedNodes.filter(isChar);
-
-            // If there is no char with the format `formatName` in the range, set the format to true
-            // for all nodes.
-            if (!selectedChars.every(char => char.format[formatName])) {
-                selectedChars.forEach(char => {
-                    char.format[formatName] = true;
-                });
-                // If there is at least one char in with the format `fomatName` in the range, set the
-                // format to false for all nodes.
+    applyFormat(formatName: string, rangeFromTo?: RangeFromTo): void {
+        this.withCustomRange(rangeFromTo, (range: VRange) => {
+            if (range.isCollapsed()) {
+                if (!this.formatCache) {
+                    this.formatCache = this._getCurrentFormat(range);
+                }
+                this.formatCache[formatName] = !this.formatCache[formatName];
             } else {
-                selectedChars.forEach(char => {
-                    char.format[formatName] = false;
-                });
+                const selectedChars = range.selectedNodes.filter(isChar);
+
+                // If there is no char with the format `formatName` in the range, set the format to true
+                // for all nodes.
+                if (!selectedChars.every(char => char.format[formatName])) {
+                    selectedChars.forEach(char => {
+                        char.format[formatName] = true;
+                    });
+                    // If there is at least one char in with the format `fomatName` in the range, set the
+                    // format to false for all nodes.
+                } else {
+                    selectedChars.forEach(char => {
+                        char.format[formatName] = false;
+                    });
+                }
             }
-        }
+        });
     }
 }

--- a/packages/core/src/VRange.ts
+++ b/packages/core/src/VRange.ts
@@ -6,6 +6,12 @@ export enum Direction {
     BACKWARD = 'BACKWARD',
     FORWARD = 'FORWARD',
 }
+// ? rename this interface?
+export enum RangePosition {
+    BEFORE = 'BEFORE',
+    AFTER = 'AFTER',
+}
+// ? extend with RangePosition?
 export enum RelativePosition {
     BEFORE = 'BEFORE',
     AFTER = 'AFTER',

--- a/packages/core/test/CorePlugin.test.ts
+++ b/packages/core/test/CorePlugin.test.ts
@@ -1,0 +1,51 @@
+import JWEditor from '../src/JWEditor';
+import { testEditor } from '../../utils/src/testUtils';
+import { OptionalRangeParams } from '../src/CorePlugin';
+
+describe('utils', () => {
+    describe('CorePlugin', () => {
+        // todo: test with startPosition after
+        // todo: test with endPosition after
+
+        describe('deleteBackward', () => {
+            it('should deleteBackward with a fake range', () => {
+                testEditor({
+                    contentBefore: '<p>abc[]</p>',
+                    stepFunction: (editor: JWEditor) => {
+                        const bNode = editor.vDocument.root.next(node => node.value === 'b');
+                        const params: OptionalRangeParams = {
+                            range: {
+                                start: bNode,
+                                end: bNode,
+                            },
+                        };
+
+                        editor.execCommand('deleteBackward', params);
+                        editor.renderer.render(editor.vDocument, editor.editable);
+                    },
+                    contentAfter: '<p>bc[]</p>',
+                });
+            });
+        });
+        describe('deleteForward', () => {
+            it('should deleteForward with a fake range', () => {
+                testEditor({
+                    contentBefore: '<p>abc[]</p>',
+                    stepFunction: (editor: JWEditor) => {
+                        const bNode = editor.vDocument.root.next(node => node.value === 'b');
+                        const params: OptionalRangeParams = {
+                            range: {
+                                start: bNode,
+                                end: bNode,
+                            },
+                        };
+
+                        editor.execCommand('deleteForward', params);
+                        editor.renderer.render(editor.vDocument, editor.editable);
+                    },
+                    contentAfter: '<p>ac[]</p>',
+                });
+            });
+        });
+    });
+});

--- a/packages/core/test/VDocument.test.ts
+++ b/packages/core/test/VDocument.test.ts
@@ -1,9 +1,169 @@
 import JWEditor from '../src/JWEditor';
 import { testEditor } from '../../utils/src/testUtils';
-import { FormatParams } from '../src/CorePlugin';
+import { FormatParams, InsertParams, OptionalRangeParams, RangeFromTo } from '../src/CorePlugin';
+import { VNode, VNodeType } from '../src/VNode';
+import { RangePosition } from '../src/VRange';
+import { expect } from 'chai';
 
 describe('stores', () => {
     describe('VDocument', () => {
+        describe('withCustomRange', () => {
+            it('should work with a provided VRange ', () => {
+                testEditor({
+                    contentBefore: 'ab[]',
+                    stepFunction: async (editor: JWEditor) => {
+                        await editor.vDocument.withCustomRange(editor.vDocument.range, range => {
+                            editor.vDocument.insertText('c', range);
+                            editor.renderer.render(editor.vDocument, editor.editable);
+                        });
+                    },
+                    contentAfter: 'abc[]',
+                });
+            });
+            it('should take the current range as default', () => {
+                testEditor({
+                    contentBefore: 'ab[]',
+                    stepFunction: async (editor: JWEditor) => {
+                        await editor.vDocument.withCustomRange(null, range => {
+                            editor.vDocument.insertText('c', range);
+                            editor.renderer.render(editor.vDocument, editor.editable);
+                        });
+                    },
+                    contentAfter: 'abc[]',
+                });
+            });
+            describe('rangeParam with RangeFromTo', () => {
+                it('should work with without rangeParams.startPosition and rangeParams.endPosition', () => {
+                    testEditor({
+                        contentBefore: 'ab[]',
+                        stepFunction: async (editor: JWEditor) => {
+                            const aNode = editor.vDocument.root.next(node => node.value === 'a');
+                            const rangeParams: RangeFromTo = {
+                                start: aNode,
+                                end: aNode,
+                            };
+                            await editor.vDocument.withCustomRange(rangeParams, range => {
+                                editor.vDocument.insertText('c', range);
+                                editor.renderer.render(editor.vDocument, editor.editable);
+                            });
+                        },
+                        contentAfter: 'cab[]',
+                    });
+                });
+                it('should work with without rangeParams.end', () => {
+                    testEditor({
+                        contentBefore: 'ab[]',
+                        stepFunction: async (editor: JWEditor) => {
+                            const aNode = editor.vDocument.root.next(node => node.value === 'a');
+                            const rangeParams: RangeFromTo = {
+                                start: aNode,
+                            };
+                            await editor.vDocument.withCustomRange(rangeParams, range => {
+                                editor.vDocument.insertText('c', range);
+                                editor.renderer.render(editor.vDocument, editor.editable);
+                                expect(range.start).to.be.equal(range.end);
+                            });
+                        },
+                        contentAfter: 'cab[]',
+                    });
+                });
+                it('should work with default RangePosition.BEFORE and RangePosition.BEFORE', () => {
+                    testEditor({
+                        contentBefore: 'ab[]',
+                        stepFunction: async (editor: JWEditor) => {
+                            const aNode = editor.vDocument.root.next(node => node.value === 'a');
+                            const rangeParams: RangeFromTo = {
+                                start: aNode,
+                                end: aNode,
+                            };
+                            await editor.vDocument.withCustomRange(rangeParams, range => {
+                                editor.vDocument.insertText('c', range);
+                                editor.renderer.render(editor.vDocument, editor.editable);
+                            });
+                        },
+                        contentAfter: 'cab[]',
+                    });
+                });
+                it('should work with RangePosition.BEFORE and RangePosition.BEFORE', () => {
+                    testEditor({
+                        contentBefore: 'ab[]',
+                        stepFunction: async (editor: JWEditor) => {
+                            const aNode = editor.vDocument.root.next(node => node.value === 'a');
+                            const rangeParams: RangeFromTo = {
+                                start: aNode,
+                                startPosition: RangePosition.BEFORE,
+                                end: aNode,
+                                endPosition: RangePosition.BEFORE,
+                            };
+                            await editor.vDocument.withCustomRange(rangeParams, range => {
+                                editor.vDocument.insertText('c', range);
+                                editor.renderer.render(editor.vDocument, editor.editable);
+                            });
+                        },
+                        contentAfter: 'cab[]',
+                    });
+                });
+                it('should work with RangePosition.BEFORE and RangePosition.AFTER', () => {
+                    testEditor({
+                        contentBefore: 'ab[]',
+                        stepFunction: async (editor: JWEditor) => {
+                            const aNode = editor.vDocument.root.next(node => node.value === 'a');
+                            const rangeParams: RangeFromTo = {
+                                start: aNode,
+                                startPosition: RangePosition.BEFORE,
+                                end: aNode,
+                                endPosition: RangePosition.AFTER,
+                            };
+                            await editor.vDocument.withCustomRange(rangeParams, range => {
+                                editor.vDocument.insertText('c', range);
+                                editor.renderer.render(editor.vDocument, editor.editable);
+                            });
+                        },
+                        contentAfter: 'cb[]',
+                    });
+                });
+                it('should work with RangePosition.AFTER and RangePosition.BEFORE', () => {
+                    testEditor({
+                        contentBefore: 'ab[]',
+                        stepFunction: async (editor: JWEditor) => {
+                            const aNode = editor.vDocument.root.next(node => node.value === 'a');
+                            const bNode = editor.vDocument.root.next(node => node.value === 'b');
+                            const rangeParams: RangeFromTo = {
+                                start: aNode,
+                                startPosition: RangePosition.AFTER,
+                                end: bNode,
+                                endPosition: RangePosition.BEFORE,
+                            };
+                            await editor.vDocument.withCustomRange(rangeParams, range => {
+                                editor.vDocument.insertText('c', range);
+                                editor.renderer.render(editor.vDocument, editor.editable);
+                            });
+                        },
+                        contentAfter: 'acb[]',
+                    });
+                });
+                it('should work with RangePosition.AFTER and RangePosition.AFTER', () => {
+                    testEditor({
+                        contentBefore: 'ab[]',
+                        stepFunction: async (editor: JWEditor) => {
+                            const aNode = editor.vDocument.root.next(node => node.value === 'a');
+                            const bNode = editor.vDocument.root.next(node => node.value === 'b');
+                            const rangeParams: RangeFromTo = {
+                                start: aNode,
+                                startPosition: RangePosition.AFTER,
+                                end: bNode,
+                                endPosition: RangePosition.AFTER,
+                            };
+                            await editor.vDocument.withCustomRange(rangeParams, range => {
+                                editor.vDocument.insertText('c', range);
+                                editor.renderer.render(editor.vDocument, editor.editable);
+                            });
+                        },
+                        contentAfter: 'ac[]',
+                    });
+                });
+            });
+        });
         describe('insertText', () => {
             describe('bold', () => {
                 describe('Range collapsed', () => {
@@ -75,6 +235,27 @@ describe('stores', () => {
                                 editor.renderer.render(editor.vDocument, editor.editable);
                             },
                             contentAfter: '<p><b>a</b></p><p>c[]b</p>',
+                        });
+                    });
+                    it('should insert with a fake range', () => {
+                        testEditor({
+                            contentBefore: '<p>a[b<b>c</b></p><p>de]f</p>',
+                            stepFunction: (editor: JWEditor) => {
+                                const bNode = editor.vDocument.root.next(
+                                    node => node.value === 'b',
+                                );
+                                const eNode = editor.vDocument.root.next(
+                                    node => node.value === 'e',
+                                );
+                                editor.execCommand('insertText', {
+                                    value: 'gh',
+                                    range: {
+                                        start: bNode,
+                                        end: eNode,
+                                    },
+                                });
+                            },
+                            contentAfter: '<p>a[<b>gh</b>e]f</p>',
                         });
                     });
                 });
@@ -278,6 +459,68 @@ describe('stores', () => {
                         },
                         contentAfter: 'a[<b>bc]</b>',
                     });
+                });
+            });
+            it('should applyFormat with a fake range', () => {
+                testEditor({
+                    contentBefore: 'a[bc]d',
+                    stepFunction: (editor: JWEditor) => {
+                        const aNode = editor.vDocument.root.next(node => node.value === 'a');
+                        const cNode = editor.vDocument.root.next(node => node.value === 'c');
+                        const params: FormatParams = {
+                            format: 'bold',
+                            range: {
+                                start: aNode,
+                                end: cNode,
+                            },
+                        };
+
+                        editor.execCommand('applyFormat', params);
+                    },
+                    contentAfter: '<b>a[b</b>c]d',
+                });
+            });
+        });
+        describe('insert', () => {
+            it('should insert with a fake range', () => {
+                testEditor({
+                    contentBefore: 'ab[]',
+                    stepFunction: (editor: JWEditor) => {
+                        const node = new VNode(VNodeType.CHAR, '#text', 'c');
+                        const aNode = editor.vDocument.root.next(node => node.value === 'a');
+                        const bNode = editor.vDocument.root.next(node => node.value === 'b');
+                        const params: InsertParams = {
+                            value: node,
+                            range: {
+                                start: aNode,
+                                end: bNode,
+                            },
+                        };
+
+                        editor.execCommand('insert', params);
+                    },
+                    contentAfter: 'cb[]',
+                });
+            });
+        });
+        describe('insertParagraphBreak', () => {
+            it('should insertParagraphBreak with a fake range', () => {
+                testEditor({
+                    contentBefore: '<p>abc</p><p>de[]</p>',
+                    stepFunction: (editor: JWEditor) => {
+                        const bNode = editor.vDocument.root.next(node => node.value === 'b');
+                        const cNode = editor.vDocument.root.next(node => node.value === 'c');
+                        const params: OptionalRangeParams = {
+                            range: {
+                                start: bNode,
+                                end: cNode,
+                            },
+                        };
+
+                        editor.execCommand('insertParagraphBreak', params);
+                        editor.renderer.render(editor.vDocument, editor.editable);
+                    },
+                    contentAfter: '<p>a</p><p>c</p><p>de[]</p>',
                 });
             });
         });


### PR DESCRIPTION
Before this commit, it was impossible to use a specific range when executing a command. The command where always using `vDocument.range`.

We want to allow the parameterization of the range for future features.