### PR TITLE
[ADD] VNode: ancestors and descendants functions

### DIFF
--- a/packages/core/src/VNodes/VNode.ts
+++ b/packages/core/src/VNodes/VNode.ts
@@ -144,8 +144,8 @@ export class VNode {
      * @param vNode
      */
     isBefore(vNode: VNode): boolean {
-        const path = this._pathToRoot(this);
-        const otherPath = this._pathToRoot(vNode);
+        const path = [].concat(this, ...this.ancestors());
+        const otherPath = [].concat(vNode, ...vNode.ancestors());
         let ancestor = path.pop();
         let otherAncestor = otherPath.pop();
         // Compare the ancestors of each nodes one by one, in a path to the
@@ -428,6 +428,44 @@ export class VNode {
         return nextSiblings;
     }
     /**
+     * Return all ancestors of the current node that satisfy the given
+     * predicate. If no predicate is given return all the ancestors of the
+     * current node.
+     *
+     * @param [predicate]
+     */
+    ancestors(predicate?: Predicate): VNode[] {
+        const ancestors: VNode[] = [];
+        let parent = this.parent;
+        while (parent) {
+            if (!predicate || predicate(parent)) {
+                ancestors.push(parent);
+            }
+            parent = parent.parent;
+        }
+        return ancestors;
+    }
+    /**
+     * Return all descendants of the current node that satisfy the given
+     * predicate. If no predicate is given return all the ancestors of the
+     * current node.
+     *
+     * @param [predicate]
+     */
+    descendants(predicate?: Predicate): VNode[] {
+        const descendants = [];
+        if (this.children) {
+            let currentDescendant = this.firstChild();
+            do {
+                if (!predicate || predicate(currentDescendant)) {
+                    descendants.push(currentDescendant);
+                }
+                currentDescendant = this._descendantAfter(currentDescendant);
+            } while (currentDescendant);
+        }
+        return descendants;
+    }
+    /**
      * Walk the document tree starting from the current node (included) by
      * calling the `next` iterator until the returned node satisfies the given
      * predicate or is falsy.
@@ -641,21 +679,6 @@ export class VNode {
     _removeAtIndex(index: number): VNode {
         this._children.splice(index, 1);
         return this;
-    }
-    /**
-     * Return an array representing the path from the given VNode to the root
-     * VNode through.
-     *
-     * @param node
-     */
-    _pathToRoot(node: VNode): VNode[] {
-        const path = [node];
-        let parent = node.parent;
-        while (parent) {
-            path.push(parent);
-            parent = parent.parent;
-        }
-        return path;
     }
 }
 

--- a/packages/core/test/VNodes.test.ts
+++ b/packages/core/test/VNodes.test.ts
@@ -8,6 +8,7 @@ import { FragmentNode } from '../src/VNodes/FragmentNode';
 import { withMarkers } from '../../utils/src/range';
 import { JWPlugin } from '../src/JWPlugin';
 import JWEditor from '../src/JWEditor';
+import { testEditor } from '../../utils/src/testUtils';
 
 describe('core', () => {
     describe('src', () => {
@@ -990,6 +991,61 @@ describe('core', () => {
                                 return vNode instanceof CharNode;
                             }),
                         ).to.deep.equal([c, a]);
+                    });
+                });
+                describe('ancestors', () => {
+                    it("should get a list of all ancestors of the root node's first leaf", async () => {
+                        await testEditor({
+                            contentBefore: '<h1><p>a</p></h1><h2>b</h2>',
+                            stepFunction: (editor: JWEditor) => {
+                                const a = editor.vDocument.root.firstLeaf();
+                                const ancestors = a.ancestors();
+                                expect(ancestors.map(ancestor => ancestor.name)).to.deep.equal([
+                                    'P',
+                                    'H1',
+                                    'FragmentNode',
+                                ]);
+                            },
+                        });
+                    });
+                    it("should get a list of all ancestors of the root node's first leaf up until HEADING1", async () => {
+                        await testEditor({
+                            contentBefore: '<h1><p>a</p></h1><h2>b</h2>',
+                            stepFunction: (editor: JWEditor) => {
+                                const a = editor.vDocument.root.firstLeaf();
+                                const ancestors = a.ancestors(ancestor => ancestor.name !== 'H1');
+                                expect(ancestors.map(ancestor => ancestor.name)).to.deep.equal([
+                                    'P',
+                                    'FragmentNode',
+                                ]);
+                            },
+                        });
+                    });
+                });
+                describe('descendants', () => {
+                    it('should get a list of all descendants of the root node ', async () => {
+                        await testEditor({
+                            contentBefore: '<h1><p>a</p></h1><h2>b</h2>',
+                            stepFunction: (editor: JWEditor) => {
+                                const descendants = editor.vDocument.root.descendants();
+                                expect(
+                                    descendants.map(descendant => descendant.name),
+                                ).to.deep.equal(['H1', 'P', 'a', 'H2', 'b']);
+                            },
+                        });
+                    });
+                    it('should get a list of all non-HEADING2 descendants of the root node ', async () => {
+                        await testEditor({
+                            contentBefore: '<h1><p>a</p></h1><h2>b</h2>',
+                            stepFunction: (editor: JWEditor) => {
+                                const descendants = editor.vDocument.root.descendants(
+                                    descendant => descendant.name !== 'H2',
+                                );
+                                expect(
+                                    descendants.map(descendant => descendant.name),
+                                ).to.deep.equal(['H1', 'P', 'a', 'b']);
+                            },
+                        });
                     });
                 });
                 describe('walk', () => {


### PR DESCRIPTION
This adds methods to return a list of a VNode's ancestors/descendants, with a predicate like for[next|previous]Siblings.