### PR TITLE
[POC] VNode: custom VNodes

### DIFF
--- a/examples/index/index.ts
+++ b/examples/index/index.ts
@@ -1,5 +1,6 @@
 import JWEditor from '../../packages/core/src/JWEditor';
 import { jabberwocky } from '../utils/jabberwocky';
+import { Youtube } from '../../packages/plugin-youtube/src/Youtube';
 import './index.css';
 
 const editor = new JWEditor();
@@ -8,5 +9,7 @@ jabberwocky.init(editor.editable);
 editor.loadConfig({
     debug: true,
 });
+
+editor.addPlugin(Youtube);
 
 editor.start();

--- a/examples/utils/jabberwocky.xml
+++ b/examples/utils/jabberwocky.xml
@@ -1,5 +1,9 @@
 <h1>Jabberwocky</h1>
 <h3>by Lewis Carroll</h3>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Ih8K2SKHJPI"
+frameborder="0"
+allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+allowfullscreen></iframe>
 <p><i>’Twas brillig, and the slithy toves<br/>
 Did gyre and gimble in the wabe:<br/>
 All mimsy were the borogoves,<br/>

--- a/packages/core/src/BasicHtmlRenderingEngine.ts
+++ b/packages/core/src/BasicHtmlRenderingEngine.ts
@@ -50,12 +50,6 @@ export const BasicHtmlRenderingEngine = {
         if (!node.hasChildren() && !node.properties.atomic) {
             renderedElement.appendChild(document.createElement('BR'));
         }
-
-        // If a LINE_BREAK has no next sibling, it must be rendered as two BRs
-        // in order for it to be visible.
-        if (node.type === VNodeType.LINE_BREAK && !node.nextSibling()) {
-            fragment.appendChild(document.createElement(tagName));
-        }
         return fragment;
     },
 };

--- a/packages/core/src/BasicHtmlRenderingEngine.ts
+++ b/packages/core/src/BasicHtmlRenderingEngine.ts
@@ -47,7 +47,7 @@ export const BasicHtmlRenderingEngine = {
 
         // If a node is empty but could accomodate children,
         // fill it to make it visible.
-        if (!node.hasChildren() && !node.properties.atomic) {
+        if (!node.hasChildren() && !node.atomic) {
             renderedElement.appendChild(document.createElement('BR'));
         }
         return fragment;

--- a/packages/core/src/BasicHtmlRenderingEngine.ts
+++ b/packages/core/src/BasicHtmlRenderingEngine.ts
@@ -1,24 +1,5 @@
-import { VNode, VNodeType } from './VNodes/VNode';
+import { VNode } from './VNodes/VNode';
 
-const getRenderingTagName = function(nodeType: VNodeType): string {
-    switch (nodeType) {
-        case 'CHAR':
-            return;
-        case 'HEADING1':
-        case 'HEADING2':
-        case 'HEADING3':
-        case 'HEADING4':
-        case 'HEADING5':
-        case 'HEADING6':
-            return 'H' + nodeType[7];
-        case 'LINE_BREAK':
-            return 'BR';
-        case 'PARAGRAPH':
-            return 'P';
-        case 'ROOT':
-            return 'ROOT';
-    }
-};
 /**
  * Renderers exist to render a node into another, different format. Each
  * format is implemented by a separate renderer following this interface.
@@ -40,7 +21,7 @@ export const BasicHtmlRenderingEngine = {
      * @param node
      */
     render: function(node: VNode): DocumentFragment {
-        const tagName = getRenderingTagName(node.type);
+        const tagName = node.htmlTag;
         const fragment = document.createDocumentFragment();
         const renderedElement = document.createElement(tagName);
         fragment.appendChild(renderedElement);

--- a/packages/core/src/BasicHtmlRenderingEngine.ts
+++ b/packages/core/src/BasicHtmlRenderingEngine.ts
@@ -1,4 +1,4 @@
-import { VNode, VNodeType } from './VNode';
+import { VNode, VNodeType } from './VNodes/VNode';
 
 const getRenderingTagName = function(nodeType: VNodeType): string {
     switch (nodeType) {

--- a/packages/core/src/CorePlugin.ts
+++ b/packages/core/src/CorePlugin.ts
@@ -2,7 +2,7 @@ import { JWPlugin } from './JWPlugin';
 import JWEditor from './JWEditor';
 import { VRangeDescription } from './VRange';
 import { Direction, RelativePosition } from '../../utils/src/range';
-import { VNode } from './VNode';
+import { VNode } from './VNodes/VNode';
 
 export interface InsertParams {
     value: VNode;

--- a/packages/core/src/CorePlugin.ts
+++ b/packages/core/src/CorePlugin.ts
@@ -1,6 +1,7 @@
 import { JWPlugin } from './JWPlugin';
 import JWEditor from './JWEditor';
-import { VRangeDescription, Direction, RelativePosition } from './VRange';
+import { VRangeDescription } from './VRange';
+import { Direction, RelativePosition } from '../../utils/src/range';
 import { VNode } from './VNode';
 
 export interface InsertParams {

--- a/packages/core/src/EventManager.ts
+++ b/packages/core/src/EventManager.ts
@@ -1,6 +1,6 @@
 import { EventNormalizer, DomRangeDescription } from './EventNormalizer';
 import { Parser } from './Parser';
-import { VNode, VNodeType } from './VNode';
+import { VNode, VNodeType } from './VNodes/VNode';
 import JWEditor from './JWEditor';
 
 interface SetRangeParams {

--- a/packages/core/src/EventManager.ts
+++ b/packages/core/src/EventManager.ts
@@ -1,6 +1,6 @@
 import { EventNormalizer, DomRangeDescription } from './EventNormalizer';
 import { Parser } from './Parser';
-import { VNode, VNodeType } from './VNodes/VNode';
+import { LineBreakNode } from './VNodes/LineBreakNode';
 import JWEditor from './JWEditor';
 
 interface SetRangeParams {
@@ -31,9 +31,7 @@ export class EventManager {
         switch (customEvent.type) {
             case 'enter':
                 if (customEvent.detail.shiftKey) {
-                    return this.editor.execCommand('insert', {
-                        value: new VNode(VNodeType.LINE_BREAK, 'BR'),
-                    });
+                    return this.editor.execCommand('insert', { value: new LineBreakNode() });
                 } else {
                     return this.editor.execCommand('insertParagraphBreak');
                 }

--- a/packages/core/src/EventManager.ts
+++ b/packages/core/src/EventManager.ts
@@ -1,5 +1,4 @@
 import { EventNormalizer, DomRangeDescription } from './EventNormalizer';
-import { Parser } from './Parser';
 import { LineBreakNode } from './VNodes/LineBreakNode';
 import JWEditor from './JWEditor';
 
@@ -39,7 +38,7 @@ export class EventManager {
             case 'setRange': {
                 const rangeParams = payload as SetRangeParams;
                 return this.editor.execCommand(customEvent.type, {
-                    vRange: Parser.parseRange(rangeParams.domRange),
+                    vRange: this.editor.parser.parseRange(rangeParams.domRange),
                 });
             }
             case 'keydown': {

--- a/packages/core/src/EventNormalizer.ts
+++ b/packages/core/src/EventNormalizer.ts
@@ -1,4 +1,4 @@
-import { Direction } from './VRange';
+import { Direction } from '../../utils/src/range';
 
 const navigationKey = new Set([
     'ArrowUp',

--- a/packages/core/src/JWEditor.ts
+++ b/packages/core/src/JWEditor.ts
@@ -7,10 +7,12 @@ import { OwlUI } from '../../owl-ui/src/OwlUI';
 import { CorePlugin } from './CorePlugin';
 import { Parser } from './Parser';
 import { DevTools } from '../../plugin-devtools/src/DevTools';
+import { VNode } from './VNodes/VNode';
 
 export interface JWEditorConfig {
     debug?: boolean;
     theme?: string;
+    replaceDefaultNodes?: Array<typeof VNode>;
 }
 
 export class JWEditor {
@@ -23,7 +25,7 @@ export class JWEditor {
     renderer: Renderer;
     vDocument: VDocument;
     debugger: OwlUI;
-    parser: Parser;
+    parser = new Parser();
 
     constructor(editable?: HTMLElement) {
         this.el = document.createElement('jw-editor');
@@ -54,7 +56,6 @@ export class JWEditor {
      */
     async start(): Promise<void> {
         // Parse the editable in the internal format of the editor.
-        this.parser = new Parser();
         this.vDocument = this.parser.parse(this._originalEditable);
 
         // Deep clone the given editable node in order to break free of any
@@ -109,6 +110,22 @@ export class JWEditor {
             this.dispatcher.registerHook(key, plugin.commandHooks[key]);
         });
     }
+    /**
+     * Add a custom VNode to the ones that this Parser can handle.
+     *
+     * @param VNodeClasses
+     */
+    addCustomNode(VNodeClass: typeof VNode): void {
+        this.parser.addCustomVNode(VNodeClass);
+    }
+    /**
+     * Add an array of custom VNodes to the ones that this Parser can handle.
+     *
+     * @param VNodeClasses
+     */
+    addCustomNodes(VNodeClasses: Array<typeof VNode>): void {
+        this.parser.addCustomVNodes(VNodeClasses);
+    }
 
     /**
      * Load the given config in this editor instance.
@@ -119,6 +136,9 @@ export class JWEditor {
         if (config.debug) {
             this.debugger = new OwlUI(this);
             this.debugger.addPlugin(DevTools);
+        }
+        if (config.replaceDefaultNodes) {
+            this.parser = new Parser(config.replaceDefaultNodes);
         }
     }
 

--- a/packages/core/src/JWEditor.ts
+++ b/packages/core/src/JWEditor.ts
@@ -23,6 +23,7 @@ export class JWEditor {
     renderer: Renderer;
     vDocument: VDocument;
     debugger: OwlUI;
+    parser: Parser;
 
     constructor(editable?: HTMLElement) {
         this.el = document.createElement('jw-editor');
@@ -53,7 +54,8 @@ export class JWEditor {
      */
     async start(): Promise<void> {
         // Parse the editable in the internal format of the editor.
-        this.vDocument = Parser.parse(this._originalEditable);
+        this.parser = new Parser();
+        this.vDocument = this.parser.parse(this._originalEditable);
 
         // Deep clone the given editable node in order to break free of any
         // handler that might have been previously registered.

--- a/packages/core/src/Parser.ts
+++ b/packages/core/src/Parser.ts
@@ -19,404 +19,14 @@ interface ParsingContext {
     vDocument: VDocument;
 }
 
-/**
- * Parse a node depending on its DOM type.
- *
- * @param currentContext The current context
- * @returns The next parsing context
- */
-function parseNode(currentContext: ParsingContext): ParsingContext {
-    let context;
-    switch (currentContext.node.nodeType) {
-        case Node.ELEMENT_NODE: {
-            context = parseElementNode(currentContext);
-            break;
-        }
-        case Node.TEXT_NODE: {
-            context = parseTextNode(currentContext);
-            break;
-        }
-        case Node.DOCUMENT_NODE:
-        case Node.DOCUMENT_FRAGMENT_NODE: {
-            // These nodes have no effect in the context of parsing, but the
-            // parsing itself will continue with their children.
-            context = currentContext;
-            break;
-        }
-        case Node.CDATA_SECTION_NODE:
-        case Node.PROCESSING_INSTRUCTION_NODE:
-        case Node.COMMENT_NODE:
-        case Node.DOCUMENT_TYPE_NODE:
-        default: {
-            throw `Unsupported node type: ${currentContext.node.nodeType}.`;
-        }
-    }
-    return nextParsingContext(context);
-}
-/**
- * Convert the DOM description of a range to the description of a VRange.
- *
- * @param range
- * @param [direction]
- */
-function parseRange(range: DomRangeDescription): VRangeDescription;
-function parseRange(range: Range, direction: Direction): VRangeDescription;
-function parseRange(range: Range | DomRangeDescription, direction?: Direction): VRangeDescription {
-    const start = _locate(range.startContainer, range.startOffset);
-    const end = _locate(range.endContainer, range.endOffset);
-    if (start && end) {
-        const [startVNode, startPosition] = start;
-        const [endVNode, endPosition] = end;
-        return {
-            start: startVNode,
-            startPosition: startPosition,
-            end: endVNode,
-            endPosition: endPosition,
-            direction: range instanceof Range ? direction : range.direction,
-        };
-    }
-}
-
-/**
- * Create and return a `VNode` corresponding to the given DOM tag.
- *
- * TODO: When introducing videos and other complex (atomic) nodes, this is going
- * to be to naive and it will have to be replaced.
- *
- * @param node
- */
-function VNodeFromTag(tag: string): VNode {
-    switch (tag) {
-        case 'P':
-            return new SimpleElementNode(VNodeType.PARAGRAPH);
-        case 'H1':
-            return new SimpleElementNode(VNodeType.HEADING1);
-        case 'H2':
-            return new SimpleElementNode(VNodeType.HEADING2);
-        case 'H3':
-            return new SimpleElementNode(VNodeType.HEADING3);
-        case 'H4':
-            return new SimpleElementNode(VNodeType.HEADING4);
-        case 'H5':
-            return new SimpleElementNode(VNodeType.HEADING5);
-        case 'H6':
-            return new SimpleElementNode(VNodeType.HEADING6);
-        case 'BR':
-            return new LineBreakNode();
-    }
-}
-/**
- * Parse the given DOM Element into VNode(s).
- *
- * @param node to parse
- * @param [format] to apply to the parsed node (default: none)
- * @returns the parsed VNode(s)
- */
-function parseElementNode(currentContext: ParsingContext): ParsingContext {
-    const context = { ...currentContext };
-
-    const node = context.node;
-    const parsedNode: VNode = VNodeFromTag(node.nodeName);
-    if (Format.tags.includes(context.node.nodeName)) {
-        // Format nodes (e.g. B, I, U) are parsed differently than regular
-        // elements since they are not represented by a proper VNode in our
-        // internal representation but by the format of its children.
-        // For the parsing, encountering a format node generates a new format
-        // context which inherits from the previous one.
-        const format = context.format.length ? context.format[0] : {};
-        context.format.unshift({
-            bold: format.bold || node.nodeName === 'B',
-            italic: format.italic || node.nodeName === 'I',
-            underline: format.underline || node.nodeName === 'U',
-        });
-    } else {
-        if (parsedNode instanceof CharNode) {
-            Object.assign(parsedNode.format, context.format[0]);
-        }
-        VDocumentMap.set(parsedNode, node);
-        context.parentVNode.append(parsedNode);
-    }
-    // A <br/> with no siblings is there only to make its parent visible.
-    // Consume it since it was just parsed as its parent element node.
-    // TODO: do this less naively to account for formatting space.
-    if (node.childNodes.length === 1 && node.childNodes[0].nodeName === 'BR') {
-        context.node = node.childNodes[0];
-        VDocumentMap.set(parsedNode, context.node);
-    }
-    // A trailing <br/> after another <br/> is there only to make its previous
-    // sibling visible. Consume it since it was just parsed as a single BR
-    // within our abstraction.
-    // TODO: do this less naively to account for formatting space.
-    if (
-        node.nodeName === 'BR' &&
-        node.nextSibling &&
-        node.nextSibling.nodeName === 'BR' &&
-        !node.nextSibling.nextSibling
-    ) {
-        context.node = node.nextSibling;
-        VDocumentMap.set(parsedNode, context.node);
-    }
-    return context;
-}
-/**
- * Parse the given text node into VNode(s).
- *
- * @param node to parse
- * @param [format] to apply to the parsed node (default: none)
- * @returns the parsed VNode(s)
- */
-function parseTextNode(currentContext: ParsingContext): ParsingContext {
-    const node = currentContext.node;
-    const parentVNode = currentContext.parentVNode;
-    const format = currentContext.format[0];
-    const text = removeFormatSpace(node);
-    for (let i = 0; i < text.length; i++) {
-        const char = text.charAt(i);
-        const parsedVNode = new CharNode(char, { ...format });
-        VDocumentMap.set(parsedVNode, node, i);
-        parentVNode.append(parsedVNode);
-    }
-    return currentContext;
-}
-
-function nextParsingContext(currentContext: ParsingContext): ParsingContext {
-    const nextContext = { ...currentContext };
-
-    const node = currentContext.node;
-    if (node.childNodes.length) {
-        // Parse the first child with the current node as parent, if any.
-        nextContext.node = node.childNodes[0];
-        // Text node cannot have children, therefore `node` is an Element, not
-        // a text node. Only text nodes can be represented by multiple VNodes,
-        // so the first matching VNode can safely be selected from the map.
-        // If `node` as no VNode representation  in the map (e.g. format nodes),
-        // its children are added into the current `parentVNode`.
-        const parsedParent = VDocumentMap.fromDom(node);
-        if (parsedParent) {
-            nextContext.parentVNode = parsedParent[0];
-        }
-    } else if (node.nextSibling) {
-        // Parse the siblings of the current node with the same parent, if any.
-        nextContext.node = node.nextSibling;
-    } else {
-        // Parse the next ancestor sibling in the ancestor tree, if any.
-        let ancestor = node;
-        // Climb back the ancestor tree to the first parent having a sibling.
-        const rootNode = currentContext.rootNode;
-        do {
-            ancestor = ancestor.parentNode;
-            if (ancestor && Format.tags.includes(ancestor.nodeName)) {
-                // Pop last formatting context from the stack
-                nextContext.format.shift();
-            }
-        } while (ancestor && !ancestor.nextSibling && ancestor !== rootNode);
-        // At this point, the found ancestor has a sibling.
-        if (ancestor && ancestor !== rootNode) {
-            // Text node cannot have children, therefore parent is an Element,
-            // not a text node. Only text nodes can be represented by multiple
-            // VNodes so the first VNode can safely be selected from the map.
-            nextContext.node = ancestor.nextSibling;
-            // Traverse the DOM tree to search for the first parent present in the VDocumentMap.
-            // We do so because, some parent are not included in the VDocumentMap
-            // (e.g.formatting nodes).
-            let elementFound;
-            let elementParent = ancestor;
-            do {
-                elementParent = elementParent.parentNode;
-                elementFound = VDocumentMap.fromDom(elementParent);
-            } while (elementParent && !elementFound);
-            nextContext.parentVNode = elementFound[0];
-        } else {
-            // If no ancestor having a sibling could be found then the tree has
-            // been fully parsed. There is no next parsing context. Stop it.
-            return;
-        }
-    }
-    return nextContext;
-}
-
-/**
- * Return true if the given node is immediately preceding (`side` === 'end')
- * or following (`side` === 'start') a segment break, to see if its edge
- * space must be removed.
- * A segment break is a sort of line break, not considering automatic breaks
- * that are function of the screen size. In this context, a segment is what
- * you see when you triple click in text in the browser.
- * Eg: `<div><p>◆one◆</p>◆two◆<br>◆three◆</div>` where ◆ = segment breaks.
- *
- * @param {Element} node
- * @param {'start'|'end'} side
- * @returns {boolean}
- */
-function _isAtSegmentBreak(node: Node, side: 'start' | 'end'): boolean {
-    const siblingSide = side === 'start' ? 'previousSibling' : 'nextSibling';
-    const sibling = node && node[siblingSide];
-    const isAgainstAnotherSegment = sibling && _isSegment(sibling);
-    const isAtEdgeOfOwnSegment = _isBlockEdge(node, side);
-    // In the DOM, a space before a BR is rendered but a space after a BR isn't.
-    const isBeforeBR = side === 'end' && sibling && sibling.nodeName === 'BR';
-    return (isAgainstAnotherSegment && !isBeforeBR) || isAtEdgeOfOwnSegment;
-}
-/**
- * Return true if the node is a segment according to W3 formatting model.
- *
- * @param node to check
- */
-function _isSegment(node: Node): boolean {
-    if (node.nodeType !== Node.ELEMENT_NODE) {
-        // Only proper elements can be a segment.
-        return false;
-    } else if (node.nodeName === 'BR') {
-        // Break (BR) tags end a segment.
-        return true;
-    } else {
-        // The W3 specification has many specific cases that defines what is
-        // or is not a segment. For the moment, we only handle display: block.
-        const temporaryElement = document.createElement(node.nodeName);
-        document.body.appendChild(temporaryElement);
-        const display = window.getComputedStyle(temporaryElement).display;
-        document.body.removeChild(temporaryElement);
-        return display.includes('block');
-    }
-}
-/**
- * Return true if the node is at the given edge of a block.
- *
- * @param node to check
- * @param side of the block to check ('start' or 'end')
- */
-function _isBlockEdge(node: Node | Node, side: 'start' | 'end'): boolean {
-    const ancestorsUpToBlock: Node[] = [];
-
-    // Move up to the first block ancestor
-    let ancestor = node;
-    while (ancestor && (_isTextNode(ancestor) || !_isSegment(ancestor))) {
-        ancestorsUpToBlock.push(ancestor);
-        ancestor = ancestor.parentElement;
-    }
-
-    // Return true if no ancestor up to the first block ancestor has a
-    // sibling on the specified side
-    const siblingSide = side === 'start' ? 'previousSibling' : 'nextSibling';
-    return ancestorsUpToBlock.every(ancestor => {
-        return !ancestor[siblingSide];
-    });
-}
-/**
- * Return true if the given node is a text node, false otherwise.
- *
- * @param node to check
- */
-function _isTextNode(node: Node): boolean {
-    return node.nodeType === Node.TEXT_NODE;
-}
-/**
- * Return a string with the value of a text node stripped of its formatting
- * space, applying the w3 rules for white space processing
- * TODO: decide what exactly to do with formatting spaces:
- * remove, keep, recompute?
- *
- * @see https://www.w3.org/TR/css-text-3/#white-space-processing
- * @returns {string}
- */
-function removeFormatSpace(node: Node): string {
-    // TODO: check the value of the `white-space` property
-    const text: string = node.textContent;
-    const spaceBeforeNewline = /([ \t])*(\n)/g;
-    const spaceAfterNewline = /(\n)([ \t])*/g;
-    const tabs = /\t/g;
-    const newlines = /\n/g;
-    const consecutiveSpace = /  */g;
-
-    // (Comments refer to the w3 link provided above.)
-    // Phase I: Collapsing and Transformation
-    let newText = text
-        // 1. All spaces and tabs immediately preceding or following a
-        //    segment break are removed.
-        .replace(spaceBeforeNewline, '$2')
-        .replace(spaceAfterNewline, '$1')
-        // 2. Segment breaks are transformed for rendering according to the
-        //    segment break transformation rules.
-        .replace(newlines, ' ')
-        // 3. Every tab is converted to a space (U+0020).
-        .replace(tabs, ' ')
-        // 4. Any space immediately following another collapsible space —
-        //    even one outside the boundary of the inline containing that
-        //    space, provided both spaces are within the same inline
-        //    formatting context—is collapsed to have zero advance width.
-        //    (It is invisible, but retains its soft wrap opportunity, if
-        //    any.)
-        .replace(consecutiveSpace, ' ');
-
-    // Phase II: Trimming and Positioning
-    // 1. A sequence of collapsible spaces at the beginning of a line
-    //    (ignoring any intervening inline box boundaries) is removed.
-    if (_isAtSegmentBreak(node, 'start')) {
-        const startSpace = /^ */g;
-        newText = newText.replace(startSpace, '');
-    }
-    // 2. If the tab size is zero, tabs are not rendered. Otherwise, each
-    //    tab is rendered as a horizontal shift that lines up the start edge
-    //    of the next glyph with the next tab stop. If this distance is less
-    //    than 0.5ch, then the subsequent tab stop is used instead. Tab
-    //    stops occur at points that are multiples of the tab size from the
-    //    block’s starting content edge. The tab size is given by the
-    //    tab-size property.
-    // TODO
-    // 3. A sequence at the end of a line (ignoring any intervening inline
-    //    box boundaries) of collapsible spaces (U+0020) and/or ideographic
-    //    spaces (U+3000) whose white-space value collapses spaces is
-    //    removed.
-    if (_isAtSegmentBreak(node, 'end')) {
-        const endSpace = /[ \u3000]*$/g;
-        newText = newText.replace(endSpace, '');
-    }
-    return newText;
-}
-/**
- * Return a position in the `VDocument` as a tuple containing a reference
- * node and a relative position with respect to this node ('BEFORE' or
- * 'AFTER'). The position is always given on the leaf.
- *
- * @param container
- * @param offset
- */
-function _locate(container: Node, offset: number): [VNode, RelativePosition] {
-    // When targetting the end of a node, the DOM gives an offset that is
-    // equal to the length of the container. In order to retrieve the last
-    // descendent, we need to make sure we target an existing node, ie. an
-    // existing index.
-    const isAfterEnd = offset >= utils.nodeLength(container);
-    let index = isAfterEnd ? utils.nodeLength(container) - 1 : offset;
-    // Move to deepest child of container.
-    while (container.hasChildNodes()) {
-        container = container.childNodes[index];
-        index = isAfterEnd ? utils.nodeLength(container) - 1 : 0;
-        // Adapt the offset to be its equivalent within the new container.
-        offset = isAfterEnd ? utils.nodeLength(container) : index;
-    }
-    // Get the VNodes matching the container.
-    const vNodes = VDocumentMap.fromDom(container);
-    if (vNodes && vNodes.length) {
-        let reference: VNode;
-        if (container.nodeType === Node.TEXT_NODE) {
-            // The reference is the index-th match (eg.: text split into chars).
-            reference = vNodes[index];
-        } else {
-            reference = vNodes[0];
-        }
-        return reference.locateRange(container, offset);
-    }
-}
-
-export const Parser = {
+export class Parser {
     /**
      * Parse an HTML element into the editor's virtual representation.
      *
      * @param node the HTML element to parse
      * @returns the element parsed into the editor's virtual representation
      */
-    parse: (node: Node): VDocument => {
+    parse(node: Node): VDocument {
         const root = new RootNode();
         VDocumentMap.set(root, node);
         const vDocument = new VDocument(root);
@@ -431,7 +41,7 @@ export const Parser = {
                 vDocument: vDocument,
             };
             do {
-                context = parseNode(context);
+                context = this.parseNode(context);
             } while (context);
         }
 
@@ -440,7 +50,7 @@ export const Parser = {
         const range = selection.rangeCount && selection.getRangeAt(0);
         if (range && node.contains(range.startContainer) && node.contains(range.endContainer)) {
             const forward = range.startContainer === selection.anchorNode;
-            const vRange = parseRange(range, forward ? Direction.FORWARD : Direction.BACKWARD);
+            const vRange = this.parseRange(range, forward ? Direction.FORWARD : Direction.BACKWARD);
             vDocument.range.set(vRange);
         }
 
@@ -450,13 +60,394 @@ export const Parser = {
         }
 
         return vDocument;
-    },
+    }
+    /**
+     * Parse a node depending on its DOM type.
+     *
+     * @param currentContext The current context
+     * @returns The next parsing context
+     */
+    parseNode(currentContext: ParsingContext): ParsingContext {
+        let context;
+        switch (currentContext.node.nodeType) {
+            case Node.ELEMENT_NODE: {
+                context = this.parseElementNode(currentContext);
+                break;
+            }
+            case Node.TEXT_NODE: {
+                context = this.parseTextNode(currentContext);
+                break;
+            }
+            case Node.DOCUMENT_NODE:
+            case Node.DOCUMENT_FRAGMENT_NODE: {
+                // These nodes have no effect in the context of parsing, but the
+                // parsing itself will continue with their children.
+                context = currentContext;
+                break;
+            }
+            case Node.CDATA_SECTION_NODE:
+            case Node.PROCESSING_INSTRUCTION_NODE:
+            case Node.COMMENT_NODE:
+            case Node.DOCUMENT_TYPE_NODE:
+            default: {
+                throw `Unsupported node type: ${currentContext.node.nodeType}.`;
+            }
+        }
+        return this.nextParsingContext(context);
+    }
     /**
      * Convert the DOM description of a range to the description of a VRange.
      *
      * @param range
      * @param [direction]
      */
-    parseRange: parseRange,
-    removeFormatSpace: removeFormatSpace,
-};
+    parseRange(range: DomRangeDescription): VRangeDescription;
+    parseRange(range: Range, direction: Direction): VRangeDescription;
+    parseRange(range: Range | DomRangeDescription, direction?: Direction): VRangeDescription {
+        const start = this._locate(range.startContainer, range.startOffset);
+        const end = this._locate(range.endContainer, range.endOffset);
+        if (start && end) {
+            const [startVNode, startPosition] = start;
+            const [endVNode, endPosition] = end;
+            return {
+                start: startVNode,
+                startPosition: startPosition,
+                end: endVNode,
+                endPosition: endPosition,
+                direction: range instanceof Range ? direction : range.direction,
+            };
+        }
+    }
+
+    /**
+     * Create and return a `VNode` corresponding to the given DOM tag.
+     *
+     * TODO: When introducing videos and other complex (atomic) nodes, this is going
+     * to be to naive and it will have to be replaced.
+     *
+     * @param node
+     */
+    VNodeFromTag(tag: string): VNode {
+        switch (tag) {
+            case 'P':
+                return new SimpleElementNode(VNodeType.PARAGRAPH);
+            case 'H1':
+                return new SimpleElementNode(VNodeType.HEADING1);
+            case 'H2':
+                return new SimpleElementNode(VNodeType.HEADING2);
+            case 'H3':
+                return new SimpleElementNode(VNodeType.HEADING3);
+            case 'H4':
+                return new SimpleElementNode(VNodeType.HEADING4);
+            case 'H5':
+                return new SimpleElementNode(VNodeType.HEADING5);
+            case 'H6':
+                return new SimpleElementNode(VNodeType.HEADING6);
+            case 'BR':
+                return new LineBreakNode();
+        }
+    }
+    /**
+     * Parse the given DOM Element into VNode(s).
+     *
+     * @param node to parse
+     * @param [format] to apply to the parsed node (default: none)
+     * @returns the parsed VNode(s)
+     */
+    parseElementNode(currentContext: ParsingContext): ParsingContext {
+        const context = { ...currentContext };
+
+        const node = context.node;
+        const parsedNode: VNode = this.VNodeFromTag(node.nodeName);
+        if (Format.tags.includes(context.node.nodeName)) {
+            // Format nodes (e.g. B, I, U) are parsed differently than regular
+            // elements since they are not represented by a proper VNode in our
+            // internal representation but by the format of its children.
+            // For the parsing, encountering a format node generates a new format
+            // context which inherits from the previous one.
+            const format = context.format.length ? context.format[0] : {};
+            context.format.unshift({
+                bold: format.bold || node.nodeName === 'B',
+                italic: format.italic || node.nodeName === 'I',
+                underline: format.underline || node.nodeName === 'U',
+            });
+        } else {
+            if (parsedNode instanceof CharNode) {
+                Object.assign(parsedNode.format, context.format[0]);
+            }
+            VDocumentMap.set(parsedNode, node);
+            context.parentVNode.append(parsedNode);
+        }
+        // A <br/> with no siblings is there only to make its parent visible.
+        // Consume it since it was just parsed as its parent element node.
+        // TODO: do this less naively to account for formatting space.
+        if (node.childNodes.length === 1 && node.childNodes[0].nodeName === 'BR') {
+            context.node = node.childNodes[0];
+            VDocumentMap.set(parsedNode, context.node);
+        }
+        // A trailing <br/> after another <br/> is there only to make its previous
+        // sibling visible. Consume it since it was just parsed as a single BR
+        // within our abstraction.
+        // TODO: do this less naively to account for formatting space.
+        if (
+            node.nodeName === 'BR' &&
+            node.nextSibling &&
+            node.nextSibling.nodeName === 'BR' &&
+            !node.nextSibling.nextSibling
+        ) {
+            context.node = node.nextSibling;
+            VDocumentMap.set(parsedNode, context.node);
+        }
+        return context;
+    }
+    /**
+     * Parse the given text node into VNode(s).
+     *
+     * @param node to parse
+     * @param [format] to apply to the parsed node (default: none)
+     * @returns the parsed VNode(s)
+     */
+    parseTextNode(currentContext: ParsingContext): ParsingContext {
+        const node = currentContext.node;
+        const parentVNode = currentContext.parentVNode;
+        const format = currentContext.format[0];
+        const text = Parser.removeFormatSpace(node);
+        for (let i = 0; i < text.length; i++) {
+            const char = text.charAt(i);
+            const parsedVNode = new CharNode(char, { ...format });
+            VDocumentMap.set(parsedVNode, node, i);
+            parentVNode.append(parsedVNode);
+        }
+        return currentContext;
+    }
+
+    nextParsingContext(currentContext: ParsingContext): ParsingContext {
+        const nextContext = { ...currentContext };
+
+        const node = currentContext.node;
+        if (node.childNodes.length) {
+            // Parse the first child with the current node as parent, if any.
+            nextContext.node = node.childNodes[0];
+            // Text node cannot have children, therefore `node` is an Element, not
+            // a text node. Only text nodes can be represented by multiple VNodes,
+            // so the first matching VNode can safely be selected from the map.
+            // If `node` as no VNode representation  in the map (e.g. format nodes),
+            // its children are added into the current `parentVNode`.
+            const parsedParent = VDocumentMap.fromDom(node);
+            if (parsedParent) {
+                nextContext.parentVNode = parsedParent[0];
+            }
+        } else if (node.nextSibling) {
+            // Parse the siblings of the current node with the same parent, if any.
+            nextContext.node = node.nextSibling;
+        } else {
+            // Parse the next ancestor sibling in the ancestor tree, if any.
+            let ancestor = node;
+            // Climb back the ancestor tree to the first parent having a sibling.
+            const rootNode = currentContext.rootNode;
+            do {
+                ancestor = ancestor.parentNode;
+                if (ancestor && Format.tags.includes(ancestor.nodeName)) {
+                    // Pop last formatting context from the stack
+                    nextContext.format.shift();
+                }
+            } while (ancestor && !ancestor.nextSibling && ancestor !== rootNode);
+            // At this point, the found ancestor has a sibling.
+            if (ancestor && ancestor !== rootNode) {
+                // Text node cannot have children, therefore parent is an Element,
+                // not a text node. Only text nodes can be represented by multiple
+                // VNodes so the first VNode can safely be selected from the map.
+                nextContext.node = ancestor.nextSibling;
+                // Traverse the DOM tree to search for the first parent present in the VDocumentMap.
+                // We do so because, some parent are not included in the VDocumentMap
+                // (e.g.formatting nodes).
+                let elementFound;
+                let elementParent = ancestor;
+                do {
+                    elementParent = elementParent.parentNode;
+                    elementFound = VDocumentMap.fromDom(elementParent);
+                } while (elementParent && !elementFound);
+                nextContext.parentVNode = elementFound[0];
+            } else {
+                // If no ancestor having a sibling could be found then the tree has
+                // been fully parsed. There is no next parsing context. Stop it.
+                return;
+            }
+        }
+        return nextContext;
+    }
+
+    /**
+     * Return true if the given node is immediately preceding (`side` === 'end')
+     * or following (`side` === 'start') a segment break, to see if its edge
+     * space must be removed.
+     * A segment break is a sort of line break, not considering automatic breaks
+     * that are function of the screen size. In this context, a segment is what
+     * you see when you triple click in text in the browser.
+     * Eg: `<div><p>◆one◆</p>◆two◆<br>◆three◆</div>` where ◆ = segment breaks.
+     *
+     * @param {Element} node
+     * @param {'start'|'end'} side
+     * @returns {boolean}
+     */
+    static _isAtSegmentBreak(node: Node, side: 'start' | 'end'): boolean {
+        const siblingSide = side === 'start' ? 'previousSibling' : 'nextSibling';
+        const sibling = node && node[siblingSide];
+        const isAgainstAnotherSegment = sibling && Parser._isSegment(sibling);
+        const isAtEdgeOfOwnSegment = Parser._isBlockEdge(node, side);
+        // In the DOM, a space before a BR is rendered but a space after a BR isn't.
+        const isBeforeBR = side === 'end' && sibling && sibling.nodeName === 'BR';
+        return (isAgainstAnotherSegment && !isBeforeBR) || isAtEdgeOfOwnSegment;
+    }
+    /**
+     * Return true if the node is a segment according to W3 formatting model.
+     *
+     * @param node to check
+     */
+    static _isSegment(node: Node): boolean {
+        if (node.nodeType !== Node.ELEMENT_NODE) {
+            // Only proper elements can be a segment.
+            return false;
+        } else if (node.nodeName === 'BR') {
+            // Break (BR) tags end a segment.
+            return true;
+        } else {
+            // The W3 specification has many specific cases that defines what is
+            // or is not a segment. For the moment, we only handle display: block.
+            const temporaryElement = document.createElement(node.nodeName);
+            document.body.appendChild(temporaryElement);
+            const display = window.getComputedStyle(temporaryElement).display;
+            document.body.removeChild(temporaryElement);
+            return display.includes('block');
+        }
+    }
+    /**
+     * Return true if the node is at the given edge of a block.
+     *
+     * @param node to check
+     * @param side of the block to check ('start' or 'end')
+     */
+    static _isBlockEdge(node: Node | Node, side: 'start' | 'end'): boolean {
+        const ancestorsUpToBlock: Node[] = [];
+
+        // Move up to the first block ancestor
+        let ancestor = node;
+        while (ancestor && (Parser._isTextNode(ancestor) || !Parser._isSegment(ancestor))) {
+            ancestorsUpToBlock.push(ancestor);
+            ancestor = ancestor.parentElement;
+        }
+
+        // Return true if no ancestor up to the first block ancestor has a
+        // sibling on the specified side
+        const siblingSide = side === 'start' ? 'previousSibling' : 'nextSibling';
+        return ancestorsUpToBlock.every(ancestor => {
+            return !ancestor[siblingSide];
+        });
+    }
+    /**
+     * Return true if the given node is a text node, false otherwise.
+     *
+     * @param node to check
+     */
+    static _isTextNode(node: Node): boolean {
+        return node.nodeType === Node.TEXT_NODE;
+    }
+    /**
+     * Return a string with the value of a text node stripped of its formatting
+     * space, applying the w3 rules for white space processing
+     * TODO: decide what exactly to do with formatting spaces:
+     * remove, keep, recompute?
+     *
+     * @see https://www.w3.org/TR/css-text-3/#white-space-processing
+     * @returns {string}
+     */
+    static removeFormatSpace(node: Node): string {
+        // TODO: check the value of the `white-space` property
+        const text: string = node.textContent;
+        const spaceBeforeNewline = /([ \t])*(\n)/g;
+        const spaceAfterNewline = /(\n)([ \t])*/g;
+        const tabs = /\t/g;
+        const newlines = /\n/g;
+        const consecutiveSpace = /  */g;
+
+        // (Comments refer to the w3 link provided above.)
+        // Phase I: Collapsing and Transformation
+        let newText = text
+            // 1. All spaces and tabs immediately preceding or following a
+            //    segment break are removed.
+            .replace(spaceBeforeNewline, '$2')
+            .replace(spaceAfterNewline, '$1')
+            // 2. Segment breaks are transformed for rendering according to the
+            //    segment break transformation rules.
+            .replace(newlines, ' ')
+            // 3. Every tab is converted to a space (U+0020).
+            .replace(tabs, ' ')
+            // 4. Any space immediately following another collapsible space —
+            //    even one outside the boundary of the inline containing that
+            //    space, provided both spaces are within the same inline
+            //    formatting context—is collapsed to have zero advance width.
+            //    (It is invisible, but retains its soft wrap opportunity, if
+            //    any.)
+            .replace(consecutiveSpace, ' ');
+
+        // Phase II: Trimming and Positioning
+        // 1. A sequence of collapsible spaces at the beginning of a line
+        //    (ignoring any intervening inline box boundaries) is removed.
+        if (Parser._isAtSegmentBreak(node, 'start')) {
+            const startSpace = /^ */g;
+            newText = newText.replace(startSpace, '');
+        }
+        // 2. If the tab size is zero, tabs are not rendered. Otherwise, each
+        //    tab is rendered as a horizontal shift that lines up the start edge
+        //    of the next glyph with the next tab stop. If this distance is less
+        //    than 0.5ch, then the subsequent tab stop is used instead. Tab
+        //    stops occur at points that are multiples of the tab size from the
+        //    block’s starting content edge. The tab size is given by the
+        //    tab-size property.
+        // TODO
+        // 3. A sequence at the end of a line (ignoring any intervening inline
+        //    box boundaries) of collapsible spaces (U+0020) and/or ideographic
+        //    spaces (U+3000) whose white-space value collapses spaces is
+        //    removed.
+        if (Parser._isAtSegmentBreak(node, 'end')) {
+            const endSpace = /[ \u3000]*$/g;
+            newText = newText.replace(endSpace, '');
+        }
+        return newText;
+    }
+    /**
+     * Return a position in the `VDocument` as a tuple containing a reference
+     * node and a relative position with respect to this node ('BEFORE' or
+     * 'AFTER'). The position is always given on the leaf.
+     *
+     * @param container
+     * @param offset
+     */
+    _locate(container: Node, offset: number): [VNode, RelativePosition] {
+        // When targetting the end of a node, the DOM gives an offset that is
+        // equal to the length of the container. In order to retrieve the last
+        // descendent, we need to make sure we target an existing node, ie. an
+        // existing index.
+        const isAfterEnd = offset >= utils.nodeLength(container);
+        let index = isAfterEnd ? utils.nodeLength(container) - 1 : offset;
+        // Move to deepest child of container.
+        while (container.hasChildNodes()) {
+            container = container.childNodes[index];
+            index = isAfterEnd ? utils.nodeLength(container) - 1 : 0;
+            // Adapt the offset to be its equivalent within the new container.
+            offset = isAfterEnd ? utils.nodeLength(container) : index;
+        }
+        // Get the VNodes matching the container.
+        const vNodes = VDocumentMap.fromDom(container);
+        if (vNodes && vNodes.length) {
+            let reference: VNode;
+            if (container.nodeType === Node.TEXT_NODE) {
+                // The reference is the index-th match (eg.: text split into chars).
+                reference = vNodes[index];
+            } else {
+                reference = vNodes[0];
+            }
+            return reference.locateRange(container, offset);
+        }
+    }
+}

--- a/packages/core/src/Parser.ts
+++ b/packages/core/src/Parser.ts
@@ -3,10 +3,10 @@ import { Format } from '../../utils/src/Format';
 import { VDocumentMap } from './VDocumentMap';
 import { VRangeDescription } from './VRange';
 import { Direction, RelativePosition } from '../../utils/src/range';
-import { VNode, FormatType, VNodeType } from './VNodes/VNode';
+import { VNode, VNodeType } from './VNodes/VNode';
 import { DomRangeDescription } from './EventNormalizer';
 import { utils } from '../../utils/src/utils';
-import { CharNode } from './VNodes/CharNode';
+import { CharNode, FormatType } from './VNodes/CharNode';
 import { SimpleElementNode } from './VNodes/SimpleElementNode';
 import { LineBreakNode } from './VNodes/LineBreakNode';
 import { RootNode } from './VNodes/RootNode';
@@ -88,19 +88,19 @@ function parseRange(range: Range | DomRangeDescription, direction?: Direction): 
 function VNodeFromTag(tag: string): VNode {
     switch (tag) {
         case 'P':
-            return new SimpleElementNode(VNodeType.PARAGRAPH, tag);
+            return new SimpleElementNode(VNodeType.PARAGRAPH);
         case 'H1':
-            return new SimpleElementNode(VNodeType.HEADING1, tag);
+            return new SimpleElementNode(VNodeType.HEADING1);
         case 'H2':
-            return new SimpleElementNode(VNodeType.HEADING2, tag);
+            return new SimpleElementNode(VNodeType.HEADING2);
         case 'H3':
-            return new SimpleElementNode(VNodeType.HEADING3, tag);
+            return new SimpleElementNode(VNodeType.HEADING3);
         case 'H4':
-            return new SimpleElementNode(VNodeType.HEADING4, tag);
+            return new SimpleElementNode(VNodeType.HEADING4);
         case 'H5':
-            return new SimpleElementNode(VNodeType.HEADING5, tag);
+            return new SimpleElementNode(VNodeType.HEADING5);
         case 'H6':
-            return new SimpleElementNode(VNodeType.HEADING6, tag);
+            return new SimpleElementNode(VNodeType.HEADING6);
         case 'BR':
             return new LineBreakNode();
     }
@@ -130,7 +130,9 @@ function parseElementNode(currentContext: ParsingContext): ParsingContext {
             underline: format.underline || node.nodeName === 'U',
         });
     } else {
-        Object.assign(parsedNode.format, context.format[0]);
+        if (parsedNode instanceof CharNode) {
+            Object.assign(parsedNode.format, context.format[0]);
+        }
         VDocumentMap.set(parsedNode, node);
         context.parentVNode.append(parsedNode);
     }

--- a/packages/core/src/Parser.ts
+++ b/packages/core/src/Parser.ts
@@ -3,13 +3,14 @@ import { Format } from '../../utils/src/Format';
 import { VDocumentMap } from './VDocumentMap';
 import { VRangeDescription } from './VRange';
 import { Direction, RelativePosition } from '../../utils/src/range';
-import { VNode, VNodeType } from './VNodes/VNode';
+import { VNode } from './VNodes/VNode';
 import { DomRangeDescription } from './EventNormalizer';
 import { utils } from '../../utils/src/utils';
-import { CharNode, FormatType } from './VNodes/CharNode';
 import { SimpleElementNode } from './VNodes/SimpleElementNode';
 import { LineBreakNode } from './VNodes/LineBreakNode';
 import { RootNode } from './VNodes/RootNode';
+import { RangeNode } from './VNodes/RangeNode';
+import { FormatType, CharNode } from './VNodes/CharNode';
 
 interface ParsingContext {
     readonly rootNode?: Node;
@@ -18,12 +19,49 @@ interface ParsingContext {
     format?: FormatType[];
     vDocument: VDocument;
 }
+export const defaultNodes = [CharNode, LineBreakNode, RangeNode, SimpleElementNode];
 
 export class Parser {
+    _customVNodes: Set<typeof VNode> = new Set();
+    constructor(replaceDefaultNodes?: Array<typeof VNode>) {
+        this.addCustomVNodes(replaceDefaultNodes || defaultNodes);
+    }
+
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
 
+    /**
+     * Add a custom VNode to the ones that this Parser can handle.
+     *
+     * @param VNodeClasses
+     */
+    addCustomVNode(VNodeClass: typeof VNode): void {
+        this._customVNodes.add(VNodeClass);
+    }
+    /**
+     * Add an array of custom VNodes to the ones that this Parser can handle.
+     *
+     * @param VNodeClasses
+     */
+    addCustomVNodes(VNodeClasses: Array<typeof VNode>): void {
+        VNodeClasses.forEach(VNodeClass => {
+            this._customVNodes.add(VNodeClass);
+        });
+    }
+    /**
+     * Return a (list of) vNode(s) matching the given node.
+     *
+     * @param node
+     */
+    parseNode(node: Node): VNode | Array<VNode> {
+        let vNode: VNode | Array<VNode> | null;
+        Array.from(this._customVNodes).some(customNode => {
+            vNode = customNode.parse(node);
+            return vNode !== null;
+        });
+        return vNode || new VNode(node.nodeName);
+    }
     /**
      * Parse an HTML element into the editor's virtual representation.
      *
@@ -64,69 +102,6 @@ export class Parser {
         }
 
         return vDocument;
-    }
-    /**
-     * Return a string with the value of a text node stripped of its formatting
-     * space, applying the w3 rules for white space processing
-     * TODO: decide what exactly to do with formatting spaces:
-     * remove, keep, recompute?
-     *
-     * @see https://www.w3.org/TR/css-text-3/#white-space-processing
-     * @returns {string}
-     */
-    static removeFormatSpace(node: Node): string {
-        // TODO: check the value of the `white-space` property
-        const text: string = node.textContent;
-        const spaceBeforeNewline = /([ \t])*(\n)/g;
-        const spaceAfterNewline = /(\n)([ \t])*/g;
-        const tabs = /\t/g;
-        const newlines = /\n/g;
-        const consecutiveSpace = /  */g;
-
-        // (Comments refer to the w3 link provided above.)
-        // Phase I: Collapsing and Transformation
-        let newText = text
-            // 1. All spaces and tabs immediately preceding or following a
-            //    segment break are removed.
-            .replace(spaceBeforeNewline, '$2')
-            .replace(spaceAfterNewline, '$1')
-            // 2. Segment breaks are transformed for rendering according to the
-            //    segment break transformation rules.
-            .replace(newlines, ' ')
-            // 3. Every tab is converted to a space (U+0020).
-            .replace(tabs, ' ')
-            // 4. Any space immediately following another collapsible space —
-            //    even one outside the boundary of the inline containing that
-            //    space, provided both spaces are within the same inline
-            //    formatting context—is collapsed to have zero advance width.
-            //    (It is invisible, but retains its soft wrap opportunity, if
-            //    any.)
-            .replace(consecutiveSpace, ' ');
-
-        // Phase II: Trimming and Positioning
-        // 1. A sequence of collapsible spaces at the beginning of a line
-        //    (ignoring any intervening inline box boundaries) is removed.
-        if (Parser._isAtSegmentBreak(node, 'start')) {
-            const startSpace = /^ */g;
-            newText = newText.replace(startSpace, '');
-        }
-        // 2. If the tab size is zero, tabs are not rendered. Otherwise, each
-        //    tab is rendered as a horizontal shift that lines up the start edge
-        //    of the next glyph with the next tab stop. If this distance is less
-        //    than 0.5ch, then the subsequent tab stop is used instead. Tab
-        //    stops occur at points that are multiples of the tab size from the
-        //    block’s starting content edge. The tab size is given by the
-        //    tab-size property.
-        // TODO
-        // 3. A sequence at the end of a line (ignoring any intervening inline
-        //    box boundaries) of collapsible spaces (U+0020) and/or ideographic
-        //    spaces (U+3000) whose white-space value collapses spaces is
-        //    removed.
-        if (Parser._isAtSegmentBreak(node, 'end')) {
-            const endSpace = /[ \u3000]*$/g;
-            newText = newText.replace(endSpace, '');
-        }
-        return newText;
     }
     /**
      * Convert the DOM description of a range to the description of a VRange.
@@ -191,34 +166,6 @@ export class Parser {
         return this._nextParsingContext(context);
     }
     /**
-     * Create and return a `VNode` corresponding to the given DOM tag.
-     *
-     * TODO: When introducing videos and other complex (atomic) nodes, this is going
-     * to be to naive and it will have to be replaced.
-     *
-     * @param node
-     */
-    _VNodeFromTag(tag: string): VNode {
-        switch (tag) {
-            case 'P':
-                return new SimpleElementNode(VNodeType.PARAGRAPH);
-            case 'H1':
-                return new SimpleElementNode(VNodeType.HEADING1);
-            case 'H2':
-                return new SimpleElementNode(VNodeType.HEADING2);
-            case 'H3':
-                return new SimpleElementNode(VNodeType.HEADING3);
-            case 'H4':
-                return new SimpleElementNode(VNodeType.HEADING4);
-            case 'H5':
-                return new SimpleElementNode(VNodeType.HEADING5);
-            case 'H6':
-                return new SimpleElementNode(VNodeType.HEADING6);
-            case 'BR':
-                return new LineBreakNode();
-        }
-    }
-    /**
      * Parse the given DOM Element into VNode(s).
      *
      * @param node to parse
@@ -229,7 +176,7 @@ export class Parser {
         const context = { ...currentContext };
 
         const node = context.node;
-        const parsedNode: VNode = this._VNodeFromTag(node.nodeName);
+        const parsedNode = this.parseNode(node) as VNode;
         if (Format.tags.includes(context.node.nodeName)) {
             // Format nodes (e.g. B, I, U) are parsed differently than regular
             // elements since they are not represented by a proper VNode in our
@@ -282,13 +229,12 @@ export class Parser {
         const node = currentContext.node;
         const parentVNode = currentContext.parentVNode;
         const format = currentContext.format[0];
-        const text = Parser.removeFormatSpace(node);
-        for (let i = 0; i < text.length; i++) {
-            const char = text.charAt(i);
-            const parsedVNode = new CharNode(char, { ...format });
-            VDocumentMap.set(parsedVNode, node, i);
+        const parsedVNodes = this.parseNode(node) as CharNode[];
+        parsedVNodes.forEach((parsedVNode: CharNode, index: number) => {
+            parsedVNode.format = { ...format };
+            VDocumentMap.set(parsedVNode, node, index);
             parentVNode.append(parsedVNode);
-        }
+        });
         return currentContext;
     }
     _nextParsingContext(currentContext: ParsingContext): ParsingContext {
@@ -380,80 +326,5 @@ export class Parser {
             }
             return reference.locateRange(container, offset);
         }
-    }
-    /**
-     * Return true if the given node is immediately preceding (`side` === 'end')
-     * or following (`side` === 'start') a segment break, to see if its edge
-     * space must be removed.
-     * A segment break is a sort of line break, not considering automatic breaks
-     * that are function of the screen size. In this context, a segment is what
-     * you see when you triple click in text in the browser.
-     * Eg: `<div><p>◆one◆</p>◆two◆<br>◆three◆</div>` where ◆ = segment breaks.
-     *
-     * @param {Element} node
-     * @param {'start'|'end'} side
-     * @returns {boolean}
-     */
-    static _isAtSegmentBreak(node: Node, side: 'start' | 'end'): boolean {
-        const siblingSide = side === 'start' ? 'previousSibling' : 'nextSibling';
-        const sibling = node && node[siblingSide];
-        const isAgainstAnotherSegment = sibling && Parser._isSegment(sibling);
-        const isAtEdgeOfOwnSegment = Parser._isBlockEdge(node, side);
-        // In the DOM, a space before a BR is rendered but a space after a BR isn't.
-        const isBeforeBR = side === 'end' && sibling && sibling.nodeName === 'BR';
-        return (isAgainstAnotherSegment && !isBeforeBR) || isAtEdgeOfOwnSegment;
-    }
-    /**
-     * Return true if the node is a segment according to W3 formatting model.
-     *
-     * @param node to check
-     */
-    static _isSegment(node: Node): boolean {
-        if (node.nodeType !== Node.ELEMENT_NODE) {
-            // Only proper elements can be a segment.
-            return false;
-        } else if (node.nodeName === 'BR') {
-            // Break (BR) tags end a segment.
-            return true;
-        } else {
-            // The W3 specification has many specific cases that defines what is
-            // or is not a segment. For the moment, we only handle display: block.
-            const temporaryElement = document.createElement(node.nodeName);
-            document.body.appendChild(temporaryElement);
-            const display = window.getComputedStyle(temporaryElement).display;
-            document.body.removeChild(temporaryElement);
-            return display.includes('block');
-        }
-    }
-    /**
-     * Return true if the node is at the given edge of a block.
-     *
-     * @param node to check
-     * @param side of the block to check ('start' or 'end')
-     */
-    static _isBlockEdge(node: Node | Node, side: 'start' | 'end'): boolean {
-        const ancestorsUpToBlock: Node[] = [];
-
-        // Move up to the first block ancestor
-        let ancestor = node;
-        while (ancestor && (Parser._isTextNode(ancestor) || !Parser._isSegment(ancestor))) {
-            ancestorsUpToBlock.push(ancestor);
-            ancestor = ancestor.parentElement;
-        }
-
-        // Return true if no ancestor up to the first block ancestor has a
-        // sibling on the specified side
-        const siblingSide = side === 'start' ? 'previousSibling' : 'nextSibling';
-        return ancestorsUpToBlock.every(ancestor => {
-            return !ancestor[siblingSide];
-        });
-    }
-    /**
-     * Return true if the given node is a text node, false otherwise.
-     *
-     * @param node to check
-     */
-    static _isTextNode(node: Node): boolean {
-        return node.nodeType === Node.TEXT_NODE;
     }
 }

--- a/packages/core/src/Parser.ts
+++ b/packages/core/src/Parser.ts
@@ -1,7 +1,8 @@
 import { VDocument } from './VDocument';
 import { Format } from '../../utils/src/Format';
 import { VDocumentMap } from './VDocumentMap';
-import { RelativePosition, VRangeDescription, Direction } from './VRange';
+import { VRangeDescription } from './VRange';
+import { Direction, RelativePosition } from '../../utils/src/range';
 import { VNode, FormatType, VNodeType } from './VNode';
 import { DomRangeDescription } from './EventNormalizer';
 import { utils } from '../../utils/src/utils';

--- a/packages/core/src/Range.ts
+++ b/packages/core/src/Range.ts
@@ -1,8 +1,0 @@
-type Direction = 'ltr' | 'rtl';
-export interface Range {
-    startContainer: Node;
-    startOffset: number;
-    endContainer: Node;
-    endOffset: number;
-    direction: Direction;
-}

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -3,7 +3,8 @@ import { VDocument } from './VDocument';
 import { isRange, isChar } from '../../utils/src/Predicates';
 import { VNode } from './VNode';
 import { Format } from '../../utils/src/Format';
-import { VRange, RelativePosition } from './VRange';
+import { VRange } from './VRange';
+import { RelativePosition } from '../../utils/src/range';
 
 interface RenderingContext {
     currentVNode?: VNode; // Current VNode rendered at this step.

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -66,8 +66,8 @@ export class Renderer {
             return false;
         } else {
             // Char VNodes are the same text node if they have the same format.
-            const formats = Object.keys({ ...a.format, ...b.format });
-            return formats.every(k => !!a.format[k] === !!b.format[k]);
+            const formats = Object.keys({ ...(a as CharNode).format, ...(b as CharNode).format });
+            return formats.every(k => !!(a as CharNode).format[k] === !!(b as CharNode).format[k]);
         }
     }
     /**

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -1,7 +1,7 @@
 import { VDocumentMap } from './VDocumentMap';
 import { VDocument } from './VDocument';
 import { isRange, isChar } from '../../utils/src/Predicates';
-import { VNode } from './VNode';
+import { VNode } from './VNodes/VNode';
 import { Format } from '../../utils/src/Format';
 import { VRange } from './VRange';
 import { RelativePosition } from '../../utils/src/range';

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -4,6 +4,7 @@ import { isRange, isChar } from '../../utils/src/Predicates';
 import { VNode } from './VNodes/VNode';
 import { Format } from '../../utils/src/Format';
 import { VRange } from './VRange';
+import { CharNode } from './VNodes/CharNode';
 import { RelativePosition } from '../../utils/src/range';
 
 interface RenderingContext {
@@ -127,7 +128,7 @@ export class Renderer {
     _renderTextNode(context: RenderingContext): RenderingContext {
         // If the node has a format, render the format nodes first.
         const renderedFormats = [];
-        const firstChar = context.currentVNode;
+        const firstChar = context.currentVNode as CharNode;
         Object.keys(firstChar.format).forEach(type => {
             if (firstChar.format[type]) {
                 const formatNode = document.createElement(Format.toTag(type));
@@ -139,18 +140,18 @@ export class Renderer {
         });
 
         // Consecutive compatible char nodes are rendered as a single text node.
-        let text = firstChar.value;
+        let text = '' + firstChar.char;
         let next = firstChar.nextSibling();
         const charNodes = [firstChar];
         while (next && this._isSameTextNode(firstChar, next)) {
             context.currentVNode = next;
-            if (isChar(next)) {
+            if (next instanceof CharNode) {
                 charNodes.push(next);
-                if (next.value === ' ' && text[text.length - 1] === ' ') {
+                if (next.char === ' ' && text[text.length - 1] === ' ') {
                     // Browsers don't render consecutive space chars otherwise.
                     text += '\u00A0';
                 } else {
-                    text += next.value;
+                    text += next.char;
                 }
             }
             next = next.nextSibling();

--- a/packages/core/src/VDocument.ts
+++ b/packages/core/src/VDocument.ts
@@ -1,8 +1,7 @@
 import { VNode, VNodeType, FormatType, FORMAT_TYPES } from './VNode';
 import { VRange } from './VRange';
 import { isChar } from '../../utils/src/Predicates';
-
-export let withRange = false;
+import { utils } from '../../utils/src/utils';
 
 export class VDocument {
     root: VNode;
@@ -97,7 +96,7 @@ export class VDocument {
      * orphaned children into the parent of the first removed node.
      */
     deleteSelection(): void {
-        VDocument.withRange(() => {
+        utils.withRange(() => {
             const nodes = this.range.selectedNodes;
             if (!nodes.length) return;
             this.range.collapse(this.range.start); // Reset the direction of the range.
@@ -124,20 +123,6 @@ export class VDocument {
     //--------------------------------------------------------------------------
     // Context
     //--------------------------------------------------------------------------
-
-    /**
-     * Call a callback on this VNode without ignoring the range nodes.
-     *
-     * @param callback
-     */
-    static withRange<T>(callback: () => T): T {
-        // Record the previous value to allow for nested calls to `withRange`.
-        const previousValue = withRange;
-        withRange = true;
-        const result = callback();
-        withRange = previousValue;
-        return result;
-    }
 
     /**
      * Apply the `format` to the range.

--- a/packages/core/src/VDocument.ts
+++ b/packages/core/src/VDocument.ts
@@ -1,6 +1,6 @@
-import { VNode, FormatType, FORMAT_TYPES } from './VNodes/VNode';
+import { VNode } from './VNodes/VNode';
 import { VRange } from './VRange';
-import { CharNode } from './VNodes/CharNode';
+import { CharNode, FormatType, FORMAT_TYPES } from './VNodes/CharNode';
 import { isChar } from '../../utils/src/Predicates';
 import { utils } from '../../utils/src/utils';
 import { RootNode } from './VNodes/RootNode';
@@ -79,13 +79,13 @@ export class VDocument {
         if (this.formatCache) {
             return this.formatCache;
         } else if (this.range.isCollapsed()) {
-            const charToCopyFormat = this.range.start.previousSibling(isChar) ||
+            const charToCopyFormat = (this.range.start.previousSibling(isChar) ||
                 this.range.start.nextSibling(isChar) || {
                     format: {},
-                };
+                }) as CharNode;
             format = { ...charToCopyFormat.format };
         } else {
-            const selectedChars = this.range.selectedNodes.filter(isChar);
+            const selectedChars = this.range.selectedNodes.filter(isChar) as CharNode[];
             FORMAT_TYPES.forEach(formatName => {
                 format[formatName] = selectedChars.some(char => char.format[formatName]);
             });
@@ -139,7 +139,7 @@ export class VDocument {
             }
             this.formatCache[formatName] = !this.formatCache[formatName];
         } else {
-            const selectedChars = this.range.selectedNodes.filter(isChar);
+            const selectedChars = this.range.selectedNodes.filter(isChar) as CharNode[];
 
             // If there is no char with the format `formatName` in the range, set the format to true
             // for all nodes.

--- a/packages/core/src/VDocument.ts
+++ b/packages/core/src/VDocument.ts
@@ -1,9 +1,10 @@
-import { VNode } from './VNodes/VNode';
+import { VNode, VNodeType } from './VNodes/VNode';
 import { VRange } from './VRange';
 import { CharNode, FormatType, FORMAT_TYPES } from './VNodes/CharNode';
 import { isChar } from '../../utils/src/Predicates';
 import { utils } from '../../utils/src/utils';
 import { RootNode } from './VNodes/RootNode';
+import { SimpleElementNode } from './VNodes/SimpleElementNode';
 
 export class VDocument {
     root: VNode;
@@ -112,7 +113,14 @@ export class VDocument {
                 // TODO: test whether the node can be merged with the container.
                 if (vNode.hasChildren()) {
                     vNode.children.slice().forEach(child => {
-                        reference.after(child);
+                        if (isChar(child) && reference.parent.type === 'root') {
+                            // A CharNode cannot be the direct child of the root.
+                            const paragraph = new SimpleElementNode(VNodeType.PARAGRAPH);
+                            reference.after(paragraph);
+                            paragraph.append(child);
+                        } else {
+                            reference.after(child);
+                        }
                         reference = child;
                     });
                 }

--- a/packages/core/src/VDocument.ts
+++ b/packages/core/src/VDocument.ts
@@ -1,5 +1,6 @@
-import { VNode, VNodeType, FormatType, FORMAT_TYPES } from './VNodes/VNode';
+import { VNode, FormatType, FORMAT_TYPES } from './VNodes/VNode';
 import { VRange } from './VRange';
+import { CharNode } from './VNodes/CharNode';
 import { isChar } from '../../utils/src/Predicates';
 import { utils } from '../../utils/src/utils';
 import { RootNode } from './VNodes/RootNode';
@@ -64,7 +65,7 @@ export class VDocument {
         // Split the text into CHAR nodes and insert them at the range.
         const characters = text.split('');
         characters.forEach(char => {
-            const vNode = new VNode(VNodeType.CHAR, '#text', char, format);
+            const vNode = new CharNode(char, format);
             this.range.start.before(vNode);
         });
         this.formatCache = null;

--- a/packages/core/src/VDocument.ts
+++ b/packages/core/src/VDocument.ts
@@ -1,7 +1,8 @@
-import { VNode, VNodeType, FormatType, FORMAT_TYPES } from './VNode';
+import { VNode, VNodeType, FormatType, FORMAT_TYPES } from './VNodes/VNode';
 import { VRange } from './VRange';
 import { isChar } from '../../utils/src/Predicates';
 import { utils } from '../../utils/src/utils';
+import { RootNode } from './VNodes/RootNode';
 
 export class VDocument {
     root: VNode;
@@ -13,7 +14,7 @@ export class VDocument {
      */
     formatCache: FormatType = null;
 
-    constructor(root: VNode) {
+    constructor(root: RootNode) {
         this.root = root;
     }
 

--- a/packages/core/src/VDocument.ts
+++ b/packages/core/src/VDocument.ts
@@ -153,13 +153,13 @@ export class VDocument {
             // for all nodes.
             if (!selectedChars.every(char => char.format[formatName])) {
                 selectedChars.forEach(char => {
-                    char.format[formatName] = true;
+                    char[formatName] = true;
                 });
                 // If there is at least one char in with the format `fomatName` in the range, set the
                 // format to false for all nodes.
             } else {
                 selectedChars.forEach(char => {
-                    char.format[formatName] = false;
+                    char[formatName] = false;
                 });
             }
         }

--- a/packages/core/src/VDocumentMap.ts
+++ b/packages/core/src/VDocumentMap.ts
@@ -1,5 +1,5 @@
 import { Format } from '../../utils/src/Format';
-import { VNode } from './VNode';
+import { VNode } from './VNodes/VNode';
 
 const fromDom = new Map<Node, VNode[]>();
 const toDom = new Map<VNode, [Node, number]>();

--- a/packages/core/src/VNode.ts
+++ b/packages/core/src/VNode.ts
@@ -1,8 +1,7 @@
 import { BasicHtmlRenderingEngine, RenderingEngine } from './BasicHtmlRenderingEngine';
-import { withRange, VDocument } from './VDocument';
 import { Predicate, isRange, isLeaf, not } from './../../utils/src/Predicates';
-import { RelativePosition } from './VRange';
-import { utils } from './../../utils/src/utils';
+import { RelativePosition } from '../../utils/src/range';
+import { utils, isWithRange } from './../../utils/src/utils';
 
 export enum VNodeType {
     ROOT = 'ROOT',
@@ -126,7 +125,7 @@ export class VNode {
      * Return the VNode's children.
      */
     get children(): VNode[] {
-        if (withRange) {
+        if (isWithRange) {
             return this._children;
         }
         return this._children.filter(not(isRange));
@@ -240,9 +239,9 @@ export class VNode {
      * @param child
      */
     childBefore(child: VNode): VNode {
-        const childBefore = VDocument.withRange(() => this.nthChild(this.indexOf(child) - 1));
+        const childBefore = utils.withRange(() => this.nthChild(this.indexOf(child) - 1));
         // Ignore range nodes by default.
-        if (!withRange && childBefore && isRange(childBefore)) {
+        if (!isWithRange && childBefore && isRange(childBefore)) {
             return this.childBefore(childBefore);
         } else {
             return childBefore;
@@ -254,9 +253,9 @@ export class VNode {
      * @param child
      */
     childAfter(child: VNode): VNode {
-        const childAfter = VDocument.withRange(() => this.nthChild(this.indexOf(child) + 1));
+        const childAfter = utils.withRange(() => this.nthChild(this.indexOf(child) + 1));
         // Ignore range nodes by default.
-        if (!withRange && childAfter && isRange(childAfter)) {
+        if (!isWithRange && childAfter && isRange(childAfter)) {
             return this.childAfter(childAfter);
         } else {
             return childAfter;
@@ -605,7 +604,7 @@ export class VNode {
      * @param reference
      */
     insertBefore(node: VNode, reference: VNode): VNode {
-        return VDocument.withRange(() => {
+        return utils.withRange(() => {
             const index = this.indexOf(reference);
             if (index < 0) {
                 throw new Error('The given VNode is not a child of this VNode');
@@ -621,7 +620,7 @@ export class VNode {
      * @param reference
      */
     insertAfter(node: VNode, reference: VNode): VNode {
-        return VDocument.withRange(() => {
+        return utils.withRange(() => {
             const index = this.indexOf(reference);
             if (index < 0) {
                 throw new Error('The given VNode is not a child of this VNode');
@@ -641,7 +640,7 @@ export class VNode {
      * @param child
      */
     removeChild(child: VNode): VNode {
-        return VDocument.withRange(() => {
+        return utils.withRange(() => {
             const index = this.indexOf(child);
             if (index < 0) {
                 throw new Error('The given VNode is not a child of this VNode');
@@ -658,7 +657,7 @@ export class VNode {
      */
     splitAt(child: VNode): VNode {
         const nodesToMove = [child];
-        nodesToMove.push(...VDocument.withRange(() => child.nextSiblings()));
+        nodesToMove.push(...utils.withRange(() => child.nextSiblings()));
         const duplicate = new VNode(this.type, this.originalTag, this.value, this.format);
         this.after(duplicate);
         nodesToMove.forEach(sibling => duplicate.append(sibling));
@@ -679,7 +678,7 @@ export class VNode {
      */
     _insertAtIndex(child: VNode, index: number): VNode {
         if (child.parent) {
-            const currentIndex = VDocument.withRange(() => child.parent.indexOf(child));
+            const currentIndex = utils.withRange(() => child.parent.indexOf(child));
             if (index && child.parent === this && currentIndex < index) {
                 index--;
             }

--- a/packages/core/src/VNodes/CharNode.ts
+++ b/packages/core/src/VNodes/CharNode.ts
@@ -1,4 +1,5 @@
 import { VNode, VNodeType } from './VNode';
+import { utils } from '../../../utils/src/utils';
 
 /**
  * This "phantom type" is there to ensure that the type `Char` is only generated
@@ -44,6 +45,18 @@ export class CharNode extends VNode {
     // Lifecycle
     //--------------------------------------------------------------------------
 
+    static parse(node: Node): VNode | VNode[] | null {
+        if (node.nodeType === Node.TEXT_NODE) {
+            const vNodes: VNode[] = [];
+            const text = utils.removeFormatSpace(node);
+            for (let i = 0; i < text.length; i++) {
+                const parsedVNode = new CharNode(text.charAt(i));
+                vNodes.push(parsedVNode);
+            }
+            return vNodes;
+        }
+        return null;
+    }
     /**
      * Return a new VNode with the same type and attributes as this VNode.
      *

--- a/packages/core/src/VNodes/CharNode.ts
+++ b/packages/core/src/VNodes/CharNode.ts
@@ -29,16 +29,17 @@ export const FORMAT_TYPES = ['bold', 'italic', 'underline'];
 
 export class CharNode extends VNode {
     char: Char;
-    format: FormatType = {
-        bold: false,
-        italic: false,
-        underline: false,
-    };
+    // Format
+    bold = false;
+    italic = false;
+    underline = false;
     constructor(char: string, format: FormatType = {}) {
         super(VNodeType.CHAR);
         this.char = makeChar(char);
         this.name = char;
-        this.format = format;
+        this.bold = !!format.bold;
+        this.italic = !!format.italic;
+        this.underline = !!format.underline;
     }
 
     //--------------------------------------------------------------------------
@@ -70,6 +71,18 @@ export class CharNode extends VNode {
     // Public
     //--------------------------------------------------------------------------
 
+    get format(): FormatType {
+        return {
+            bold: this.bold,
+            italic: this.italic,
+            underline: this.underline,
+        };
+    }
+    set format(format: FormatType) {
+        this.bold = !!format.bold;
+        this.italic = !!format.italic;
+        this.underline = !!format.underline;
+    }
     /**
      * Return true if the VNode is atomic (ie. it may not have children).
      *

--- a/packages/core/src/VNodes/CharNode.ts
+++ b/packages/core/src/VNodes/CharNode.ts
@@ -1,0 +1,10 @@
+import { VNode, VNodeType, FormatType } from './VNode';
+
+export class CharNode extends VNode {
+    properties = {
+        atomic: true,
+    };
+    constructor(char: string, format: FormatType) {
+        super(VNodeType.CHAR, '#text', char, format);
+    }
+}

--- a/packages/core/src/VNodes/CharNode.ts
+++ b/packages/core/src/VNodes/CharNode.ts
@@ -21,9 +21,6 @@ export function makeChar(char: string): Char {
 }
 
 export class CharNode extends VNode {
-    properties = {
-        atomic: true,
-    };
     char: Char;
     constructor(char: string, format?: FormatType) {
         super(VNodeType.CHAR, '#text', format);
@@ -48,6 +45,14 @@ export class CharNode extends VNode {
     // Public
     //--------------------------------------------------------------------------
 
+    /**
+     * Return true if the VNode is atomic (ie. it may not have children).
+     *
+     * @override
+     */
+    get atomic(): boolean {
+        return true;
+    }
     /**
      * Return the length of this VNode.
      */

--- a/packages/core/src/VNodes/CharNode.ts
+++ b/packages/core/src/VNodes/CharNode.ts
@@ -1,4 +1,4 @@
-import { VNode, VNodeType, FormatType } from './VNode';
+import { VNode, VNodeType } from './VNode';
 
 /**
  * This "phantom type" is there to ensure that the type `Char` is only generated
@@ -19,13 +19,25 @@ export function makeChar(char: string): Char {
         throw new Error('Cannot make a Char out of anything else than a string of length 1.');
     }
 }
+export interface FormatType {
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+}
+export const FORMAT_TYPES = ['bold', 'italic', 'underline'];
 
 export class CharNode extends VNode {
     char: Char;
-    constructor(char: string, format?: FormatType) {
-        super(VNodeType.CHAR, '#text', format);
+    format: FormatType = {
+        bold: false,
+        italic: false,
+        underline: false,
+    };
+    constructor(char: string, format: FormatType = {}) {
+        super(VNodeType.CHAR);
         this.char = makeChar(char);
         this.name = char;
+        this.format = format;
     }
 
     //--------------------------------------------------------------------------

--- a/packages/core/src/VNodes/CharNode.ts
+++ b/packages/core/src/VNodes/CharNode.ts
@@ -1,10 +1,67 @@
 import { VNode, VNodeType, FormatType } from './VNode';
 
+/**
+ * This "phantom type" is there to ensure that the type `Char` is only generated
+ * through the use of the function `makeChar`, so as to force going through the
+ * length check.
+ */
+type InternalChar<T> = { valid: true } & string;
+export type Char = InternalChar<{}>;
+/**
+ * Return a Char type from a string of length 1 (validating the type).
+ *
+ * @param char
+ */
+export function makeChar(char: string): Char {
+    if (char.length === 1) {
+        return char as Char;
+    } else {
+        throw new Error('Cannot make a Char out of anything else than a string of length 1.');
+    }
+}
+
 export class CharNode extends VNode {
     properties = {
         atomic: true,
     };
-    constructor(char: string, format: FormatType) {
-        super(VNodeType.CHAR, '#text', char, format);
+    char: Char;
+    constructor(char: string, format?: FormatType) {
+        super(VNodeType.CHAR, '#text', format);
+        this.char = makeChar(char);
+        this.name = char;
+    }
+
+    //--------------------------------------------------------------------------
+    // Lifecycle
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return a new VNode with the same type and attributes as this VNode.
+     *
+     * @override
+     */
+    shallowDuplicate(): CharNode {
+        return new CharNode(this.char, this.format);
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return the length of this VNode.
+     */
+    get length(): number {
+        return 1;
+    }
+    /**
+     * Return this VNode's inner text (concatenation of all descendent
+     * char nodes values).
+     *
+     * @param __current
+     */
+    text(__current = ''): string {
+        __current += this.char;
+        return __current;
     }
 }

--- a/packages/core/src/VNodes/LineBreakNode.ts
+++ b/packages/core/src/VNodes/LineBreakNode.ts
@@ -2,10 +2,6 @@ import { VNode, VNodeType } from './VNode';
 import { RelativePosition } from '../../../utils/src/range';
 
 export class LineBreakNode extends VNode {
-    properties = {
-        atomic: true,
-    };
-
     constructor() {
         super(VNodeType.LINE_BREAK, 'BR');
     }
@@ -28,6 +24,19 @@ export class LineBreakNode extends VNode {
             t.appendChild(document.createElement('br'));
         }
         return t;
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return true if the VNode is atomic (ie. it may not have children).
+     *
+     * @override
+     */
+    get atomic(): boolean {
+        return true;
     }
     /**
      * Return a new VNode with the same type and attributes as this VNode.

--- a/packages/core/src/VNodes/LineBreakNode.ts
+++ b/packages/core/src/VNodes/LineBreakNode.ts
@@ -1,0 +1,10 @@
+import { VNode, VNodeType } from './VNode';
+
+export class LineBreakNode extends VNode {
+    properties = {
+        atomic: true,
+    };
+    constructor() {
+        super(VNodeType.LINE_BREAK, 'BR');
+    }
+}

--- a/packages/core/src/VNodes/LineBreakNode.ts
+++ b/packages/core/src/VNodes/LineBreakNode.ts
@@ -2,6 +2,7 @@ import { VNode, VNodeType } from './VNode';
 import { RelativePosition } from '../../../utils/src/range';
 
 export class LineBreakNode extends VNode {
+    htmlTag = 'BR';
     constructor() {
         super(VNodeType.LINE_BREAK);
     }
@@ -10,6 +11,12 @@ export class LineBreakNode extends VNode {
     // Lifecycle
     //--------------------------------------------------------------------------
 
+    static parse(node: Node): LineBreakNode {
+        if (node.nodeName === 'BR') {
+            return new LineBreakNode();
+        }
+        return null;
+    }
     /**
      * Render the VNode to the given format.
      *
@@ -46,6 +53,11 @@ export class LineBreakNode extends VNode {
     shallowDuplicate(): LineBreakNode {
         return new LineBreakNode();
     }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
     /**
      * Locate where to set the range, when it targets this VNode, at a certain
      * offset. This allows us to handle special cases.

--- a/packages/core/src/VNodes/LineBreakNode.ts
+++ b/packages/core/src/VNodes/LineBreakNode.ts
@@ -1,10 +1,57 @@
 import { VNode, VNodeType } from './VNode';
+import { RelativePosition } from '../../../utils/src/range';
 
 export class LineBreakNode extends VNode {
     properties = {
         atomic: true,
     };
+
     constructor() {
         super(VNodeType.LINE_BREAK, 'BR');
+    }
+
+    //--------------------------------------------------------------------------
+    // Lifecycle
+    //--------------------------------------------------------------------------
+
+    /**
+     * Render the VNode to the given format.
+     *
+     * @param [to] the name of the format to which we want to render (default:
+     * html)
+     */
+    render<T>(to = 'html'): T {
+        const t = this.renderingEngines[to].render(this) as T;
+        if (to === 'html' && !this.nextSibling() && t instanceof DocumentFragment) {
+            // If a LINE_BREAK has no next sibling, it must be rendered as two
+            // BRs in order for it to be visible.
+            t.appendChild(document.createElement('br'));
+        }
+        return t;
+    }
+    /**
+     * Return a new VNode with the same type and attributes as this VNode.
+     *
+     *  @override
+     */
+    shallowDuplicate(): LineBreakNode {
+        return new LineBreakNode();
+    }
+    /**
+     * Locate where to set the range, when it targets this VNode, at a certain
+     * offset. This allows us to handle special cases.
+     *
+     * @param domNode
+     * @param offset
+     */
+    locateRange(domNode: Node, offset: number): [VNode, RelativePosition] {
+        const rangeLocation = super.locateRange(domNode, offset);
+        // When clicking on a trailing line break, we need to target after the
+        // line break. The DOM represents these as 2 <br> so this is a special
+        // case.
+        if (!this.nextSibling() && !domNode.nextSibling) {
+            rangeLocation[1] = RelativePosition.AFTER;
+        }
+        return rangeLocation;
     }
 }

--- a/packages/core/src/VNodes/LineBreakNode.ts
+++ b/packages/core/src/VNodes/LineBreakNode.ts
@@ -3,7 +3,7 @@ import { RelativePosition } from '../../../utils/src/range';
 
 export class LineBreakNode extends VNode {
     constructor() {
-        super(VNodeType.LINE_BREAK, 'BR');
+        super(VNodeType.LINE_BREAK);
     }
 
     //--------------------------------------------------------------------------

--- a/packages/core/src/VNodes/RangeNode.ts
+++ b/packages/core/src/VNodes/RangeNode.ts
@@ -1,10 +1,15 @@
 import { VNode, VNodeType } from './VNode';
 
 export class RangeNode extends VNode {
-    properties = {
-        atomic: true,
-    };
     constructor(tailOrHead: 'tail' | 'head') {
         super(tailOrHead === 'tail' ? VNodeType.RANGE_TAIL : VNodeType.RANGE_HEAD);
+    }
+    /**
+     * Return true if the VNode is atomic (ie. it may not have children).
+     *
+     * @override
+     */
+    get atomic(): boolean {
+        return true;
     }
 }

--- a/packages/core/src/VNodes/RangeNode.ts
+++ b/packages/core/src/VNodes/RangeNode.ts
@@ -1,0 +1,10 @@
+import { VNode, VNodeType } from './VNode';
+
+export class RangeNode extends VNode {
+    properties = {
+        atomic: true,
+    };
+    constructor(tailOrHead: 'tail' | 'head') {
+        super(tailOrHead === 'tail' ? VNodeType.RANGE_TAIL : VNodeType.RANGE_HEAD);
+    }
+}

--- a/packages/core/src/VNodes/RootNode.ts
+++ b/packages/core/src/VNodes/RootNode.ts
@@ -1,0 +1,7 @@
+import { VNode, VNodeType } from './VNode';
+
+export class RootNode extends VNode {
+    constructor() {
+        super(VNodeType.ROOT);
+    }
+}

--- a/packages/core/src/VNodes/SimpleElementNode.ts
+++ b/packages/core/src/VNodes/SimpleElementNode.ts
@@ -1,0 +1,7 @@
+import { VNode, VNodeType } from './VNode';
+
+export class SimpleElementNode extends VNode {
+    constructor(type: VNodeType, originalTag?: string) {
+        super(type, originalTag);
+    }
+}

--- a/packages/core/src/VNodes/SimpleElementNode.ts
+++ b/packages/core/src/VNodes/SimpleElementNode.ts
@@ -1,7 +1,7 @@
 import { VNode, VNodeType } from './VNode';
 
 export class SimpleElementNode extends VNode {
-    constructor(type: VNodeType, originalTag?: string) {
-        super(type, originalTag);
+    constructor(type: VNodeType) {
+        super(type);
     }
 }

--- a/packages/core/src/VNodes/SimpleElementNode.ts
+++ b/packages/core/src/VNodes/SimpleElementNode.ts
@@ -1,7 +1,54 @@
 import { VNode, VNodeType } from './VNode';
 
 export class SimpleElementNode extends VNode {
+    htmlTag = '';
     constructor(type: VNodeType) {
         super(type);
+        this.htmlTag =
+            {
+                heading1: 'H1',
+                heading2: 'H2',
+                heading3: 'H3',
+                heading4: 'H4',
+                heading5: 'H5',
+                heading6: 'H6',
+                paragraph: 'P',
+            }[this.type] || 'UNKNOWN-ELEMENT';
+    }
+
+    //--------------------------------------------------------------------------
+    // Lifecycle
+    //--------------------------------------------------------------------------
+
+    static parse(node: Node): SimpleElementNode {
+        switch (node.nodeName) {
+            case 'H1':
+                return new SimpleElementNode(VNodeType.HEADING1);
+            case 'H2':
+                return new SimpleElementNode(VNodeType.HEADING2);
+            case 'H3':
+                return new SimpleElementNode(VNodeType.HEADING3);
+            case 'H4':
+                return new SimpleElementNode(VNodeType.HEADING4);
+            case 'H5':
+                return new SimpleElementNode(VNodeType.HEADING5);
+            case 'H6':
+                return new SimpleElementNode(VNodeType.HEADING6);
+            case 'P':
+                return new SimpleElementNode(VNodeType.PARAGRAPH);
+            default:
+                return null;
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return a new VNode with the same type and attributes as this VNode.
+     */
+    shallowDuplicate(): SimpleElementNode {
+        return new SimpleElementNode(this.type as VNodeType);
     }
 }

--- a/packages/core/src/VNodes/VNode.ts
+++ b/packages/core/src/VNodes/VNode.ts
@@ -1,7 +1,7 @@
-import { BasicHtmlRenderingEngine, RenderingEngine } from './BasicHtmlRenderingEngine';
-import { Predicate, isRange, isLeaf, not } from './../../utils/src/Predicates';
-import { RelativePosition } from '../../utils/src/range';
-import { utils, isWithRange } from './../../utils/src/utils';
+import { BasicHtmlRenderingEngine, RenderingEngine } from '../BasicHtmlRenderingEngine';
+import { Predicate, isRange, isLeaf, not } from '../../../utils/src/Predicates';
+import { RelativePosition } from '../../../utils/src/range';
+import { utils, isWithRange } from '../../../utils/src/utils';
 
 export enum VNodeType {
     ROOT = 'ROOT',

--- a/packages/core/src/VNodes/VNode.ts
+++ b/packages/core/src/VNodes/VNode.ts
@@ -197,34 +197,6 @@ export class VNode {
     //--------------------------------------------------------------------------
 
     /**
-     * Return the child's previous sibling.
-     *
-     * @param child
-     */
-    childBefore(child: VNode): VNode {
-        const childBefore = utils.withRange(() => this.nthChild(this.indexOf(child) - 1));
-        // Ignore range nodes by default.
-        if (!isWithRange && childBefore && isRange(childBefore)) {
-            return this.childBefore(childBefore);
-        } else {
-            return childBefore;
-        }
-    }
-    /**
-     * Return the child's next sibling.
-     *
-     * @param child
-     */
-    childAfter(child: VNode): VNode {
-        const childAfter = utils.withRange(() => this.nthChild(this.indexOf(child) + 1));
-        // Ignore range nodes by default.
-        if (!isWithRange && childAfter && isRange(childAfter)) {
-            return this.childAfter(childAfter);
-        } else {
-            return childAfter;
-        }
-    }
-    /**
      * Return the child at given index.
      *
      * @see _nthChild
@@ -232,51 +204,6 @@ export class VNode {
      */
     nthChild(index: number): VNode {
         return this.children[index];
-    }
-    /**
-     * Return the descendant of this node that directly precedes the given node
-     * in depth-first pre-order traversal.
-     *
-     * @param node
-     */
-    descendantBefore(node: VNode): VNode {
-        let previous = node.previousSibling();
-        if (previous) {
-            // The node before node is the last leaf of its previous sibling.
-            previous = previous.lastLeaf();
-        } else if (node.parent !== this) {
-            // If it has no previous sibling then climb up to the parent.
-            // This is similar to `previous` but can't go further than `this`.
-            previous = node.parent;
-        }
-        return previous;
-    }
-    /**
-     * Return the descendant of this node that directly follows the given node
-     * in depth-first pre-order traversal.
-     *
-     * @param node
-     */
-    descendantAfter(node: VNode): VNode {
-        // The node after node is its first child.
-        let next = node.firstChild();
-        if (!next) {
-            // If it has no children then it is its next sibling.
-            next = node.nextSibling();
-        }
-        if (!next) {
-            // If it has no siblings either then climb up to the closest parent
-            // which has a next sibiling.
-            // This is similar to `next` but can't go further than `this`.
-            let ancestor = node.parent;
-            while (ancestor !== this && !ancestor.nextSibling()) {
-                ancestor = ancestor.parent;
-            }
-            if (ancestor !== this) {
-                next = ancestor.nextSibling();
-            }
-        }
-        return next;
     }
     /**
      * Return this VNode's siblings.
@@ -353,7 +280,7 @@ export class VNode {
     firstDescendant(predicate?: Predicate): VNode {
         const firstDescendant = this.firstChild();
         if (firstDescendant && predicate) {
-            return firstDescendant.walk((node: VNode) => this.descendantAfter(node), predicate);
+            return firstDescendant.walk((node: VNode) => this._descendantAfter(node), predicate);
         } else {
             return firstDescendant;
         }
@@ -370,7 +297,7 @@ export class VNode {
             lastDescendant = lastDescendant.lastChild();
         }
         if (lastDescendant && predicate) {
-            return lastDescendant.walk((node: VNode) => this.descendantBefore(node), predicate);
+            return lastDescendant.walk((node: VNode) => this._descendantBefore(node), predicate);
         } else {
             return lastDescendant;
         }
@@ -382,7 +309,7 @@ export class VNode {
      * @param [predicate]
      */
     previousSibling(predicate?: Predicate): VNode {
-        const previousSibling = this.parent && this.parent.childBefore(this);
+        const previousSibling = this.parent && this.parent._childBefore(this);
         if (previousSibling && predicate) {
             return previousSibling.walk((node: VNode) => node.previousSibling(), predicate);
         } else {
@@ -396,7 +323,7 @@ export class VNode {
      * @param [predicate]
      */
     nextSibling(predicate?: Predicate): VNode {
-        const nextSibling = this.parent && this.parent.childAfter(this);
+        const nextSibling = this.parent && this.parent._childAfter(this);
         if (nextSibling && predicate) {
             return nextSibling.walk((node: VNode) => node.nextSibling(), predicate);
         } else {
@@ -631,6 +558,79 @@ export class VNode {
     // Private
     //--------------------------------------------------------------------------
 
+    /**
+     * Return the child's previous sibling.
+     *
+     * @param child
+     */
+    _childBefore(child: VNode): VNode {
+        const childBefore = utils.withRange(() => this.nthChild(this.indexOf(child) - 1));
+        // Ignore range nodes by default.
+        if (!isWithRange && childBefore && isRange(childBefore)) {
+            return this._childBefore(childBefore);
+        } else {
+            return childBefore;
+        }
+    }
+    /**
+     * Return the child's next sibling.
+     *
+     * @param child
+     */
+    _childAfter(child: VNode): VNode {
+        const childAfter = utils.withRange(() => this.nthChild(this.indexOf(child) + 1));
+        // Ignore range nodes by default.
+        if (!isWithRange && childAfter && isRange(childAfter)) {
+            return this._childAfter(childAfter);
+        } else {
+            return childAfter;
+        }
+    }
+    /**
+     * Return the descendant of this node that directly precedes the given node
+     * in depth-first pre-order traversal.
+     *
+     * @param node
+     */
+    _descendantBefore(node: VNode): VNode {
+        let previous = node.previousSibling();
+        if (previous) {
+            // The node before node is the last leaf of its previous sibling.
+            previous = previous.lastLeaf();
+        } else if (node.parent !== this) {
+            // If it has no previous sibling then climb up to the parent.
+            // This is similar to `previous` but can't go further than `this`.
+            previous = node.parent;
+        }
+        return previous;
+    }
+    /**
+     * Return the descendant of this node that directly follows the given node
+     * in depth-first pre-order traversal.
+     *
+     * @param node
+     */
+    _descendantAfter(node: VNode): VNode {
+        // The node after node is its first child.
+        let next = node.firstChild();
+        if (!next) {
+            // If it has no children then it is its next sibling.
+            next = node.nextSibling();
+        }
+        if (!next) {
+            // If it has no siblings either then climb up to the closest parent
+            // which has a next sibiling.
+            // This is similar to `next` but can't go further than `this`.
+            let ancestor = node.parent;
+            while (ancestor !== this && !ancestor.nextSibling()) {
+                ancestor = ancestor.parent;
+            }
+            if (ancestor !== this) {
+                next = ancestor.nextSibling();
+            }
+        }
+        return next;
+    }
     /**
      * Insert a VNode at the given index within this VNode's children.
      * Return self.

--- a/packages/core/src/VNodes/VNode.ts
+++ b/packages/core/src/VNodes/VNode.ts
@@ -119,20 +119,6 @@ export class VNode {
         return this.children.length;
     }
     /**
-     * Return the length of this node and all its descendents.
-     *
-     * @param __current
-     */
-    totalLength(__current = 0): number {
-        __current += this.length;
-        this.children.forEach((child: VNode): void => {
-            if (child.hasChildren()) {
-                __current = child.totalLength(__current);
-            }
-        });
-        return __current;
-    }
-    /**
      * Return the index of this VNode within its parent.
      *
      * @see indexOf

--- a/packages/core/src/VNodes/VNode.ts
+++ b/packages/core/src/VNodes/VNode.ts
@@ -45,23 +45,23 @@ export class VNode {
     renderingEngines: Record<string, RenderingEngine> = {
         html: BasicHtmlRenderingEngine,
     };
+    name: string;
     originalTag: string;
-    value: string;
     properties: VNodeProperties = {
         atomic: false,
     };
     _children: VNode[] = [];
 
-    constructor(type: VNodeType, originalTag = '', value?: string, format?: FormatType) {
+    constructor(type: VNodeType, originalTag = '', format?: FormatType) {
         this.type = type;
         this.originalTag = originalTag;
-        this.value = value;
         this.format = format || {
             bold: false,
             italic: false,
             underline: false,
         };
         this._updateProperties();
+        this.name = this.type;
         id++;
     }
     /**
@@ -88,7 +88,8 @@ export class VNode {
     /**
      * Render the VNode to the given format.
      *
-     * @param to the name of the format to which we want to render (default: html)
+     * @param [to] the name of the format to which we want to render (default:
+     * html)
      */
     render<T>(to = 'html'): T {
         return this.renderingEngines[to].render(this) as T;
@@ -116,6 +117,12 @@ export class VNode {
         }
         return [this, position];
     }
+    /**
+     * Return a new VNode with the same type and attributes as this VNode.
+     */
+    shallowDuplicate(): VNode {
+        return new VNode(this.type, this.originalTag, this.format);
+    }
 
     //--------------------------------------------------------------------------
     // Properties
@@ -134,7 +141,7 @@ export class VNode {
      * Return the length of this VNode.
      */
     get length(): number {
-        return this.value ? this.value.length : this.children.length;
+        return this.children.length;
     }
     /**
      * Return the length of this node and all its descendents.
@@ -174,9 +181,6 @@ export class VNode {
      * @param __current
      */
     text(__current = ''): string {
-        if (this.value) {
-            __current += this.value;
-        }
         this.children.forEach((child: VNode): void => {
             __current = child.text(__current);
         });
@@ -658,7 +662,7 @@ export class VNode {
     splitAt(child: VNode): VNode {
         const nodesToMove = [child];
         nodesToMove.push(...utils.withRange(() => child.nextSiblings()));
-        const duplicate = new VNode(this.type, this.originalTag, this.value, this.format);
+        const duplicate = this.shallowDuplicate();
         this.after(duplicate);
         nodesToMove.forEach(sibling => duplicate.append(sibling));
         return duplicate;

--- a/packages/core/src/VNodes/VNode.ts
+++ b/packages/core/src/VNodes/VNode.ts
@@ -18,10 +18,6 @@ export enum VNodeType {
     LINE_BREAK = 'LINE_BREAK',
 }
 
-export interface VNodeProperties {
-    atomic: boolean;
-}
-
 export interface FormatType {
     bold?: boolean;
     italic?: boolean;
@@ -29,12 +25,6 @@ export interface FormatType {
 }
 export const FORMAT_TYPES = ['bold', 'italic', 'underline'];
 
-const atomicTypes = [
-    VNodeType.CHAR,
-    VNodeType.LINE_BREAK,
-    VNodeType.RANGE_TAIL,
-    VNodeType.RANGE_HEAD,
-];
 let id = 0;
 
 export class VNode {
@@ -47,9 +37,6 @@ export class VNode {
     };
     name: string;
     originalTag: string;
-    properties: VNodeProperties = {
-        atomic: false,
-    };
     _children: VNode[] = [];
 
     constructor(type: VNodeType, originalTag = '', format?: FormatType) {
@@ -60,7 +47,6 @@ export class VNode {
             italic: false,
             underline: false,
         };
-        this._updateProperties();
         this.name = this.type;
         id++;
     }
@@ -122,6 +108,12 @@ export class VNode {
     // Properties
     //--------------------------------------------------------------------------
 
+    /**
+     * Return true if the VNode is atomic (ie. it may not have children).
+     */
+    get atomic(): boolean {
+        return false;
+    }
     /**
      * Return the VNode's children.
      */
@@ -192,14 +184,6 @@ export class VNode {
     hasFormat(): boolean {
         return Object.keys(this.format).some(
             (key: keyof FormatType): boolean => !!this.format[key],
-        );
-    }
-    /**
-     * Return true if this VNode has a vNode property set to true.
-     */
-    hasProperties(): boolean {
-        return Object.keys(this.properties).some(
-            (key: keyof VNodeProperties): boolean => !!this.properties[key],
         );
     }
     /**
@@ -694,13 +678,5 @@ export class VNode {
     _removeAtIndex(index: number): VNode {
         this._children.splice(index, 1);
         return this;
-    }
-    /**
-     * Update the VNode's properties.
-     */
-    _updateProperties(): void {
-        if (atomicTypes.includes(this.type)) {
-            this.properties.atomic = true;
-        }
     }
 }

--- a/packages/core/src/VNodes/VNode.ts
+++ b/packages/core/src/VNodes/VNode.ts
@@ -4,32 +4,33 @@ import { RelativePosition } from '../../../utils/src/range';
 import { utils, isWithRange } from '../../../utils/src/utils';
 
 export enum VNodeType {
-    ROOT = 'ROOT',
-    RANGE_TAIL = 'RANGE_TAIL',
-    RANGE_HEAD = 'RANGE_HEAD',
-    PARAGRAPH = 'PARAGRAPH',
-    HEADING1 = 'HEADING1',
-    HEADING2 = 'HEADING2',
-    HEADING3 = 'HEADING3',
-    HEADING4 = 'HEADING4',
-    HEADING5 = 'HEADING5',
-    HEADING6 = 'HEADING6',
-    CHAR = 'CHAR',
-    LINE_BREAK = 'LINE_BREAK',
+    ROOT = 'root',
+    RANGE_TAIL = 'range_tail',
+    RANGE_HEAD = 'range_head',
+    PARAGRAPH = 'paragraph',
+    HEADING1 = 'heading1',
+    HEADING2 = 'heading2',
+    HEADING3 = 'heading3',
+    HEADING4 = 'heading4',
+    HEADING5 = 'heading5',
+    HEADING6 = 'heading6',
+    CHAR = 'char',
+    LINE_BREAK = 'line_break',
 }
 let id = 0;
 
 export class VNode {
-    readonly type: VNodeType;
+    readonly type: VNodeType | string;
     readonly id = id;
     parent: VNode | null = null;
     renderingEngines: Record<string, RenderingEngine> = {
         html: BasicHtmlRenderingEngine,
     };
     name: string;
+    htmlTag: string;
     _children: VNode[] = [];
 
-    constructor(type: VNodeType) {
+    constructor(type: VNodeType | string) {
         this.type = type;
         this.name = this.type;
         id++;
@@ -55,6 +56,10 @@ export class VNode {
     // Lifecycle
     //--------------------------------------------------------------------------
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    static parse(node: Node): VNode | VNode[] | null {
+        return null;
+    }
     /**
      * Render the VNode to the given format.
      *

--- a/packages/core/src/VNodes/VNode.ts
+++ b/packages/core/src/VNodes/VNode.ts
@@ -295,7 +295,7 @@ export class VNode {
      * @param [predicate]
      */
     previousSibling(predicate?: Predicate): VNode {
-        const previousSibling = this.parent && this.parent._childBefore(this);
+        const previousSibling = (this.parent && this.parent._childBefore(this)) || undefined;
         if (previousSibling && predicate) {
             return previousSibling.walk((node: VNode) => node.previousSibling(), predicate);
         } else {
@@ -309,7 +309,7 @@ export class VNode {
      * @param [predicate]
      */
     nextSibling(predicate?: Predicate): VNode {
-        const nextSibling = this.parent && this.parent._childAfter(this);
+        const nextSibling = (this.parent && this.parent._childAfter(this)) || undefined;
         if (nextSibling && predicate) {
             return nextSibling.walk((node: VNode) => node.nextSibling(), predicate);
         } else {
@@ -335,7 +335,7 @@ export class VNode {
         if (previous && predicate) {
             return previous.walk((node: VNode) => node.previous(), predicate);
         } else {
-            return previous;
+            return previous || undefined;
         }
     }
     /**
@@ -359,7 +359,7 @@ export class VNode {
             while (ancestor && !ancestor.nextSibling()) {
                 ancestor = ancestor.parent;
             }
-            next = ancestor && ancestor.nextSibling();
+            next = (ancestor && ancestor.nextSibling()) || undefined;
         }
         if (next && predicate) {
             return next.walk((node: VNode) => node.next(), predicate);

--- a/packages/core/src/VNodes/VNode.ts
+++ b/packages/core/src/VNodes/VNode.ts
@@ -109,12 +109,6 @@ export class VNode {
         if (domNodeLength && offset >= domNodeLength) {
             position = RelativePosition.AFTER;
         }
-        // When clicking on a trailing line break, we need to target after the
-        // line break. The DOM represents these as 2 <br> so this is a special
-        // case. TODO: move this to LINE_BREAK node when it's implemented.
-        if (this.type === 'LINE_BREAK' && !this.nextSibling() && !domNode.nextSibling) {
-            position = RelativePosition.AFTER;
-        }
         return [this, position];
     }
     /**

--- a/packages/core/src/VNodes/VNode.ts
+++ b/packages/core/src/VNodes/VNode.ts
@@ -17,36 +17,20 @@ export enum VNodeType {
     CHAR = 'CHAR',
     LINE_BREAK = 'LINE_BREAK',
 }
-
-export interface FormatType {
-    bold?: boolean;
-    italic?: boolean;
-    underline?: boolean;
-}
-export const FORMAT_TYPES = ['bold', 'italic', 'underline'];
-
 let id = 0;
 
 export class VNode {
     readonly type: VNodeType;
-    format: FormatType;
     readonly id = id;
     parent: VNode | null = null;
     renderingEngines: Record<string, RenderingEngine> = {
         html: BasicHtmlRenderingEngine,
     };
     name: string;
-    originalTag: string;
     _children: VNode[] = [];
 
-    constructor(type: VNodeType, originalTag = '', format?: FormatType) {
+    constructor(type: VNodeType) {
         this.type = type;
-        this.originalTag = originalTag;
-        this.format = format || {
-            bold: false,
-            italic: false,
-            underline: false,
-        };
         this.name = this.type;
         id++;
     }
@@ -101,7 +85,7 @@ export class VNode {
      * Return a new VNode with the same type and attributes as this VNode.
      */
     shallowDuplicate(): VNode {
-        return new VNode(this.type, this.originalTag, this.format);
+        return new VNode(this.type);
     }
 
     //--------------------------------------------------------------------------
@@ -177,14 +161,6 @@ export class VNode {
      */
     hasChildren(): boolean {
         return this.children.length > 0;
-    }
-    /**
-     * Return true if this VNode has a format property set to true.
-     */
-    hasFormat(): boolean {
-        return Object.keys(this.format).some(
-            (key: keyof FormatType): boolean => !!this.format[key],
-        );
     }
     /**
      * Return true if this VNode comes before the given VNode in the pre-order

--- a/packages/core/src/VRange.ts
+++ b/packages/core/src/VRange.ts
@@ -288,7 +288,7 @@ export class VRange {
      */
     _setTail(reference: VNode, position = RelativePosition.BEFORE): VRange {
         reference = reference.firstLeaf();
-        if (!reference.hasChildren() && !reference.properties.atomic) {
+        if (!reference.hasChildren() && !reference.atomic) {
             reference.prepend(this._tail);
         } else if (position === RelativePosition.AFTER && reference !== this._head) {
             // We check that `reference` isn't `_head` to avoid a backward
@@ -311,7 +311,7 @@ export class VRange {
      */
     _setHead(reference: VNode, position = RelativePosition.AFTER): VRange {
         reference = reference.lastLeaf();
-        if (!reference.hasChildren() && !reference.properties.atomic) {
+        if (!reference.hasChildren() && !reference.atomic) {
             reference.append(this._head);
         } else if (position === RelativePosition.BEFORE && reference !== this._tail) {
             // We check that `reference` isn't `_tail` to avoid a backward

--- a/packages/core/src/VRange.ts
+++ b/packages/core/src/VRange.ts
@@ -1,16 +1,8 @@
 import { VNode, VNodeType } from './VNode';
-import { VDocument } from './VDocument';
 import { isRange } from '../../utils/src/Predicates';
+import { utils } from '../../utils/src/utils';
+import { RelativePosition, Direction } from '../../utils/src/range';
 
-export enum Direction {
-    BACKWARD = 'BACKWARD',
-    FORWARD = 'FORWARD',
-}
-export enum RelativePosition {
-    BEFORE = 'BEFORE',
-    AFTER = 'AFTER',
-    INSIDE = 'INSIDE',
-}
 export interface VRangeDescription {
     start: VNode;
     startPosition?: RelativePosition;
@@ -18,9 +10,6 @@ export interface VRangeDescription {
     endPosition?: RelativePosition;
     direction: Direction;
 }
-
-export const RANGE_TAIL_CHAR = '[';
-export const RANGE_HEAD_CHAR = ']';
 
 export class VRange {
     readonly _tail = new VNode(VNodeType.RANGE_TAIL);
@@ -38,7 +27,7 @@ export class VRange {
     }
     get direction(): Direction {
         if (!this._direction) {
-            const forward = VDocument.withRange(() => this._tail.isBefore(this._head));
+            const forward = utils.withRange(() => this._tail.isBefore(this._head));
             this._direction = forward ? Direction.FORWARD : Direction.BACKWARD;
         }
         return this._direction;
@@ -77,7 +66,7 @@ export class VRange {
      * Return true if the range is collapsed.
      */
     isCollapsed(): boolean {
-        return VDocument.withRange(() => {
+        return utils.withRange(() => {
             if (this.direction === Direction.FORWARD) {
                 return this._tail.nextSibling() === this._head;
             } else {
@@ -92,7 +81,7 @@ export class VRange {
     get selectedNodes(): VNode[] {
         const selectedNodes: VNode[] = [];
         let node = this.start;
-        VDocument.withRange(() => {
+        utils.withRange(() => {
             while ((node = node.next()) && node !== this.end) {
                 selectedNodes.push(node);
             }

--- a/packages/core/src/VRange.ts
+++ b/packages/core/src/VRange.ts
@@ -1,7 +1,8 @@
-import { VNode, VNodeType } from './VNode';
+import { VNode } from './VNodes/VNode';
 import { isRange } from '../../utils/src/Predicates';
 import { utils } from '../../utils/src/utils';
 import { RelativePosition, Direction } from '../../utils/src/range';
+import { RangeNode } from './VNodes/RangeNode';
 
 export interface VRangeDescription {
     start: VNode;
@@ -12,8 +13,8 @@ export interface VRangeDescription {
 }
 
 export class VRange {
-    readonly _tail = new VNode(VNodeType.RANGE_TAIL);
-    readonly _head = new VNode(VNodeType.RANGE_HEAD);
+    readonly _tail = new RangeNode('tail');
+    readonly _head = new RangeNode('head');
     /**
      * The direction of the range depends on whether tail is before head or the
      * opposite. This is costly to compute and, as such, is only computed when
@@ -35,13 +36,13 @@ export class VRange {
     /**
      * Return the first range node in order of traversal.
      */
-    get start(): VNode {
+    get start(): RangeNode {
         return this.direction === Direction.FORWARD ? this._tail : this._head;
     }
     /**
      * Return the last range node in order of traversal.
      */
-    get end(): VNode {
+    get end(): RangeNode {
         return this.direction === Direction.FORWARD ? this._head : this._tail;
     }
     /**

--- a/packages/core/test/Parser.test.ts
+++ b/packages/core/test/Parser.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { Parser } from '../src/Parser';
-import { VNodeType } from '../src/VNode';
+import { VNodeType } from '../src/VNodes/VNode';
 
 describe('utils', () => {
     describe('Parser', () => {

--- a/packages/core/test/Parser.test.ts
+++ b/packages/core/test/Parser.test.ts
@@ -48,6 +48,9 @@ describe('utils', () => {
                 const p = vDocument.root.children[0];
                 expect(p.type).to.equal(VNodeType.PARAGRAPH);
                 expect(p.children.length).to.equal(4);
+                const a = p.children[0] as CharNode;
+                expect(a.type).to.equal(VNodeType.CHAR);
+                expect(a.char).to.equal('a');
                 const b = p.children[1] as CharNode;
                 expect(b.char).to.equal('b');
                 expect(b.format).to.deep.equal({

--- a/packages/core/test/Parser.test.ts
+++ b/packages/core/test/Parser.test.ts
@@ -1,15 +1,16 @@
 import { expect } from 'chai';
-import { Parser } from '../src/Parser';
 import { VNodeType } from '../src/VNodes/VNode';
 import { CharNode } from '../src/VNodes/CharNode';
+import { Parser } from '../src/Parser';
 
 describe('utils', () => {
     describe('Parser', () => {
+        const parser = new Parser();
         describe('parse()', () => {
             it('should parse a "p" tag with some content', () => {
                 const element = document.createElement('div');
                 element.innerHTML = '<p>a</p>';
-                const vDocument = Parser.parse(element);
+                const vDocument = parser.parse(element);
 
                 expect(vDocument.root.type).to.equal(VNodeType.ROOT);
                 expect(vDocument.root.children.length).to.equal(1);
@@ -22,7 +23,7 @@ describe('utils', () => {
             it('should parse a "p" tag with no content', () => {
                 const element = document.createElement('div');
                 element.innerHTML = '<p><br></p>';
-                const vDocument = Parser.parse(element);
+                const vDocument = parser.parse(element);
                 const p = vDocument.root.firstChild();
                 // The placeholder <br> should not be parsed.
                 expect(p.hasChildren()).to.be.false;
@@ -30,7 +31,7 @@ describe('utils', () => {
             it('should parse two trailing consecutive <br> as one LINE_BREAK', () => {
                 const element = document.createElement('div');
                 element.innerHTML = '<p>a<br><br>';
-                const vDocument = Parser.parse(element);
+                const vDocument = parser.parse(element);
                 const p = vDocument.root.firstChild();
                 // Only one <br> should be parsed.
                 expect(p.children.length).to.equal(2);
@@ -40,7 +41,7 @@ describe('utils', () => {
             it('handles nested formatted nodes', () => {
                 const element = document.createElement('div');
                 element.innerHTML = '<p>a<i>b<b>c</b>d</i></p>';
-                const vDocument = Parser.parse(element);
+                const vDocument = parser.parse(element);
 
                 expect(vDocument.root.type).to.equal(VNodeType.ROOT);
                 expect(vDocument.root.children.length).to.equal(1);

--- a/packages/core/test/Parser.test.ts
+++ b/packages/core/test/Parser.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { Parser } from '../src/Parser';
 import { VNodeType } from '../src/VNodes/VNode';
+import { CharNode } from '../src/VNodes/CharNode';
 
 describe('utils', () => {
     describe('Parser', () => {
@@ -16,7 +17,7 @@ describe('utils', () => {
                 expect(p.type).to.equal(VNodeType.PARAGRAPH);
                 expect(p.children.length).to.equal(1);
                 expect(p.children[0].type).to.equal(VNodeType.CHAR);
-                expect(p.children[0].value).to.equal('a');
+                expect((p.children[0] as CharNode).char).to.equal('a');
             });
             it('should parse a "p" tag with no content', () => {
                 const element = document.createElement('div');
@@ -34,7 +35,7 @@ describe('utils', () => {
                 // Only one <br> should be parsed.
                 expect(p.children.length).to.equal(2);
                 expect(p.lastChild().type).to.equal(VNodeType.LINE_BREAK);
-                expect(p.lastChild().previousSibling().value).to.equal('a');
+                expect((p.lastChild().previousSibling() as CharNode).char).to.equal('a');
             });
             it('handles nested formatted nodes', () => {
                 const element = document.createElement('div');
@@ -47,20 +48,20 @@ describe('utils', () => {
                 expect(p.type).to.equal(VNodeType.PARAGRAPH);
                 expect(p.children.length).to.equal(4);
                 expect(p.children[0].type).to.equal(VNodeType.CHAR);
-                expect(p.children[0].value).to.equal('a');
-                expect(p.children[1].value).to.equal('b');
+                expect((p.children[0] as CharNode).char).to.equal('a');
+                expect((p.children[1] as CharNode).char).to.equal('b');
                 expect(p.children[1].format).to.deep.equal({
                     bold: false,
                     italic: true,
                     underline: false,
                 });
-                expect(p.children[2].value).to.equal('c');
+                expect((p.children[2] as CharNode).char).to.equal('c');
                 expect(p.children[2].format).to.deep.equal({
                     bold: true,
                     italic: true,
                     underline: false,
                 });
-                expect(p.children[3].value).to.equal('d');
+                expect((p.children[3] as CharNode).char).to.equal('d');
                 expect(p.children[3].format).to.deep.equal({
                     bold: false,
                     italic: true,

--- a/packages/core/test/Parser.test.ts
+++ b/packages/core/test/Parser.test.ts
@@ -47,22 +47,23 @@ describe('utils', () => {
                 const p = vDocument.root.children[0];
                 expect(p.type).to.equal(VNodeType.PARAGRAPH);
                 expect(p.children.length).to.equal(4);
-                expect(p.children[0].type).to.equal(VNodeType.CHAR);
-                expect((p.children[0] as CharNode).char).to.equal('a');
-                expect((p.children[1] as CharNode).char).to.equal('b');
-                expect(p.children[1].format).to.deep.equal({
+                const b = p.children[1] as CharNode;
+                expect(b.char).to.equal('b');
+                expect(b.format).to.deep.equal({
                     bold: false,
                     italic: true,
                     underline: false,
                 });
-                expect((p.children[2] as CharNode).char).to.equal('c');
-                expect(p.children[2].format).to.deep.equal({
+                const c = p.children[2] as CharNode;
+                expect(c.char).to.equal('c');
+                expect(c.format).to.deep.equal({
                     bold: true,
                     italic: true,
                     underline: false,
                 });
-                expect((p.children[3] as CharNode).char).to.equal('d');
-                expect(p.children[3].format).to.deep.equal({
+                const d = p.children[3] as CharNode;
+                expect(d.char).to.equal('d');
+                expect(d.format).to.deep.equal({
                     bold: false,
                     italic: true,
                     underline: false,

--- a/packages/core/test/Renderer.test.ts
+++ b/packages/core/test/Renderer.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import JWEditor from '../src/JWEditor';
 import { Renderer } from '../src/Renderer';
 import { testEditor } from '../../utils/src/testUtils';
-import { VNode, VNodeType } from '../src/VNode';
+import { VNode, VNodeType } from '../src/VNodes/VNode';
 
 describe('utils', () => {
     describe('Renderer', () => {

--- a/packages/core/test/Renderer.test.ts
+++ b/packages/core/test/Renderer.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import JWEditor from '../src/JWEditor';
 import { Renderer } from '../src/Renderer';
 import { testEditor } from '../../utils/src/testUtils';
-import { VNode, VNodeType } from '../src/VNodes/VNode';
+import { CharNode } from '../src/VNodes/CharNode';
 
 describe('utils', () => {
     describe('Renderer', () => {
@@ -14,9 +14,9 @@ describe('utils', () => {
 
                 const editor = new JWEditor(element);
                 editor.start();
-                editor.vDocument.root.append(new VNode(VNodeType.CHAR, '', ' '));
-                editor.vDocument.root.append(new VNode(VNodeType.CHAR, '', ' '));
-                editor.vDocument.root.append(new VNode(VNodeType.CHAR, '', 'b'));
+                editor.vDocument.root.append(new CharNode(' '));
+                editor.vDocument.root.append(new CharNode(' '));
+                editor.vDocument.root.append(new CharNode('b'));
 
                 const renderer = new Renderer();
                 renderer.render(editor.vDocument, editor.editable);
@@ -32,11 +32,11 @@ describe('utils', () => {
 
                 const editor = new JWEditor(element);
                 editor.start();
-                editor.vDocument.root.append(new VNode(VNodeType.CHAR, '', ' '));
-                editor.vDocument.root.append(new VNode(VNodeType.CHAR, '', ' '));
-                editor.vDocument.root.append(new VNode(VNodeType.CHAR, '', ' '));
-                editor.vDocument.root.append(new VNode(VNodeType.CHAR, '', ' '));
-                editor.vDocument.root.append(new VNode(VNodeType.CHAR, '', 'b'));
+                editor.vDocument.root.append(new CharNode(' '));
+                editor.vDocument.root.append(new CharNode(' '));
+                editor.vDocument.root.append(new CharNode(' '));
+                editor.vDocument.root.append(new CharNode(' '));
+                editor.vDocument.root.append(new CharNode('b'));
 
                 const renderer = new Renderer();
                 renderer.render(editor.vDocument, editor.editable);

--- a/packages/core/test/VDocument.test.ts
+++ b/packages/core/test/VDocument.test.ts
@@ -1,14 +1,13 @@
 import JWEditor from '../src/JWEditor';
 import { testEditor } from '../../utils/src/testUtils';
 import { FormatParams } from '../src/CorePlugin';
-import { VNode, VNodeType } from '../src/VNodes/VNode';
+import { LineBreakNode } from '../src/VNodes/LineBreakNode';
 
 const deleteForward = (editor: JWEditor): void => editor.execCommand('deleteForward');
 const deleteBackward = (editor: JWEditor): void => editor.execCommand('deleteBackward');
 const insertParagraphBreak = (editor: JWEditor): void => editor.execCommand('insertParagraphBreak');
-const insertLineBreak = (editor: JWEditor): void => {
-    editor.execCommand('insert', { value: new VNode(VNodeType.LINE_BREAK, 'BR') });
-};
+const insertLineBreak = (editor: JWEditor): void =>
+    editor.execCommand('insert', { value: new LineBreakNode() });
 
 describe('stores', () => {
     describe('VDocument', () => {

--- a/packages/core/test/VDocument.test.ts
+++ b/packages/core/test/VDocument.test.ts
@@ -421,7 +421,6 @@ describe('stores', () => {
                                 contentBefore: '<p>ab</p><p><br><br><br><br>[]</p><p>cd</p>',
                                 stepFunction: deleteForward,
                                 contentAfter: '<p>ab</p><p><br><br><br>[]cd</p>',
-                                debug: true,
                             });
                             // 2-1
                             await testEditor({

--- a/packages/core/test/VDocument.test.ts
+++ b/packages/core/test/VDocument.test.ts
@@ -1,7 +1,7 @@
 import JWEditor from '../src/JWEditor';
 import { testEditor } from '../../utils/src/testUtils';
 import { FormatParams } from '../src/CorePlugin';
-import { VNode, VNodeType } from '../src/VNode';
+import { VNode, VNodeType } from '../src/VNodes/VNode';
 
 const deleteForward = (editor: JWEditor): void => editor.execCommand('deleteForward');
 const deleteBackward = (editor: JWEditor): void => editor.execCommand('deleteBackward');

--- a/packages/core/test/VNodes.test.ts
+++ b/packages/core/test/VNodes.test.ts
@@ -6,6 +6,7 @@ import { RangeNode } from '../src/VNodes/RangeNode';
 import { SimpleElementNode } from '../src/VNodes/SimpleElementNode';
 import { RootNode } from '../src/VNodes/RootNode';
 import { utils } from '../../utils/src/utils';
+import JWEditor from '../src/JWEditor';
 
 describe('core', () => {
     describe('src', () => {
@@ -1144,6 +1145,32 @@ describe('core', () => {
                         expect(p.children).to.deep.equal([a, tail]);
                         expect(p.nextSibling().children).to.deep.equal([b, head, c]);
                     });
+                });
+            });
+            describe('Custom VNode', () => {
+                it('should create and parse a custom node', () => {
+                    const editor = new JWEditor();
+                    class MyCustomNode extends VNode {
+                        customKey = 'yes';
+                        constructor() {
+                            super('custom');
+                        }
+                        static parse(node: Node): VNode | VNode[] | null {
+                            if (node.nodeName === 'CUSTOM-NODE') {
+                                return new MyCustomNode();
+                            }
+                        }
+                    }
+                    editor.addCustomNode(MyCustomNode);
+                    editor.start();
+                    const root = document.createElement('ROOT-NODE');
+                    const element = document.createElement('CUSTOM-NODE');
+                    root.appendChild(element);
+                    const vDocument = editor.parser.parse(root);
+                    const customVNode = vDocument.root.firstChild();
+                    expect(customVNode.constructor.name).to.equal('MyCustomNode');
+                    expect(customVNode.type).to.equal('custom');
+                    expect((customVNode as MyCustomNode).customKey).to.equal('yes');
                 });
             });
         });

--- a/packages/core/test/VNodes.test.ts
+++ b/packages/core/test/VNodes.test.ts
@@ -1,0 +1,1151 @@
+import { expect } from 'chai';
+import { VNode, VNodeType } from '../src/VNodes/VNode';
+import { CharNode } from '../src/VNodes/CharNode';
+import { LineBreakNode } from '../src/VNodes/LineBreakNode';
+import { RangeNode } from '../src/VNodes/RangeNode';
+import { SimpleElementNode } from '../src/VNodes/SimpleElementNode';
+import { RootNode } from '../src/VNodes/RootNode';
+import { utils } from '../../utils/src/utils';
+
+describe('core', () => {
+    describe('src', () => {
+        describe('VNodes', () => {
+            describe('CharNode', () => {
+                describe('constructor', () => {
+                    it('should create a CharNode', async () => {
+                        const c = new CharNode(' ');
+                        expect(c.char).to.equal(' ');
+                        expect(c.atomic).to.equal(true);
+                        expect(c.format).to.deep.equal({
+                            bold: false,
+                            italic: false,
+                            underline: false,
+                        });
+                        expect(c.length).to.equal(1);
+                    });
+                    it('should create a CharNode with format', async () => {
+                        const c = new CharNode(' ', { bold: true });
+                        expect(c.char).to.equal(' ');
+                        expect(c.atomic).to.equal(true);
+                        expect(c.bold).to.equal(true);
+                        expect(c.format).to.deep.equal({
+                            bold: true,
+                            italic: false,
+                            underline: false,
+                        });
+                    });
+                    it('should throw an exception if create a CharNode with wrong value', async () => {
+                        expect(() => {
+                            // eslint-disable-next-line no-new
+                            new CharNode('ab');
+                        }).to.throw('Char', 'length greater than 1');
+                        expect(() => {
+                            // eslint-disable-next-line no-new
+                            new CharNode('');
+                        }).to.throw('Char', 'empty text');
+                    });
+                });
+                describe('parse', () => {
+                    it('should parse a textNode', async () => {
+                        const text = document.createTextNode('abc');
+                        const nNodes = CharNode.parse(text);
+                        expect(nNodes.length).to.equal(3);
+                        expect(nNodes[0].char).to.equal('a');
+                        expect(nNodes[1].char).to.equal('b');
+                        expect(nNodes[2].char).to.equal('c');
+                    });
+                    it('should not parse a SPAN node', async () => {
+                        const span = document.createElement('span');
+                        expect(CharNode.parse(span)).to.equal(null);
+                    });
+                });
+                describe('shallowDuplicate', () => {
+                    it('should duplicate a simple char', async () => {
+                        const c = new CharNode('a');
+                        const copy = c.shallowDuplicate();
+                        expect(copy).to.not.equal(c);
+                        expect(copy instanceof CharNode).to.equal(true);
+                        expect(copy.char).to.equal(c.char);
+                        expect(copy.format).to.deep.equal(c.format);
+                    });
+                    it('should duplicate a char with format', async () => {
+                        const c = new CharNode('a');
+                        c.bold = true;
+                        const copy = c.shallowDuplicate();
+                        expect(copy).to.not.equal(c);
+                        expect(copy.format.bold).to.equal(true, 'copy is bold');
+                        expect(copy.char).to.equal(c.char);
+                        expect(copy.format).to.deep.equal(c.format);
+                    });
+                    it('should mark as italic a duplicate a char', async () => {
+                        const c = new CharNode('a');
+                        const copy = c.shallowDuplicate();
+                        copy.italic = true;
+                        expect(copy.format.italic).to.equal(true, 'copy is now italic');
+                        expect(c.format.italic).to.equal(false, 'original char is not italic');
+                    });
+                    it('should update the format for a duplicate a char', async () => {
+                        const c = new CharNode('a');
+                        const copy = c.shallowDuplicate();
+                        copy.format = { italic: true };
+                        expect(copy.format.italic).to.equal(true, 'copy is now italic');
+                        expect(c.format.italic).to.equal(false, 'original char is not italic');
+                    });
+                });
+                describe('text', () => {
+                    it('should concat the CharNodes value', async () => {
+                        const a = new CharNode('a');
+                        const b = new CharNode('b');
+                        const c = new CharNode('c');
+                        let text = a.text();
+                        text = b.text(text);
+                        text = c.text(text);
+                        expect(text).to.equal('abc');
+                    });
+                });
+            });
+            describe('SimpleElementNode', () => {
+                describe('constructor', () => {
+                    it('should create a paragraph', async () => {
+                        const vNode = new SimpleElementNode(VNodeType.PARAGRAPH);
+                        expect(vNode.atomic).to.equal(false);
+                        expect(vNode.htmlTag).to.equal('P');
+                    });
+                    it('should create a heading', async () => {
+                        for (let i = 1; i <= 6; i++) {
+                            const vNode = new SimpleElementNode(VNodeType['HEADING' + i]);
+                            expect(vNode.atomic).to.equal(false);
+                            expect(vNode.htmlTag).to.equal('H' + i);
+                        }
+                    });
+                    it('should create a unknown', async () => {
+                        for (let i = 1; i <= 6; i++) {
+                            const vNode = new SimpleElementNode(VNodeType.ROOT);
+                            expect(vNode.atomic).to.equal(false);
+                            expect(vNode.htmlTag).to.equal('UNKNOWN-ELEMENT');
+                        }
+                    });
+                });
+                describe('parse', () => {
+                    it('should parse a paragraph', async () => {
+                        const node = document.createElement('p');
+                        const vNode = SimpleElementNode.parse(node);
+                        expect(vNode.htmlTag).to.equal('P');
+                    });
+                    it('should parse a heading', async () => {
+                        for (let i = 1; i <= 6; i++) {
+                            const node = document.createElement('h' + i);
+                            const vNode = SimpleElementNode.parse(node);
+                            expect(vNode.htmlTag).to.equal('H' + i);
+                        }
+                    });
+                    it('should not parse a SPAN node', async () => {
+                        const span = document.createElement('span');
+                        expect(SimpleElementNode.parse(span)).to.equal(null);
+                    });
+                });
+                describe('shallowDuplicate', () => {
+                    it('should duplicate a SimpleElementNode', async () => {
+                        const vNode = new SimpleElementNode(VNodeType.PARAGRAPH);
+                        const copy = vNode.shallowDuplicate();
+                        expect(copy).to.not.equal(vNode);
+                        expect(copy.htmlTag).to.equal('P');
+                    });
+                });
+            });
+            describe('LineBreakNode', () => {
+                describe('constructor', () => {
+                    it('should create a LineBreakNode', async () => {
+                        const lineBreak = new LineBreakNode();
+                        expect(lineBreak.atomic).to.equal(true);
+                    });
+                });
+                describe('parse', () => {
+                    it('should parse a BR node', async () => {
+                        const br = document.createElement('br');
+                        expect(LineBreakNode.parse(br).atomic).to.equal(true);
+                    });
+                    it('should not parse a SPAN node', async () => {
+                        const span = document.createElement('span');
+                        expect(LineBreakNode.parse(span)).to.equal(null);
+                    });
+                });
+                describe('render', () => {
+                    it('should render an ending lineBreak (default html arg)', async () => {
+                        const lineBreak = new LineBreakNode();
+                        const fragment = lineBreak.render<DocumentFragment>();
+                        expect(fragment.childNodes.length).to.equal(2);
+                        expect(fragment.firstChild.nodeName).to.equal('BR');
+                        expect(fragment.lastChild.nodeName).to.equal('BR');
+                    });
+                    it('should render an ending lineBreak', async () => {
+                        const lineBreak = new LineBreakNode();
+                        const fragment = lineBreak.render<DocumentFragment>('html');
+                        expect(fragment.childNodes.length).to.equal(2);
+                        expect(fragment.firstChild.nodeName).to.equal('BR');
+                        expect(fragment.lastChild.nodeName).to.equal('BR');
+                    });
+                    it('should render a lineBreak with char after', async () => {
+                        const p = new SimpleElementNode(VNodeType.PARAGRAPH);
+                        const lineBreak = new LineBreakNode();
+                        p.append(lineBreak);
+                        const c = new CharNode(' ');
+                        p.append(c);
+                        const fragment = lineBreak.render<DocumentFragment>('html');
+                        expect(fragment.childNodes.length).to.equal(1);
+                        expect(fragment.firstChild.nodeName).to.equal('BR');
+                    });
+                });
+                describe('shallowDuplicate', () => {
+                    it('should duplicate a LineBreakNode', async () => {
+                        const lineBreak = new LineBreakNode();
+                        const copy = lineBreak.shallowDuplicate();
+                        expect(copy).to.not.equal(lineBreak);
+                        expect(copy instanceof LineBreakNode).to.equal(true);
+                    });
+                });
+                describe('locateRange', () => {
+                    it('should locate where to set the range at end', async () => {
+                        const p = new SimpleElementNode(VNodeType.PARAGRAPH);
+                        const a = new CharNode('a');
+                        p.append(a);
+                        const lineBreak = new LineBreakNode();
+                        p.append(lineBreak);
+                        const doc = document.createElement('p');
+                        doc.innerHTML = 'a<br><br>';
+                        expect(lineBreak.locateRange(doc.childNodes[1], 0)).to.deep.equal([
+                            lineBreak,
+                            'BEFORE',
+                        ]);
+                        expect(lineBreak.locateRange(doc.childNodes[2], 0)).to.deep.equal([
+                            lineBreak,
+                            'AFTER',
+                        ]);
+                    });
+                    it('should locate where to set the range inside string', async () => {
+                        const p = new SimpleElementNode(VNodeType.PARAGRAPH);
+                        const a = new CharNode('a');
+                        p.append(a);
+                        const lineBreak = new LineBreakNode();
+                        p.append(lineBreak);
+                        const b = new CharNode('b');
+                        p.append(b);
+                        const doc = document.createElement('p');
+                        doc.innerHTML = 'a<br>b';
+                        expect(lineBreak.locateRange(doc.childNodes[1], 0)).to.deep.equal([
+                            lineBreak,
+                            'BEFORE',
+                        ]);
+                    });
+                });
+            });
+            describe('RootNode', () => {
+                describe('constructor', () => {
+                    it('should create a root node', async () => {
+                        const vNode = new RootNode();
+                        expect(vNode instanceof RootNode).to.equal(true);
+                    });
+                });
+            });
+            describe('RangeNode', () => {
+                describe('constructor', () => {
+                    it('should create a range node', async () => {
+                        const tail = new RangeNode('tail');
+                        expect(tail.type).to.equal('range_tail');
+                        expect(tail.atomic).to.equal(true);
+
+                        const head = new RangeNode('head');
+                        expect(head.type).to.equal('range_head');
+                        expect(head.atomic).to.equal(true);
+                    });
+                });
+            });
+            describe('VNode', () => {
+                /*
+                 * ROOT
+                 * - a
+                 * - H1
+                 *   - RangeTail
+                 *   - b
+                 * - c
+                 * - P
+                 *   - d
+                 *   - P
+                 *     - e
+                 *      - RangeHead
+                 *     - f
+                 */
+                const root = new VNode(VNodeType.ROOT);
+                const a = new CharNode('a');
+                root.append(a);
+                const h1 = new SimpleElementNode(VNodeType.HEADING1);
+                root.append(h1);
+                const b = new CharNode('b');
+                h1.append(b);
+                const tail = new RangeNode('tail');
+                h1.prepend(tail);
+                const c = new CharNode('c');
+                root.append(c);
+                const p = new SimpleElementNode(VNodeType.PARAGRAPH);
+                root.append(p);
+                const d = new CharNode('d');
+                p.append(d);
+                const pp = new SimpleElementNode(VNodeType.PARAGRAPH);
+                p.append(pp);
+                const e = new CharNode('e');
+                pp.append(e);
+                const head = new RangeNode('head');
+                pp.append(head);
+                const f = new CharNode('f');
+                pp.append(f);
+
+                describe('constructor', () => {
+                    it('should create a VNode', async () => {
+                        const fakeLineBreak = new VNode(VNodeType.LINE_BREAK);
+                        expect(fakeLineBreak.atomic).to.equal(false);
+                    });
+                });
+                describe('toString', () => {
+                    it('should display an understandable rendering', async () => {
+                        const root = new RootNode();
+                        const p = new VNode(VNodeType.PARAGRAPH);
+                        root.append(p);
+                        const a = new CharNode('a');
+                        p.append(a);
+                        const tail = new RangeNode('tail');
+                        p.append(tail);
+                        const b = new CharNode('b');
+                        p.append(b);
+                        const head = new RangeNode('head');
+                        p.append(head);
+                        const c = new CharNode('c');
+                        p.append(c);
+                        expect(root + '').to.deep.equal(
+                            'RootNode<root>VNode<paragraph>CharNode<char/>CharNode<char/>CharNode<char/><paragraph><root>',
+                        );
+                    });
+                });
+                describe('children', () => {
+                    it('should return the children nodes (without range)', async () => {
+                        expect(root.children).to.deep.equal([a, h1, c, p]);
+                        expect(h1.children).to.deep.equal([b]);
+                    });
+                    it('should return the children nodes with the range', async () => {
+                        utils.withRange(() => {
+                            expect(root.children).to.deep.equal([a, h1, c, p]);
+                            expect(h1.children).to.deep.equal([tail, b]);
+                        });
+                    });
+                });
+                describe('parse', () => {
+                    it('should not parse a node', async () => {
+                        const p = document.createElement('p');
+                        expect(VNode.parse(p)).to.equal(null);
+                    });
+                });
+                describe('Render', () => {
+                    it('should render a VNode', async () => {
+                        const root = new VNode(VNodeType.ROOT);
+                        const fragment = root.render<DocumentFragment>();
+                        expect(fragment.firstChild.nodeName).to.equal('UNDEFINED');
+                    });
+                });
+                describe('locateRange', () => {
+                    it('should locate where to set the range at end', async () => {
+                        const p = new SimpleElementNode(VNodeType.PARAGRAPH);
+                        p.append(new VNode(VNodeType.ROOT));
+                        p.append(new LineBreakNode());
+                        p.append(new VNode(VNodeType.ROOT));
+                        const doc = document.createElement('p');
+                        doc.innerHTML = '<span><span><br><span><span>';
+                        expect(p.lastChild().locateRange(doc.lastChild, 0)).to.deep.equal([
+                            p.lastChild(),
+                            'BEFORE',
+                        ]);
+                        expect(p.lastChild().locateRange(doc.lastChild, 1)).to.deep.equal([
+                            p.lastChild(),
+                            'AFTER',
+                        ]);
+                    });
+                    it('should locate where to set the range inside string', async () => {
+                        const p = new SimpleElementNode(VNodeType.PARAGRAPH);
+                        const a = new CharNode('a');
+                        p.append(a);
+                        const vNode = new VNode(VNodeType.ROOT);
+                        p.append(vNode);
+                        const b = new CharNode('b');
+                        p.append(b);
+                        const doc = document.createElement('p');
+                        doc.innerHTML = 'a<span><span>b';
+                        expect(vNode.locateRange(doc.childNodes[1], 0)).to.deep.equal([
+                            vNode,
+                            'BEFORE',
+                        ]);
+                        expect(vNode.locateRange(doc.childNodes[1], 1)).to.deep.equal([
+                            vNode,
+                            'AFTER',
+                        ]);
+                    });
+                });
+                describe('shallowDuplicate', () => {
+                    it('should ducplicate a VNode', async () => {
+                        const vNode = new VNode(VNodeType.ROOT);
+                        const copy = vNode.shallowDuplicate();
+                        expect(copy).to.not.equal(vNode);
+                        expect(vNode.type).to.equal(VNodeType.ROOT);
+                    });
+                });
+                describe('index', () => {
+                    it('should found the index of this VNode within its parent', async () => {
+                        const root = new VNode(VNodeType.ROOT);
+                        const p = new SimpleElementNode(VNodeType.PARAGRAPH);
+                        root.append(p);
+                        const h1 = new SimpleElementNode(VNodeType.HEADING1);
+                        root.append(h1);
+                        const a = new CharNode('a');
+                        root.append(a);
+                        const br = new LineBreakNode();
+                        root.append(br);
+                        const h2 = new SimpleElementNode(VNodeType.HEADING2);
+                        root.append(h2);
+                        const b = new CharNode('b');
+                        root.append(b);
+
+                        expect(root.length).to.equal(6);
+                        expect(p.index).to.equal(0);
+                        expect(h1.index).to.equal(1);
+                        expect(a.index).to.equal(2);
+                        expect(br.index).to.equal(3);
+                        expect(h2.index).to.equal(4);
+                        expect(b.index).to.equal(5);
+                    });
+                });
+                describe('text', () => {
+                    it('should concat all children CharNodes value', async () => {
+                        const root = new VNode(VNodeType.ROOT);
+                        const a = new CharNode('a');
+                        root.append(a);
+                        const b = new CharNode('b');
+                        root.append(b);
+                        const c = new CharNode('c');
+                        root.append(c);
+                        const p = new SimpleElementNode(VNodeType.PARAGRAPH);
+                        root.append(p);
+                        const d = new CharNode('d');
+                        p.append(d);
+                        const e = new CharNode('e');
+                        p.append(e);
+                        expect(root.text()).to.equal('abcde');
+                    });
+                });
+                describe('isBefore', () => {
+                    it('should return if the is before (after in same parent)', async () => {
+                        const root = new VNode(VNodeType.ROOT);
+                        const a = new CharNode('a');
+                        root.append(a);
+                        const b = new CharNode('b');
+                        root.append(b);
+                        const c = new CharNode('c');
+                        root.append(c);
+                        expect(a.isBefore(b)).to.equal(true);
+                        expect(a.isBefore(c)).to.equal(true);
+                        expect(b.isBefore(a)).to.equal(false);
+                        expect(b.isBefore(c)).to.equal(true);
+                        expect(c.isBefore(a)).to.equal(false);
+                    });
+                    it('should return if the is before (after in an other parent)', async () => {
+                        expect(a.isBefore(a)).to.equal(false, 'a isBefore a');
+                        expect(a.isBefore(b)).to.equal(true, 'a isBefore b');
+                        expect(a.isBefore(c)).to.equal(true, 'a isBefore c');
+                        expect(a.isBefore(d)).to.equal(true, 'a isBefore d');
+                        expect(a.isBefore(e)).to.equal(true, 'a isBefore e');
+                        expect(a.isBefore(f)).to.equal(true, 'a isBefore f');
+
+                        expect(b.isBefore(a)).to.equal(false, 'b isBefore a');
+                        expect(b.isBefore(b)).to.equal(false, 'b isBefore b');
+                        expect(b.isBefore(c)).to.equal(true, 'b isBefore c');
+                        expect(b.isBefore(d)).to.equal(true, 'b isBefore d');
+                        expect(b.isBefore(e)).to.equal(true, 'b isBefore e');
+                        expect(b.isBefore(f)).to.equal(true, 'b isBefore f');
+
+                        expect(c.isBefore(a)).to.equal(false, 'c isBefore a');
+                        expect(c.isBefore(b)).to.equal(false, 'c isBefore b');
+                        expect(c.isBefore(c)).to.equal(false, 'c isBefore c');
+                        expect(c.isBefore(d)).to.equal(true, 'c isBefore d');
+                        expect(c.isBefore(e)).to.equal(true, 'c isBefore e');
+                        expect(c.isBefore(f)).to.equal(true, 'c isBefore f');
+
+                        expect(d.isBefore(a)).to.equal(false, 'd isBefore a');
+                        expect(d.isBefore(b)).to.equal(false, 'd isBefore b');
+                        expect(d.isBefore(c)).to.equal(false, 'd isBefore c');
+                        expect(d.isBefore(d)).to.equal(false, 'd isBefore d');
+                        expect(d.isBefore(e)).to.equal(true, 'd isBefore e');
+                        expect(d.isBefore(f)).to.equal(true, 'd isBefore f');
+
+                        expect(e.isBefore(a)).to.equal(false, 'e isBefore a');
+                        expect(e.isBefore(b)).to.equal(false, 'e isBefore b');
+                        expect(e.isBefore(c)).to.equal(false, 'e isBefore c');
+                        expect(e.isBefore(d)).to.equal(false, 'e isBefore d');
+                        expect(e.isBefore(e)).to.equal(false, 'e isBefore e');
+                        expect(e.isBefore(f)).to.equal(true, 'e isBefore f');
+
+                        expect(f.isBefore(a)).to.equal(false, 'f isBefore a');
+                        expect(f.isBefore(b)).to.equal(false, 'f isBefore b');
+                        expect(f.isBefore(c)).to.equal(false, 'f isBefore c');
+                        expect(f.isBefore(d)).to.equal(false, 'f isBefore d');
+                        expect(f.isBefore(e)).to.equal(false, 'f isBefore e');
+                        expect(f.isBefore(f)).to.equal(false, 'f isBefore f');
+                    });
+                });
+                describe('isAfter', () => {
+                    it('should return if the is after (after in same parent)', async () => {
+                        const root = new VNode(VNodeType.ROOT);
+                        const a = new CharNode('a');
+                        root.append(a);
+                        const b = new CharNode('b');
+                        root.append(b);
+                        const c = new CharNode('c');
+                        root.append(c);
+                        expect(a.isAfter(b)).to.equal(false);
+                        expect(a.isAfter(c)).to.equal(false);
+                        expect(b.isAfter(a)).to.equal(true);
+                        expect(b.isAfter(c)).to.equal(false);
+                        expect(c.isAfter(a)).to.equal(true);
+                    });
+                    it('should return if the is after (after in an other parent)', async () => {
+                        expect(a.isAfter(a)).to.equal(false, 'a isAfter a');
+                        expect(a.isAfter(b)).to.equal(false, 'a isAfter b');
+                        expect(a.isAfter(c)).to.equal(false, 'a isAfter c');
+                        expect(a.isAfter(d)).to.equal(false, 'a isAfter d');
+                        expect(a.isAfter(e)).to.equal(false, 'a isAfter e');
+                        expect(a.isAfter(f)).to.equal(false, 'a isAfter f');
+
+                        expect(b.isAfter(a)).to.equal(true, 'b isAfter a');
+                        expect(b.isAfter(b)).to.equal(false, 'b isAfter b');
+                        expect(b.isAfter(c)).to.equal(false, 'b isAfter c');
+                        expect(b.isAfter(d)).to.equal(false, 'b isAfter d');
+                        expect(b.isAfter(e)).to.equal(false, 'b isAfter e');
+                        expect(b.isAfter(f)).to.equal(false, 'b isAfter f');
+
+                        expect(c.isAfter(a)).to.equal(true, 'c isAfter a');
+                        expect(c.isAfter(b)).to.equal(true, 'c isAfter b');
+                        expect(c.isAfter(c)).to.equal(false, 'c isAfter c');
+                        expect(c.isAfter(d)).to.equal(false, 'c isAfter d');
+                        expect(c.isAfter(e)).to.equal(false, 'c isAfter e');
+                        expect(c.isAfter(f)).to.equal(false, 'c isAfter f');
+
+                        expect(d.isAfter(a)).to.equal(true, 'd isAfter a');
+                        expect(d.isAfter(b)).to.equal(true, 'd isAfter b');
+                        expect(d.isAfter(c)).to.equal(true, 'd isAfter c');
+                        expect(d.isAfter(d)).to.equal(false, 'd isAfter d');
+                        expect(d.isAfter(e)).to.equal(false, 'd isAfter e');
+                        expect(d.isAfter(f)).to.equal(false, 'd isAfter f');
+
+                        expect(e.isAfter(a)).to.equal(true, 'e isAfter a');
+                        expect(e.isAfter(b)).to.equal(true, 'e isAfter b');
+                        expect(e.isAfter(c)).to.equal(true, 'e isAfter c');
+                        expect(e.isAfter(d)).to.equal(true, 'e isAfter d');
+                        expect(e.isAfter(e)).to.equal(false, 'e isAfter e');
+                        expect(e.isAfter(f)).to.equal(false, 'e isAfter f');
+
+                        expect(f.isAfter(a)).to.equal(true, 'f isAfter a');
+                        expect(f.isAfter(b)).to.equal(true, 'f isAfter b');
+                        expect(f.isAfter(c)).to.equal(true, 'f isAfter c');
+                        expect(f.isAfter(d)).to.equal(true, 'f isAfter d');
+                        expect(f.isAfter(e)).to.equal(true, 'f isAfter e');
+                        expect(f.isAfter(f)).to.equal(false, 'f isAfter f');
+                    });
+                });
+                describe('nthChild', () => {
+                    it('should return the child at given index', async () => {
+                        expect(root.nthChild(0)).to.equal(a);
+                        expect(root.nthChild(1)).to.equal(h1);
+                        expect(root.nthChild(2)).to.equal(c);
+                        expect(root.nthChild(3)).to.equal(p);
+                    });
+                });
+                describe('siblings', () => {
+                    it('should return the node siblings', async () => {
+                        expect(h1.siblings).to.deep.equal([a, h1, c, p]);
+                        expect(b.siblings).to.deep.equal([b], 'siblings without the range');
+                        expect(root.siblings).to.deep.equal([]);
+                    });
+                    it('should return the node siblings with the range', async () => {
+                        utils.withRange(() => {
+                            expect(h1.siblings).to.deep.equal([a, h1, c, p]);
+                            expect(b.siblings).to.deep.equal([tail, b]);
+                            expect(root.siblings).to.deep.equal([]);
+                        });
+                    });
+                });
+                describe('firstChild', () => {
+                    it('should return the firstChild node', async () => {
+                        expect(root.firstChild()).to.deep.equal(a, 'root.firstChild = a');
+                        expect(h1.firstChild()).to.deep.equal(
+                            b,
+                            'h1.firstChild = b (not the range)',
+                        );
+                        expect(p.firstChild()).to.deep.equal(d, 'p.firstChild = d');
+                        expect(pp.firstChild()).to.deep.equal(e, 'pp.firstChild = e');
+                    });
+                    it('should return the firstChild node with predicate without result', async () => {
+                        expect(
+                            root.firstChild(() => {
+                                return false;
+                            }),
+                        ).to.equal(undefined);
+                    });
+                    it('should return the firstChild node with predicate', async () => {
+                        expect(
+                            root.firstChild(vNode => {
+                                return vNode instanceof CharNode;
+                            }),
+                        ).to.equal(a);
+                        expect(
+                            root.firstChild(vNode => {
+                                return vNode instanceof SimpleElementNode;
+                            }),
+                        ).to.equal(h1);
+                    });
+                });
+                describe('lastChild', () => {
+                    it('should return the lastChild node', async () => {
+                        expect(root.lastChild()).to.deep.equal(p, 'root.lastChild = p');
+                        expect(h1.lastChild()).to.deep.equal(b, 'h1.lastChild = b');
+                        expect(p.lastChild()).to.deep.equal(pp, 'p.lastChild = pp');
+                        expect(pp.lastChild()).to.deep.equal(f, 'pp.lastChild = f');
+                    });
+                    it('should return the lastChild node with predicate without result', async () => {
+                        expect(
+                            root.lastChild(() => {
+                                return false;
+                            }),
+                        ).to.equal(undefined);
+                    });
+                    it('should return the lastChild node with predicate', async () => {
+                        expect(
+                            root.lastChild(vNode => {
+                                return vNode instanceof CharNode;
+                            }),
+                        ).to.equal(c);
+                        expect(
+                            root.lastChild(vNode => {
+                                return vNode instanceof SimpleElementNode;
+                            }),
+                        ).to.equal(p);
+                    });
+                });
+                describe('firstLeaf', () => {
+                    it('should return the firstLeaf', async () => {
+                        expect(root.firstLeaf()).to.deep.equal(a, 'root.firstLeaf = a');
+                        expect(h1.firstLeaf()).to.deep.equal(b, 'h1.firstLeaf = b');
+                        expect(p.firstLeaf()).to.deep.equal(d, 'p.firstLeaf = d');
+                        expect(pp.firstLeaf()).to.deep.equal(e, 'pp.firstLeaf = e');
+                    });
+                    it('should return the firstLeaf with predicate without result', async () => {
+                        expect(
+                            root.firstLeaf(() => {
+                                return false;
+                            }),
+                        ).to.equal(undefined);
+                        expect(
+                            root.firstLeaf(vNode => {
+                                return vNode.id === tail.id;
+                            }),
+                        ).to.equal(undefined);
+                    });
+                    it('should return the firstLeaf with predicate', async () => {
+                        expect(
+                            root.firstLeaf(vNode => {
+                                return vNode.id === e.id;
+                            }),
+                        ).to.equal(e);
+                    });
+                    it('should return itself if is firstLeaf', async () => {
+                        expect(b.firstLeaf()).to.deep.equal(b);
+                    });
+                });
+                describe('lastLeaf', () => {
+                    it('should return the lastLeaf', async () => {
+                        expect(root.lastLeaf()).to.deep.equal(f, 'root.lastLeaf = a');
+                        expect(h1.lastLeaf()).to.deep.equal(b, 'h1.lastLeaf = b');
+                        expect(p.lastLeaf()).to.deep.equal(f, 'p.lastLeaf = d');
+                        expect(pp.lastLeaf()).to.deep.equal(f, 'pp.lastLeaf = e');
+                    });
+                    it('should return the lastLeaf with predicate without result', async () => {
+                        expect(
+                            root.lastLeaf(() => {
+                                return false;
+                            }),
+                        ).to.equal(undefined);
+                        expect(
+                            root.lastLeaf(vNode => {
+                                return vNode.id === tail.id;
+                            }),
+                        ).to.equal(undefined);
+                    });
+                    it('should return the lastLeaf with predicate', async () => {
+                        expect(
+                            root.lastLeaf(vNode => {
+                                return vNode.id === e.id;
+                            }),
+                        ).to.equal(e);
+                    });
+                    it('should return itself if is lastLeaf', async () => {
+                        expect(b.lastLeaf()).to.deep.equal(b);
+                    });
+                });
+                describe('firstDescendant', () => {
+                    it('should return the firstDescendant', async () => {
+                        expect(root.firstDescendant()).to.deep.equal(a, 'root.firstDescendant = a');
+                        expect(h1.firstDescendant()).to.deep.equal(
+                            b,
+                            'h1.firstDescendant = b (not the range)',
+                        );
+                        expect(p.firstDescendant()).to.deep.equal(d, 'p.firstDescendant = d');
+                        expect(pp.firstDescendant()).to.deep.equal(e, 'pp.firstDescendant = e');
+                    });
+                    it('should return the firstDescendant with predicate without result', async () => {
+                        expect(a.firstDescendant()).to.deep.equal(undefined);
+                        expect(
+                            root.firstDescendant(() => {
+                                return false;
+                            }),
+                        ).to.equal(undefined);
+                        expect(
+                            root.firstDescendant(vNode => {
+                                return vNode.id === tail.id;
+                            }),
+                        ).to.equal(undefined);
+                    });
+                    it('should return the firstDescendant with predicate', async () => {
+                        expect(
+                            root.firstDescendant(vNode => {
+                                return vNode.id === pp.id;
+                            }),
+                        ).to.equal(pp);
+                    });
+                });
+                describe('lastDescendant', () => {
+                    it('should return the lastDescendant', async () => {
+                        expect(root.lastDescendant()).to.deep.equal(f, 'root.lastDescendant = p');
+                        expect(h1.lastDescendant()).to.deep.equal(
+                            b,
+                            'h1.lastDescendant = b (not the range)',
+                        );
+                        expect(p.lastDescendant()).to.deep.equal(f, 'p.lastDescendant = f');
+                        expect(pp.lastDescendant()).to.deep.equal(f, 'pp.lastDescendant = f');
+                    });
+                    it('should return the lastDescendant with predicate without result', async () => {
+                        expect(a.lastDescendant()).to.deep.equal(undefined);
+                        expect(
+                            root.lastDescendant(() => {
+                                return false;
+                            }),
+                        ).to.equal(undefined);
+                        expect(
+                            root.lastDescendant(vNode => {
+                                return vNode.id === tail.id;
+                            }),
+                        ).to.equal(undefined);
+                    });
+                    it('should return the lastDescendant with predicate', async () => {
+                        expect(
+                            root.lastDescendant(vNode => {
+                                return vNode.id === pp.id;
+                            }),
+                        ).to.equal(pp);
+                    });
+                });
+                describe('previousSibling', () => {
+                    it('should return the previousSibling', async () => {
+                        expect(h1.previousSibling()).to.deep.equal(a, 'h1.previousSibling = a');
+                        expect(p.previousSibling()).to.deep.equal(c, 'p.previousSibling = c');
+                        expect(pp.previousSibling()).to.deep.equal(d, 'pp.previousSibling = d');
+                        expect(f.previousSibling()).to.deep.equal(e, 'f.previousSibling = e');
+                    });
+                    it('should return the previousSibling with predicate without result', async () => {
+                        expect(root.previousSibling()).to.deep.equal(undefined);
+                        expect(d.previousSibling()).to.deep.equal(undefined);
+                        expect(
+                            root.previousSibling(() => {
+                                return false;
+                            }),
+                        ).to.equal(undefined);
+                        expect(
+                            b.previousSibling(vNode => {
+                                return vNode.id === tail.id;
+                            }),
+                        ).to.equal(undefined);
+                    });
+                    it('should return the previousSibling with predicate', async () => {
+                        expect(
+                            p.previousSibling(vNode => {
+                                return vNode.id === a.id;
+                            }),
+                        ).to.equal(a);
+                    });
+                });
+                describe('nextSibling', () => {
+                    it('should return the nextSibling', async () => {
+                        expect(h1.nextSibling()).to.deep.equal(c, 'h1.nextSibling = c');
+                        expect(d.nextSibling()).to.deep.equal(pp, 'd.nextSibling = pp');
+                        expect(e.nextSibling()).to.deep.equal(f, 'e.nextSibling = f');
+                    });
+                    it('should return the nextSibling with predicate without result', async () => {
+                        expect(root.nextSibling()).to.deep.equal(undefined);
+                        expect(pp.nextSibling()).to.deep.equal(undefined);
+                        expect(
+                            root.nextSibling(() => {
+                                return false;
+                            }),
+                        ).to.equal(undefined);
+                        expect(
+                            f.nextSibling(vNode => {
+                                return vNode.id === head.id;
+                            }),
+                        ).to.equal(undefined);
+                    });
+                    it('should return the nextSibling with predicate', async () => {
+                        expect(
+                            h1.nextSibling(vNode => {
+                                return vNode.id === p.id;
+                            }),
+                        ).to.equal(p);
+                    });
+                });
+                describe('previous', () => {
+                    it('should return the previous node', async () => {
+                        expect(h1.previous()).to.deep.equal(a, 'h1.previous = a');
+                        expect(p.previous()).to.deep.equal(c, 'p.previous = c');
+                        expect(pp.previous()).to.deep.equal(d, 'pp.previous = d');
+                        expect(f.previous()).to.deep.equal(e, 'f.previous = e');
+                    });
+                    it('should return the previous with predicate without result', async () => {
+                        expect(root.previous()).to.deep.equal(undefined);
+                        expect(
+                            root.previous(() => {
+                                return false;
+                            }),
+                        ).to.equal(undefined);
+                        expect(
+                            b.previous(vNode => {
+                                return vNode.id === tail.id;
+                            }),
+                        ).to.equal(undefined);
+                    });
+                    it('should return the previous with predicate', async () => {
+                        expect(
+                            pp.previous(vNode => {
+                                return vNode.id === b.id;
+                            }),
+                        ).to.equal(b);
+                    });
+                });
+                describe('next', () => {
+                    it('should return the next', async () => {
+                        expect(root.next()).to.deep.equal(a, 'root.next = a');
+                        expect(h1.next()).to.deep.equal(b, 'h1.next = b');
+                        expect(d.next()).to.deep.equal(pp, 'd.next = pp');
+                        expect(e.next()).to.deep.equal(f, 'e.next = f');
+                    });
+                    it('should return the next with predicate without result', async () => {
+                        expect(f.next()).to.deep.equal(undefined);
+                        expect(
+                            root.next(() => {
+                                return false;
+                            }),
+                        ).to.equal(undefined);
+                        expect(
+                            a.next(vNode => {
+                                return vNode.id === head.id;
+                            }),
+                        ).to.equal(undefined);
+                    });
+                    it('should return the next with predicate', async () => {
+                        expect(
+                            b.next(vNode => {
+                                return vNode.id === e.id;
+                            }),
+                        ).to.equal(e);
+                    });
+                });
+                describe('previousLeaf', () => {
+                    it('should return the previousLeaf node', async () => {
+                        expect(h1.previousLeaf()).to.deep.equal(a, 'h1.previousLeaf = a');
+                        expect(c.previousLeaf()).to.deep.equal(b, 'c.previousLeaf = b');
+                        expect(e.previousLeaf()).to.deep.equal(d, 'e.previousLeaf = d');
+                        expect(f.previousLeaf()).to.deep.equal(e, 'f.previousLeaf = e');
+                    });
+                    it('should return the previousLeaf with predicate without result', async () => {
+                        expect(root.previousLeaf()).to.deep.equal(undefined);
+                        expect(
+                            root.previousLeaf(() => {
+                                return false;
+                            }),
+                        ).to.equal(undefined);
+                        expect(
+                            b.previousLeaf(vNode => {
+                                return vNode.id === tail.id;
+                            }),
+                        ).to.equal(undefined);
+                    });
+                    it('should return the previousLeaf with predicate', async () => {
+                        expect(
+                            e.previousLeaf(vNode => {
+                                return vNode.id === b.id;
+                            }),
+                        ).to.equal(b);
+                        expect(
+                            e.previousLeaf(vNode => {
+                                return vNode instanceof CharNode;
+                            }),
+                        ).to.equal(d);
+                    });
+                });
+                describe('nextLeaf', () => {
+                    it('should return the nextLeaf node', async () => {
+                        expect(root.nextLeaf()).to.deep.equal(a, 'root.nextLeaf = a');
+                        expect(h1.nextLeaf()).to.deep.equal(b, 'h1.nextLeaf = b');
+                        expect(c.nextLeaf()).to.deep.equal(d, 'c.nextLeaf = d');
+                        expect(b.nextLeaf()).to.deep.equal(c, 'b.nextLeaf = c');
+                    });
+                    it('should return the nextLeaf with predicate without result', async () => {
+                        expect(f.nextLeaf()).to.deep.equal(undefined);
+                        expect(
+                            root.nextLeaf(() => {
+                                return false;
+                            }),
+                        ).to.equal(undefined);
+                        expect(
+                            b.nextLeaf(vNode => {
+                                return vNode.id === tail.id;
+                            }),
+                        ).to.equal(undefined);
+                    });
+                    it('should return the nextLeaf with predicate', async () => {
+                        expect(
+                            b.nextLeaf(vNode => {
+                                return vNode.id === e.id;
+                            }),
+                        ).to.equal(e);
+                        expect(
+                            b.nextLeaf(vNode => {
+                                return vNode instanceof CharNode;
+                            }),
+                        ).to.equal(c);
+                    });
+                });
+                describe('previousSiblings', () => {
+                    it('should return the previousSiblings', async () => {
+                        expect(h1.previousSiblings()).to.deep.equal(
+                            [a],
+                            'h1.previousSiblings = [a]',
+                        );
+                        expect(p.previousSiblings()).to.deep.equal(
+                            [c, h1, a],
+                            'p.previousSiblings = [c, h1, a]',
+                        );
+                        expect(pp.previousSiblings()).to.deep.equal(
+                            [d],
+                            'pp.previousSiblings = [d]',
+                        );
+                        expect(f.previousSiblings()).to.deep.equal([e], 'f.previousSiblings = [e]');
+                    });
+                    it('should return the previousSiblings with predicate without result', async () => {
+                        expect(root.previousSiblings()).to.deep.equal([]);
+                        expect(d.previousSiblings()).to.deep.equal([]);
+                        expect(
+                            root.previousSiblings(() => {
+                                return false;
+                            }),
+                        ).to.deep.equal([]);
+                        expect(
+                            b.previousSiblings(vNode => {
+                                return vNode.id === tail.id;
+                            }),
+                        ).to.deep.equal([]);
+                    });
+                    it('should return the previousSiblings with predicate', async () => {
+                        expect(
+                            p.previousSiblings(vNode => {
+                                return vNode instanceof CharNode;
+                            }),
+                        ).to.deep.equal([c]);
+                    });
+                });
+                describe('nextSiblings', () => {
+                    it('should return the nextSiblings', async () => {
+                        expect(h1.nextSiblings()).to.deep.equal([c, p], 'h1.nextSiblings = [c, p]');
+                        expect(d.nextSiblings()).to.deep.equal([pp], 'd.nextSiblings = [pp]');
+                        expect(e.nextSiblings()).to.deep.equal([f], 'e.nextSiblings = [f]');
+                    });
+                    it('should return the nextSiblings with predicate without result', async () => {
+                        expect(root.nextSiblings()).to.deep.equal([]);
+                        expect(pp.nextSiblings()).to.deep.equal([]);
+                        expect(
+                            root.nextSiblings(() => {
+                                return false;
+                            }),
+                        ).to.deep.equal([]);
+                        expect(
+                            e.nextSiblings(vNode => {
+                                return vNode.id === head.id;
+                            }),
+                        ).to.deep.equal([]);
+                    });
+                    it('should return the nextSiblings with predicate', async () => {
+                        expect(
+                            p.previousSiblings(vNode => {
+                                return vNode instanceof CharNode;
+                            }),
+                        ).to.deep.equal([c]);
+                    });
+                });
+                describe('walk', () => {
+                    it('should walk', async () => {
+                        expect(
+                            h1.walk(vNode => vNode.next(), vNode => vNode instanceof CharNode),
+                        ).to.deep.equal(b);
+                    });
+                });
+                describe('before', () => {
+                    it('should insert before node', async () => {
+                        const root = new VNode(VNodeType.ROOT);
+                        const a = new CharNode('a');
+                        root.append(a);
+                        const b = new CharNode('b');
+                        a.before(b);
+                        const c = new CharNode('c');
+                        a.before(c);
+                        expect(a.siblings).to.deep.equal([b, c, a]);
+                    });
+                });
+                describe('after', () => {
+                    it('should insert after node', async () => {
+                        const root = new VNode(VNodeType.ROOT);
+                        const a = new CharNode('a');
+                        root.append(a);
+                        const b = new CharNode('b');
+                        a.after(b);
+                        const c = new CharNode('c');
+                        a.after(c);
+                        expect(a.siblings).to.deep.equal([a, c, b]);
+                    });
+                    it('should move a node after another', async () => {
+                        const root = new VNode(VNodeType.ROOT);
+                        const a = new CharNode('a');
+                        root.append(a);
+                        const b = new CharNode('b');
+                        root.append(b);
+                        const c = new CharNode('c');
+                        root.append(c);
+                        b.after(a);
+                        expect(a.siblings).to.deep.equal([b, a, c]);
+                    });
+                });
+                describe('insertBefore', () => {
+                    it('should insert insert before node', async () => {
+                        const root = new VNode(VNodeType.ROOT);
+                        const a = new CharNode('a');
+                        root.append(a);
+                        const b = new CharNode('b');
+                        root.insertBefore(b, a);
+                        const c = new CharNode('c');
+                        root.insertBefore(c, a);
+                        expect(a.siblings).to.deep.equal([b, c, a]);
+                    });
+                    it('should throw when try to insert before unknown node', async () => {
+                        expect(() => {
+                            root.insertBefore(c, new CharNode('d'));
+                        }).to.throw('child');
+                    });
+                });
+                describe('insertAfter', () => {
+                    it('should insert insert after node', async () => {
+                        const root = new VNode(VNodeType.ROOT);
+                        const a = new CharNode('a');
+                        root.append(a);
+                        const b = new CharNode('b');
+                        root.insertAfter(b, a);
+                        const c = new CharNode('c');
+                        root.insertAfter(c, a);
+                        expect(a.siblings).to.deep.equal([a, c, b]);
+                    });
+                    it('should throw when try to insert after unknown node', async () => {
+                        expect(() => {
+                            root.insertAfter(c, new CharNode('d'));
+                        }).to.throw('child');
+                    });
+                });
+                describe('remove', () => {
+                    it('should remove node itself', async () => {
+                        const root = new VNode(VNodeType.ROOT);
+                        const a = new CharNode('a');
+                        root.append(a);
+                        const b = new CharNode('b');
+                        root.append(b);
+                        const c = new CharNode('c');
+                        root.append(c);
+                        expect(a.siblings).to.deep.equal([a, b, c]);
+                        b.remove();
+                        expect(a.siblings).to.deep.equal([a, c]);
+                    });
+                });
+                describe('removeChild', () => {
+                    it('should remove a child', async () => {
+                        const root = new VNode(VNodeType.ROOT);
+                        const a = new CharNode('a');
+                        root.append(a);
+                        const b = new CharNode('b');
+                        root.append(b);
+                        const c = new CharNode('c');
+                        root.append(c);
+                        expect(a.siblings).to.deep.equal([a, b, c]);
+                        root.removeChild(b);
+                        expect(a.siblings).to.deep.equal([a, c]);
+                    });
+                    it('should throw when try to remove a unknown node', async () => {
+                        expect(() => {
+                            root.removeChild(new CharNode('d'));
+                        }).to.throw('child');
+                    });
+                });
+                describe('splitAt', () => {
+                    it('should split a paragraph', async () => {
+                        const root = new RootNode();
+                        const p = new VNode(VNodeType.PARAGRAPH);
+                        root.append(p);
+                        const a = new CharNode('a');
+                        p.append(a);
+                        const b = new CharNode('b');
+                        p.append(b);
+                        const c = new CharNode('c');
+                        p.append(c);
+                        p.splitAt(b);
+                        expect(p.children).to.deep.equal([a]);
+                        expect(p.nextSibling().children).to.deep.equal([b, c]);
+                    });
+                    it('should split a paragraph with range', async () => {
+                        const root = new RootNode();
+                        const p = new VNode(VNodeType.PARAGRAPH);
+                        root.append(p);
+                        const a = new CharNode('a');
+                        p.append(a);
+                        const tail = new RangeNode('tail');
+                        p.append(tail);
+                        const b = new CharNode('b');
+                        p.append(b);
+                        const head = new RangeNode('head');
+                        p.append(head);
+                        const c = new CharNode('c');
+                        p.append(c);
+                        p.splitAt(b);
+                        expect(p.children).to.deep.equal([a, tail]);
+                        expect(p.nextSibling().children).to.deep.equal([b, head, c]);
+                    });
+                });
+            });
+        });
+    });
+});

--- a/packages/plugin-devtools/assets/DevTools.xml
+++ b/packages/plugin-devtools/assets/DevTools.xml
@@ -27,7 +27,7 @@
     <!-- INSPECTOR.Tree -->
     <devtools-node t-name="TreeComponent"
         t-att-class="{
-            element: props.vNode.length and !props.vNode.value,
+            element: props.vNode.length and !props.vNode.char,
             folded: state.folded,
             root: props.isRoot,
             'self-closing': props.vNode.length == 0,
@@ -51,7 +51,7 @@
                 }">
                 <b><t t-esc="repr"/></b>
             </span>
-            <span t-elif="props.vNode.value" t-on-click="onClickNode"
+            <span t-elif="props.vNode.char" t-on-click="onClickNode"
                 t-on-dblclick="onDblClickNode"
                 class="selectable-line" t-att-class="{
                     bold: props.vNode.format.bold,
@@ -119,8 +119,8 @@
     <t t-name="infoVNode">
         <div class="about">
             <span class="type">VNode</span> <t t-esc="props.vNode.type or &quot;?&quot;"/>
-            <t t-if="props.vNode.value">:
-                "<t t-esc="props.vNode.value"/>"
+            <t t-if="props.vNode.char">:
+                "<t t-esc="props.vNode.char"/>"
             </t>
             <span class="id"><t t-esc="props.vNode.id"/></span>
         </div>
@@ -136,9 +136,9 @@
                         <td>type</td>
                         <td><t t-esc="props.vNode.type or &quot;UNKNOWN&quot;"/></td>
                     </tr>
-                    <tr t-if="props.vNode.value">
-                        <td>value</td>
-                        <td>"<t t-esc="props.vNode.value"/>"</td>
+                    <tr t-if="props.vNode.char">
+                        <td>char</td>
+                        <td>"<t t-esc="props.vNode.char"/>"</td>
                     </tr>
                     <tr>
                         <td>length</td>

--- a/packages/plugin-devtools/assets/DevTools.xml
+++ b/packages/plugin-devtools/assets/DevTools.xml
@@ -154,7 +154,7 @@
                             <t t-esc="'' + props.vNode.atomic"/>
                         </td>
                     </tr>
-                    <tr t-if="props.vNode.hasFormat()">
+                    <tr t-if="props.vNode.format">
                         <td>format</td>
                         <td>
                             <ol style="list-style-type: none">
@@ -163,10 +163,6 @@
                                 <li t-if="props.vNode.format.underline">Underline</li>
                             </ol>
                         </td>
-                    </tr>
-                    <tr>
-                        <td>original tag</td>
-                        <td><t t-esc="props.vNode.originalTag or &quot;None&quot;"/></td>
                     </tr>
                     <tr t-if="props.vNode.text().length">
                         <td>text</td>

--- a/packages/plugin-devtools/assets/DevTools.xml
+++ b/packages/plugin-devtools/assets/DevTools.xml
@@ -146,7 +146,7 @@
                     </tr>
                     <tr>
                         <td>total length</td>
-                        <td><t t-esc="props.vNode.totalLength()"/></td>
+                        <td><t t-esc="totalLength(props.vNode)"/></td>
                     </tr>
                     <tr>
                         <td>atomic</td>

--- a/packages/plugin-devtools/assets/DevTools.xml
+++ b/packages/plugin-devtools/assets/DevTools.xml
@@ -157,16 +157,27 @@
                     <tr t-if="props.vNode.format">
                         <td>format</td>
                         <td>
-                            <ol style="list-style-type: none">
+                            <ol t-if="Object.keys(props.vNode.format).length" style="list-style-type: none">
                                 <li t-if="props.vNode.format.bold">bold</li>
                                 <li t-if="props.vNode.format.italic">italic</li>
                                 <li t-if="props.vNode.format.underline">underline</li>
                             </ol>
+                            <t t-else="">{}</t>
                         </td>
                     </tr>
                     <tr t-if="props.vNode.text().length">
                         <td>text</td>
                         <td>"<t t-esc="props.vNode.text()"/>"</td>
+                    </tr>
+                </tbody>
+            </table>
+            <t t-set="customPropsNames" t-value="Object.keys(props.vNode)"/>
+            <div class="divider" t-if="Object.keys(nodeCustomProperties(props.vNode)).length">📖 My Custom Properties</div>
+            <table>
+                <tbody>
+                    <tr t-foreach="nodeCustomProperties(props.vNode)" t-as="prop" t-key="prop_index">
+                        <td><t t-esc="prop.key"/></td>
+                        <td><t t-esc="prop.value"/></td>
                     </tr>
                 </tbody>
             </table>

--- a/packages/plugin-devtools/assets/DevTools.xml
+++ b/packages/plugin-devtools/assets/DevTools.xml
@@ -44,7 +44,7 @@
             <t t-call="treeChildren"/>
         </t>
         <t t-else="">
-            <span t-if="props.vNode.type == 'RANGE_TAIL' or props.vNode.type == 'RANGE_HEAD'"
+            <span t-if="props.vNode.type == 'range_tail' or props.vNode.type == 'range_head'"
                 t-on-click="onClickNode" t-on-dblclick="onDblClickNode"
                 class="selectable-line range-node" t-att-class="{
                     selected: props.selectedID == props.vNode.id,
@@ -54,9 +54,9 @@
             <span t-elif="props.vNode.char" t-on-click="onClickNode"
                 t-on-dblclick="onDblClickNode"
                 class="selectable-line" t-att-class="{
-                    bold: props.vNode.format.bold,
-                    italic: props.vNode.format.italic,
-                    underline: props.vNode.format.underline,
+                    bold: props.vNode.format and props.vNode.format.bold,
+                    italic: props.vNode.format and props.vNode.format.italic,
+                    underline: props.vNode.format and props.vNode.format.underline,
                     selected: props.selectedID == props.vNode.id,
                 }">
                 <t t-esc="repr"/>
@@ -65,11 +65,11 @@
                 <span class="element-name selectable-line" t-on-click="onClickNode"
                     t-on-dblclick="onDblClickNode"
                     t-att-class="{
-                        bold: props.vNode.format.bold,
-                        italic: props.vNode.format.italic,
-                        underline: props.vNode.format.underline,
+                        bold: props.vNode.format and props.vNode.format.bold,
+                        italic: props.vNode.format and props.vNode.format.italic,
+                        underline: props.vNode.format and props.vNode.format.underline,
                         selected: props.selectedID == props.vNode.id,
-                        'line-break': props.vNode.type === 'LINE_BREAK',
+                        'line-break': props.vNode.type === 'line_break',
                     }">
                     <t t-esc="repr"/>
                 </span>
@@ -118,7 +118,7 @@
     <!-- INSPECTOR.Info.vNode -->
     <t t-name="infoVNode">
         <div class="about">
-            <span class="type">VNode</span> <t t-esc="props.vNode.type or &quot;?&quot;"/>
+            <span class="type"><t t-esc="className(props.vNode)"/></span> <t t-esc="props.vNode.type or &quot;?&quot;"/>
             <t t-if="props.vNode.char">:
                 "<t t-esc="props.vNode.char"/>"
             </t>
@@ -158,9 +158,9 @@
                         <td>format</td>
                         <td>
                             <ol style="list-style-type: none">
-                                <li t-if="props.vNode.format.bold">Bold</li>
-                                <li t-if="props.vNode.format.italic">Italic</li>
-                                <li t-if="props.vNode.format.underline">Underline</li>
+                                <li t-if="props.vNode.format.bold">bold</li>
+                                <li t-if="props.vNode.format.italic">italic</li>
+                                <li t-if="props.vNode.format.underline">underline</li>
                             </ol>
                         </td>
                     </tr>

--- a/packages/plugin-devtools/assets/DevTools.xml
+++ b/packages/plugin-devtools/assets/DevTools.xml
@@ -148,12 +148,10 @@
                         <td>total length</td>
                         <td><t t-esc="props.vNode.totalLength()"/></td>
                     </tr>
-                    <tr t-if="props.vNode.hasProperties()">
-                        <td>properties</td>
+                    <tr>
+                        <td>atomic</td>
                         <td>
-                            <ol style="list-style-type: none">
-                                <li t-if="props.vNode.properties.atomic">Atomic</li>
-                            </ol>
+                            <t t-esc="'' + props.vNode.atomic"/>
                         </td>
                     </tr>
                     <tr t-if="props.vNode.hasFormat()">

--- a/packages/plugin-devtools/src/components/CommandsComponent.ts
+++ b/packages/plugin-devtools/src/components/CommandsComponent.ts
@@ -40,24 +40,11 @@ export class CommandsComponent extends OwlUIComponent<CommandsProps> {
      *
      * @param value
      */
-    formatPayloadValue(value: Node | string | boolean | number): string {
+    formatPayloadValue(value: Node | string | boolean | number | object): string {
         if (value && value instanceof Node && value.nodeName) {
             return '<' + value.nodeName.toLowerCase() + '>';
         }
-        switch (value) {
-            case true:
-                return 'true';
-            case false:
-                return 'false';
-            case null:
-                return 'null';
-            case 0:
-                return '0';
-            case undefined:
-                return 'undefined';
-            default:
-                return '' + value;
-        }
+        return '' + value;
     }
     /**
      * Return the command handler corresponding to the given token.

--- a/packages/plugin-devtools/src/components/InfoComponent.ts
+++ b/packages/plugin-devtools/src/components/InfoComponent.ts
@@ -31,6 +31,9 @@ export class InfoComponent extends OwlUIComponent<{}> {
             vNode: vNode,
         });
     }
+    className(vNode: VNode): string {
+        return vNode.constructor.name;
+    }
 
     //--------------------------------------------------------------------------
     // Private

--- a/packages/plugin-devtools/src/components/InfoComponent.ts
+++ b/packages/plugin-devtools/src/components/InfoComponent.ts
@@ -1,6 +1,6 @@
 import { OwlUIComponent } from '../../../owl-ui/src/OwlUIComponent';
 import { VRange } from '../../../core/src/VRange';
-import { VNode } from '../../../core/src/VNode';
+import { VNode } from '../../../core/src/VNodes/VNode';
 
 interface InfoState {
     currentTab: string;

--- a/packages/plugin-devtools/src/components/InfoComponent.ts
+++ b/packages/plugin-devtools/src/components/InfoComponent.ts
@@ -41,7 +41,6 @@ export class InfoComponent extends OwlUIComponent<{}> {
         const prevSibling = rangeNode.previousSibling();
         const position = nextSibling ? 'BEFORE' : prevSibling ? 'AFTER' : 'INSIDE';
         const reference = nextSibling || prevSibling || rangeNode.parent;
-        const nodeRepr = reference.value || reference.type;
-        return `${position} ${reference.id} (${nodeRepr})`;
+        return `${position} ${reference.id} (${reference.name})`;
     }
 }

--- a/packages/plugin-devtools/src/components/InfoComponent.ts
+++ b/packages/plugin-devtools/src/components/InfoComponent.ts
@@ -6,6 +6,7 @@ interface InfoState {
     currentTab: string;
     range: VRange;
 }
+const vNodeKeys = Object.keys(new VNode('default'));
 export class InfoComponent extends OwlUIComponent<{}> {
     state: InfoState = {
         currentTab: 'vNode',
@@ -34,6 +35,31 @@ export class InfoComponent extends OwlUIComponent<{}> {
     className(vNode: VNode): string {
         return vNode.constructor.name;
     }
+    /**
+     * Return an object representing the given VNode's public properties as
+     * alphabetically sorted pairs of key and value strings.
+     *
+     * @param vNode
+     */
+    nodeCustomProperties(vNode: VNode): { [key: string]: string }[] {
+        return Object.keys(vNode)
+            .filter(key => !key.startsWith('_') && !vNodeKeys.includes(key))
+            .sort()
+            .map(key => {
+                let value = '' + vNode[key];
+                if (typeof vNode[key] === 'object') {
+                    if (!vNode[key] || !Object.keys(vNode[key]).length) {
+                        value = '{}';
+                    } else if (vNode[key].toString === {}.toString) {
+                        value = this._objectRepr(vNode[key]);
+                    }
+                }
+                if (typeof vNode[key] === 'string') {
+                    value = '"' + value + '"';
+                }
+                return { key: key, value: value };
+            });
+    }
 
     //--------------------------------------------------------------------------
     // Private
@@ -45,5 +71,13 @@ export class InfoComponent extends OwlUIComponent<{}> {
         const position = nextSibling ? 'BEFORE' : prevSibling ? 'AFTER' : 'INSIDE';
         const reference = nextSibling || prevSibling || rangeNode.parent;
         return `${position} ${reference.id} (${reference.name})`;
+    }
+    _objectRepr(obj: object): string {
+        return Object.keys(obj)
+            .filter(key => key !== 'toString')
+            .map(key => {
+                return key + ': ' + obj[key];
+            })
+            .join('\n');
     }
 }

--- a/packages/plugin-devtools/src/components/InfoComponent.ts
+++ b/packages/plugin-devtools/src/components/InfoComponent.ts
@@ -60,6 +60,20 @@ export class InfoComponent extends OwlUIComponent<{}> {
                 return { key: key, value: value };
             });
     }
+    /**
+     * Return the length of this node and all its descendents.
+     *
+     * @param __current
+     */
+    totalLength(vNode: VNode, __current = 0): number {
+        __current += vNode.length;
+        vNode.children.forEach((child: VNode): void => {
+            if (child.hasChildren()) {
+                __current = this.totalLength(child, __current);
+            }
+        });
+        return __current;
+    }
 
     //--------------------------------------------------------------------------
     // Private

--- a/packages/plugin-devtools/src/components/InspectorComponent.ts
+++ b/packages/plugin-devtools/src/components/InspectorComponent.ts
@@ -2,7 +2,7 @@ import { InfoComponent } from './InfoComponent';
 import { PathComponent } from './PathComponent';
 import { TreeComponent } from './TreeComponent';
 import { OwlUIComponent } from '../../../owl-ui/src/OwlUIComponent';
-import { VNode } from '../../../core/src/VNode';
+import { VNode } from '../../../core/src/VNodes/VNode';
 
 ////////////////////////////// todo: use API ///////////////////////////////////
 

--- a/packages/plugin-devtools/src/components/PathComponent.ts
+++ b/packages/plugin-devtools/src/components/PathComponent.ts
@@ -1,18 +1,21 @@
 import { OwlUIComponent } from '../../../owl-ui/src/OwlUIComponent';
 import { VNode } from '../../../core/src/VNodes/VNode';
+import { CharNode } from '../../../core/src/VNodes/CharNode';
 
 export class PathComponent extends OwlUIComponent<{}> {
     getNodeRepr(vNode: VNode): string {
         const name: string = (vNode.type && vNode.type.toLowerCase()) || '?';
         let format = '';
-        if (vNode.format.bold) {
-            format += '.b';
-        }
-        if (vNode.format.italic) {
-            format += '.i';
-        }
-        if (vNode.format.underline) {
-            format += '.u';
+        if (vNode instanceof CharNode) {
+            if (vNode.format.bold) {
+                format += '.b';
+            }
+            if (vNode.format.italic) {
+                format += '.i';
+            }
+            if (vNode.format.underline) {
+                format += '.u';
+            }
         }
         return name + format;
     }

--- a/packages/plugin-devtools/src/components/PathComponent.ts
+++ b/packages/plugin-devtools/src/components/PathComponent.ts
@@ -1,5 +1,5 @@
 import { OwlUIComponent } from '../../../owl-ui/src/OwlUIComponent';
-import { VNode } from '../../../core/src/VNode';
+import { VNode } from '../../../core/src/VNodes/VNode';
 
 export class PathComponent extends OwlUIComponent<{}> {
     getNodeRepr(vNode: VNode): string {

--- a/packages/plugin-devtools/src/components/TreeComponent.ts
+++ b/packages/plugin-devtools/src/components/TreeComponent.ts
@@ -2,7 +2,8 @@ import { utils } from '../../../../packages/utils/src/utils';
 import { OwlUIComponent } from '../../../owl-ui/src/OwlUIComponent';
 import { isRange } from '../../../../packages/utils/src/Predicates';
 import { VNode, VNodeType } from '../../../core/src/VNode';
-import { VRangeDescription, Direction } from '../../../core/src/VRange';
+import { VRangeDescription } from '../../../core/src/VRange';
+import { Direction } from '../../../utils/src/range';
 
 interface NodeProps {
     isRoot: boolean;

--- a/packages/plugin-devtools/src/components/TreeComponent.ts
+++ b/packages/plugin-devtools/src/components/TreeComponent.ts
@@ -128,9 +128,6 @@ export class TreeComponent extends OwlUIComponent<NodeProps> {
         if (node.name) {
             return utils.toUnicode(node.name);
         }
-        if (node.originalTag.length) {
-            return node.originalTag.toLowerCase();
-        }
         return '?';
     }
     /**

--- a/packages/plugin-devtools/src/components/TreeComponent.ts
+++ b/packages/plugin-devtools/src/components/TreeComponent.ts
@@ -119,17 +119,14 @@ export class TreeComponent extends OwlUIComponent<NodeProps> {
      * @returns {string}
      */
     _getNodeRepr(node: VNode): string {
-        if (node.value) {
-            return utils.toUnicode(node.value);
-        }
         if (isRange(node)) {
             return node.type === VNodeType.RANGE_TAIL ? '[' : ']';
         }
         if (node.type && node.type === VNodeType.LINE_BREAK) {
             return '↲';
         }
-        if (node.type) {
-            return node.type.toLowerCase();
+        if (node.name) {
+            return utils.toUnicode(node.name);
         }
         if (node.originalTag.length) {
             return node.originalTag.toLowerCase();

--- a/packages/plugin-devtools/src/components/TreeComponent.ts
+++ b/packages/plugin-devtools/src/components/TreeComponent.ts
@@ -1,7 +1,7 @@
 import { utils } from '../../../../packages/utils/src/utils';
 import { OwlUIComponent } from '../../../owl-ui/src/OwlUIComponent';
 import { isRange } from '../../../../packages/utils/src/Predicates';
-import { VNode, VNodeType } from '../../../core/src/VNode';
+import { VNode, VNodeType } from '../../../core/src/VNodes/VNode';
 import { VRangeDescription } from '../../../core/src/VRange';
 import { Direction } from '../../../utils/src/range';
 

--- a/packages/plugin-youtube/src/VNodes/YoutubeNode.ts
+++ b/packages/plugin-youtube/src/VNodes/YoutubeNode.ts
@@ -1,0 +1,71 @@
+import { VNode } from '../../../core/src/VNodes/VNode';
+
+interface YoutubeOptions {
+    width?: string;
+    height?: string;
+    frameborder?: string;
+    allow?: string;
+    allowfullscreen?: boolean;
+}
+
+export class YoutubeNode extends VNode {
+    htmlTag = 'IFRAME';
+    url: string;
+    youtubeOptions: YoutubeOptions;
+    constructor(url: string, youtubeOptions: YoutubeOptions = {}) {
+        super('youtube');
+        this.url = url;
+        this.youtubeOptions = youtubeOptions;
+    }
+
+    //--------------------------------------------------------------------------
+    // Lifecycle
+    //--------------------------------------------------------------------------
+
+    static parse(node: Node): VNode | VNode[] | null {
+        if (node.nodeName === 'IFRAME') {
+            const element = node as Element;
+            const src = element.getAttribute('src');
+            if (src && src.includes('youtu')) {
+                return new YoutubeNode(src, {
+                    width: element.getAttribute('width'),
+                    height: element.getAttribute('height'),
+                    frameborder: element.getAttribute('frameborder'),
+                    allow: element.getAttribute('allow'),
+                    allowfullscreen: element.getAttribute('allowfullscreen') !== null,
+                });
+            }
+        }
+        return null;
+    }
+    /**
+     * Render the VNode to the given format.
+     *
+     * @param [to] the name of the format to which we want to render (default:
+     * html)
+     */
+    render<T>(to = 'html'): T {
+        const t = this.renderingEngines[to].render(this) as T;
+        if (to === 'html' && t instanceof DocumentFragment) {
+            const iframe = t.firstChild as Element;
+            iframe.setAttribute('src', this.url);
+            Object.keys(this.youtubeOptions).forEach(key => {
+                iframe.setAttribute(key, this.youtubeOptions[key]);
+            });
+        }
+        return t;
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return true if the VNode is atomic (ie. it may not have children).
+     *
+     * @override
+     */
+    get atomic(): boolean {
+        return true;
+    }
+}

--- a/packages/plugin-youtube/src/Youtube.ts
+++ b/packages/plugin-youtube/src/Youtube.ts
@@ -1,0 +1,10 @@
+import { JWPlugin, JWPluginConfig } from '../../core/src/JWPlugin';
+import JWEditor from '../../core/src/JWEditor';
+import { YoutubeNode } from './VNodes/YoutubeNode';
+
+export class Youtube extends JWPlugin {
+    constructor(editor: JWEditor, options: JWPluginConfig = {}) {
+        super(editor, options);
+        this.editor.addCustomNode(YoutubeNode);
+    }
+}

--- a/packages/utils/src/Predicates.ts
+++ b/packages/utils/src/Predicates.ts
@@ -1,4 +1,4 @@
-import { VNode, VNodeType } from '../../core/src/VNode';
+import { VNode, VNodeType } from '../../core/src/VNodes/VNode';
 
 export type Predicate = (node: VNode) => boolean;
 

--- a/packages/utils/src/range.ts
+++ b/packages/utils/src/range.ts
@@ -1,0 +1,22 @@
+type DomDirection = 'ltr' | 'rtl';
+export interface Range {
+    startContainer: Node;
+    startOffset: number;
+    endContainer: Node;
+    endOffset: number;
+    direction: DomDirection;
+}
+
+export enum RelativePosition {
+    BEFORE = 'BEFORE',
+    AFTER = 'AFTER',
+    INSIDE = 'INSIDE',
+}
+
+export enum Direction {
+    BACKWARD = 'BACKWARD',
+    FORWARD = 'FORWARD',
+}
+
+export const RANGE_TAIL_CHAR = '[';
+export const RANGE_HEAD_CHAR = ']';

--- a/packages/utils/src/testUtils.ts
+++ b/packages/utils/src/testUtils.ts
@@ -2,7 +2,7 @@ import JWEditor from '../../core/src/JWEditor';
 import { expect } from 'chai';
 import { RANGE_HEAD_CHAR, RANGE_TAIL_CHAR, Direction } from './range';
 import { DomRangeDescription } from '../../core/src/EventNormalizer';
-import { Parser } from '../../core/src/Parser';
+import { utils } from './utils';
 
 export interface TestEditorSpec {
     contentBefore: string;
@@ -91,7 +91,7 @@ function _parseTextualRange(testContainer: Node): DomRangeDescription {
 
             // Get the next node to check.
             next = _nextNode(node);
-            node.textContent = Parser.removeFormatSpace(node);
+            node.textContent = utils.removeFormatSpace(node);
             // Remove the textual range node if it is empty.
             if (!node.textContent.length) {
                 node.parentNode.removeChild(node);

--- a/packages/utils/src/testUtils.ts
+++ b/packages/utils/src/testUtils.ts
@@ -1,6 +1,6 @@
 import JWEditor from '../../core/src/JWEditor';
 import { expect } from 'chai';
-import { RANGE_HEAD_CHAR, RANGE_TAIL_CHAR, Direction } from '../../core/src/VRange';
+import { RANGE_HEAD_CHAR, RANGE_TAIL_CHAR, Direction } from './range';
 import { DomRangeDescription } from '../../core/src/EventNormalizer';
 import { Parser } from '../../core/src/Parser';
 

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -1,3 +1,5 @@
+export let isWithRange = false;
+
 export const utils = {
     /**
      * Convert certain special characters to unicode.
@@ -23,6 +25,19 @@ export const utils = {
         const isTextNode = node.nodeType === Node.TEXT_NODE;
         const content = isTextNode ? node.nodeValue : node.childNodes;
         return content.length;
+    },
+    /**
+     * Call a callback on this VNode without ignoring the range nodes.
+     *
+     * @param callback
+     */
+    withRange<T>(callback: () => T): T {
+        // Record the previous value to allow for nested calls to `withRange`.
+        const previousValue = isWithRange;
+        isWithRange = true;
+        const result = callback();
+        isWithRange = previousValue;
+        return result;
     },
     /**
      * Take a collection of nodes and return a regular array

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -40,10 +40,153 @@ export const utils = {
         return result;
     },
     /**
+     * Return a string with the value of a text node stripped of its formatting
+     * space, applying the w3 rules for white space processing
+     * TODO: decide what exactly to do with formatting spaces:
+     * remove, keep, recompute?
+     *
+     * @see https://www.w3.org/TR/css-text-3/#white-space-processing
+     * @returns {string}
+     */
+    removeFormatSpace(node: Node): string {
+        // TODO: check the value of the `white-space` property
+        const text: string = node.textContent;
+        const spaceBeforeNewline = /([ \t])*(\n)/g;
+        const spaceAfterNewline = /(\n)([ \t])*/g;
+        const tabs = /\t/g;
+        const newlines = /\n/g;
+        const consecutiveSpace = /  */g;
+
+        // (Comments refer to the w3 link provided above.)
+        // Phase I: Collapsing and Transformation
+        let newText = text
+            // 1. All spaces and tabs immediately preceding or following a
+            //    segment break are removed.
+            .replace(spaceBeforeNewline, '$2')
+            .replace(spaceAfterNewline, '$1')
+            // 2. Segment breaks are transformed for rendering according to the
+            //    segment break transformation rules.
+            .replace(newlines, ' ')
+            // 3. Every tab is converted to a space (U+0020).
+            .replace(tabs, ' ')
+            // 4. Any space immediately following another collapsible space —
+            //    even one outside the boundary of the inline containing that
+            //    space, provided both spaces are within the same inline
+            //    formatting context—is collapsed to have zero advance width.
+            //    (It is invisible, but retains its soft wrap opportunity, if
+            //    any.)
+            .replace(consecutiveSpace, ' ');
+
+        // Phase II: Trimming and Positioning
+        // 1. A sequence of collapsible spaces at the beginning of a line
+        //    (ignoring any intervening inline box boundaries) is removed.
+        if (utils._isAtSegmentBreak(node, 'start')) {
+            const startSpace = /^ */g;
+            newText = newText.replace(startSpace, '');
+        }
+        // 2. If the tab size is zero, tabs are not rendered. Otherwise, each
+        //    tab is rendered as a horizontal shift that lines up the start edge
+        //    of the next glyph with the next tab stop. If this distance is less
+        //    than 0.5ch, then the subsequent tab stop is used instead. Tab
+        //    stops occur at points that are multiples of the tab size from the
+        //    block’s starting content edge. The tab size is given by the
+        //    tab-size property.
+        // TODO
+        // 3. A sequence at the end of a line (ignoring any intervening inline
+        //    box boundaries) of collapsible spaces (U+0020) and/or ideographic
+        //    spaces (U+3000) whose white-space value collapses spaces is
+        //    removed.
+        if (utils._isAtSegmentBreak(node, 'end')) {
+            const endSpace = /[ \u3000]*$/g;
+            newText = newText.replace(endSpace, '');
+        }
+        return newText;
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
      * Take a collection of nodes and return a regular array
      * with the same contents.
      */
     _collectionToArray: (collection: NodeListOf<Node> | HTMLCollection): Node[] => {
         return Array.prototype.slice.call(collection);
+    },
+    /**
+     * Return true if the given node is immediately preceding (`side` === 'end')
+     * or following (`side` === 'start') a segment break, to see if its edge
+     * space must be removed.
+     * A segment break is a sort of line break, not considering automatic breaks
+     * that are function of the screen size. In this context, a segment is what
+     * you see when you triple click in text in the browser.
+     * Eg: `<div><p>◆one◆</p>◆two◆<br>◆three◆</div>` where ◆ = segment breaks.
+     *
+     * @param {Element} node
+     * @param {'start'|'end'} side
+     * @returns {boolean}
+     */
+    _isAtSegmentBreak(node: Node, side: 'start' | 'end'): boolean {
+        const siblingSide = side === 'start' ? 'previousSibling' : 'nextSibling';
+        const sibling = node && node[siblingSide];
+        const isAgainstAnotherSegment = sibling && utils._isSegment(sibling);
+        const isAtEdgeOfOwnSegment = utils._isBlockEdge(node, side);
+        // In the DOM, a space before a BR is rendered but a space after a BR isn't.
+        const isBeforeBR = side === 'end' && sibling && sibling.nodeName === 'BR';
+        return (isAgainstAnotherSegment && !isBeforeBR) || isAtEdgeOfOwnSegment;
+    },
+    /**
+     * Return true if the node is a segment according to W3 formatting model.
+     *
+     * @param node to check
+     */
+    _isSegment(node: Node): boolean {
+        if (node.nodeType !== Node.ELEMENT_NODE) {
+            // Only proper elements can be a segment.
+            return false;
+        } else if (node.nodeName === 'BR') {
+            // Break (BR) tags end a segment.
+            return true;
+        } else {
+            // The W3 specification has many specific cases that defines what is
+            // or is not a segment. For the moment, we only handle display: block.
+            const temporaryElement = document.createElement(node.nodeName);
+            document.body.appendChild(temporaryElement);
+            const display = window.getComputedStyle(temporaryElement).display;
+            document.body.removeChild(temporaryElement);
+            return display.includes('block');
+        }
+    },
+    /**
+     * Return true if the node is at the given edge of a block.
+     *
+     * @param node to check
+     * @param side of the block to check ('start' or 'end')
+     */
+    _isBlockEdge(node: Node | Node, side: 'start' | 'end'): boolean {
+        const ancestorsUpToBlock: Node[] = [];
+
+        // Move up to the first block ancestor
+        let ancestor = node;
+        while (ancestor && (utils._isTextNode(ancestor) || !utils._isSegment(ancestor))) {
+            ancestorsUpToBlock.push(ancestor);
+            ancestor = ancestor.parentElement;
+        }
+
+        // Return true if no ancestor up to the first block ancestor has a
+        // sibling on the specified side
+        const siblingSide = side === 'start' ? 'previousSibling' : 'nextSibling';
+        return ancestorsUpToBlock.every(ancestor => {
+            return !ancestor[siblingSide];
+        });
+    },
+    /**
+     * Return true if the given node is a text node, false otherwise.
+     *
+     * @param node to check
+     */
+    _isTextNode(node: Node): boolean {
+        return node.nodeType === Node.TEXT_NODE;
     },
 };

--- a/packages/utils/test/testUtils.test.ts
+++ b/packages/utils/test/testUtils.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { testEditor } from '../src/testUtils';
-import { VNodeType } from '../../core/src/VNode';
+import { VNodeType } from '../../core/src/VNodes/VNode';
 import JWEditor from '../../core/src/JWEditor';
 
 describe('core', () => {

--- a/packages/utils/test/testUtils.test.ts
+++ b/packages/utils/test/testUtils.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { testEditor } from '../src/testUtils';
 import { VNodeType } from '../../core/src/VNodes/VNode';
 import JWEditor from '../../core/src/JWEditor';
+import { CharNode } from '../../core/src/VNodes/CharNode';
 
 describe('core', () => {
     describe('utils', () => {
@@ -32,7 +33,7 @@ describe('core', () => {
                             expect(p.type).to.equal(VNodeType.PARAGRAPH);
                             expect(p.children.length).to.equal(1);
                             expect(p.children[0].type).to.equal(VNodeType.CHAR);
-                            expect(p.children[0].value).to.equal('a');
+                            expect((p.children[0] as CharNode).char).to.equal('a');
                         },
                     });
                 });


### PR DESCRIPTION
_This is a POC. It requires extensive discussion with the team._

# Usage
## Declaration
### Declare a custom node class
```typescript
class MyCustomNodeClass extends VNode { ... }
```
### Parse into a custom node
Within the class:
```typescript
static parse(node: Node): VNode | VNode[] | null {
    if (...check node...) {
        return new MyCustomNodeClass();
    }
    return null;
}
```
### Render a custom node to HTML
#### Into a single node
Above the class constructor:
```typescript
htmlTag: 'MY-TAG';
```
#### Complex
```typescript
render<T>(to = 'html'): T {
    const t = this.renderingEngines[to].render(this) as T;
    if (to === 'html' && t instanceof DocumentFragment) {
        ...modify or replace t...
    }
    return t;
}
```

## Import
The following code examples are meant to be added after instantiation of the editor, and before `editor.start()`.
### Add a custom node
```typescript
editor.addCustomNode(MyCustomNodeClass);
```

### Add a batch of custom nodes
```typescript
editor.addCustomNodes([MyCustomNodeClass1, MyCustomNodeClass2]);
```

### Replace the whole set of default VNodes with another (advanced feature)
```typescript
editor.loadConfig({
    replaceDefaultNodes: [
        MyCustomNodeClass1,
        MyCustomNodeClass2
    ],
});
```

### Add a plugin with custom nodes
In the plugin's constructor:
```typescript
this.editor.addCustomNodes([
    MyCustomNodeClass1,
    MyCustomNodeClass2,
]);
```
Note: This PR includes a commit with a plugin that does that, for the sake of example.