### PR TITLE
[IMP] core: Add a keymap mechanism

### DIFF
--- a/packages/core/src/EventManager.ts
+++ b/packages/core/src/EventManager.ts
@@ -42,66 +42,6 @@ export class EventManager {
                 };
                 return this.editor.execCommand(customEvent.type, vSelectionParams);
             }
-            case 'keydown': {
-                // TODO: keydown should be matched with existing shortcuts. If
-                // it matches an command shortcut, trigger the corresponding
-                // command, otherwise do not trigger any command.
-                if (
-                    payload.ctrlKey &&
-                    !payload.altKey &&
-                    !payload.shiftKey &&
-                    !payload.metaKey &&
-                    payload.key === 'b'
-                ) {
-                    return this.editor.execCommand('applyFormat', { format: 'bold' });
-                } else if (
-                    payload.ctrlKey &&
-                    !payload.altKey &&
-                    !payload.shiftKey &&
-                    !payload.metaKey &&
-                    payload.key === 'i'
-                ) {
-                    return this.editor.execCommand('applyFormat', { format: 'italic' });
-                } else if (
-                    payload.ctrlKey &&
-                    !payload.altKey &&
-                    !payload.shiftKey &&
-                    !payload.metaKey &&
-                    payload.key === 'u'
-                ) {
-                    return this.editor.execCommand('applyFormat', { format: 'underline' });
-                } else if (
-                    payload.ctrlKey &&
-                    !payload.altKey &&
-                    payload.shiftKey &&
-                    !payload.metaKey &&
-                    payload.key === '7'
-                ) {
-                    return this.editor.execCommand('toggleList', { type: 'ordered' });
-                } else if (
-                    payload.ctrlKey &&
-                    !payload.altKey &&
-                    payload.shiftKey &&
-                    !payload.metaKey &&
-                    payload.key === '8'
-                ) {
-                    return this.editor.execCommand('toggleList', { type: 'unordered' });
-                }
-                // TODO: keydown should be matched with existing shortcuts.
-                return;
-            }
-            case 'tab':
-                if (!payload.shiftKey && !payload.ctrlKey && !payload.altKey && !payload.metaKey) {
-                    return this.editor.execCommand('indent');
-                } else if (
-                    payload.shiftKey &&
-                    !payload.ctrlKey &&
-                    !payload.altKey &&
-                    !payload.metaKey
-                ) {
-                    return this.editor.execCommand('outdent');
-                }
-                break;
             default:
                 this.editor.execCommand(customEvent.type, payload);
         }

--- a/packages/core/src/JWPlugin.ts
+++ b/packages/core/src/JWPlugin.ts
@@ -1,6 +1,7 @@
 import JWEditor from './JWEditor';
 import { ParsingFunction } from './Parser';
 import { CommandIdentifier, CommandDefinition, CommandHandler } from './Dispatcher';
+import { Shortcut } from './JWEditor';
 
 export interface JWPluginConfig {
     name?: string;
@@ -13,6 +14,7 @@ export class JWPlugin {
     editor: JWEditor;
     commands: Record<CommandIdentifier, CommandDefinition> = {};
     commandHooks: Record<CommandIdentifier, CommandHandler> = {};
+    shortcuts: Shortcut[];
 
     constructor(editor: JWEditor, options: JWPluginConfig = {}) {
         this.editor = editor;

--- a/packages/core/src/Keymap.ts
+++ b/packages/core/src/Keymap.ts
@@ -1,0 +1,171 @@
+import { CommandIdentifier, CommandArgs } from './Dispatcher';
+
+export interface BoundCommand {
+    /**
+     * An undefined `commandId` effectively unbinds the shortcut.
+     */
+    readonly commandId: CommandIdentifier | undefined;
+    readonly commandArgs?: CommandArgs;
+}
+
+interface ModifiedShortcut {
+    modifiers: Set<string>;
+}
+
+interface KeyShortcutPattern extends ModifiedShortcut {
+    key: string;
+}
+
+interface CodeShortcutPattern extends ModifiedShortcut {
+    code: string;
+}
+
+type ShortcutPattern = KeyShortcutPattern | CodeShortcutPattern;
+
+interface Shortcut {
+    pattern: ShortcutPattern;
+    boundCommand?: BoundCommand;
+}
+
+/**
+ * Keymap allow to add and remove shortucts and provide a function to match if a
+ * particular pattern is found within registred shortucts.
+ *
+ * ## Adding shortcuts
+ * The expression to describe a shortuct is zero or more `modifiers` and one
+ * `hotkey` joined with the symbol `+`.
+ *
+ * ### Modifiers
+ * - SHIFT
+ * - ALT
+ * - CTRL
+ * - META
+ * - CMD (alias of META)
+ *
+ * Example:
+ * ```typescript
+ * // using a modifier and one key
+ * keymap.bindShortuct('CTRL+A', 'commandIdentifier')
+ * // using multiples modifiers and one key
+ * keymap.bindShortuct('CTRL+ALT+A', 'commandIdentifier')
+ * ```
+ *
+ * ### Hotkeys
+ * A hotkey can be wether a `key` or `code`.
+ *
+ * #### Key
+ * The syntax to describe a `key` is to write the `key` as it is. The convention
+ * is to write it in uppercase.
+ *
+ * Example:
+ * ```typescript
+ * keymap.bindShortuct('CTRL+A', 'commandIdentifier')
+ * ```
+ * The list of possible `key` values are defined in the following link:
+ * https://www.w3.org/TR/uievents/#dom-keyboardevent-key
+ *
+ * #### Code
+ * The syntax to describe a `code` is to write `<code>` (surrounded by "<" and
+ * ">").
+ *
+ * Example:
+ * ```typescript
+ * keymap.bindShortuct('CTRL+<KeyA>', 'commandIdentifier')
+ * ```
+ *
+ * The list of possible `code` values are defined in the following link:
+ * https://www.w3.org/TR/uievents/#dom-keyboardevent-key
+ *
+ * ## Removing shortucts
+ * To remove a shortuct, call `bindShortcut` without commandIdentifier
+ *
+ * Example:
+ * ```typescript
+ * keymap.bindShortuct('CTRL+<KeyA>')
+ * ```
+ */
+export class Keymap {
+    shortcuts: Shortcut[] = [];
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * Add or remove a shortuct.
+     *
+     * If `commandId` is set, add the shortcut.
+     *
+     * If there is no `commandId`, it means that we want nothing to execute.
+     * Thus unbinding the command.
+     *
+     * @param patternString
+     * @param commandId
+     * @param commandArgs
+     */
+    bindShortcut(
+        patternString: string,
+        commandId?: CommandIdentifier,
+        commandArgs?: CommandArgs,
+    ): void {
+        this.shortcuts.unshift({
+            pattern: this.parsePattern(patternString),
+            boundCommand: { commandId, commandArgs },
+        });
+    }
+
+    /**
+     * Get first BoundCommand found when providing `keyEvent`.
+     *
+     * @param keyEvent
+     */
+    match(keyEvent: KeyboardEvent): BoundCommand {
+        const matchingMappings = this.shortcuts.find(shortcut => {
+            const modifiers = shortcut.pattern.modifiers;
+
+            let match: boolean;
+            if ('code' in shortcut.pattern) {
+                match = shortcut.pattern.code === keyEvent.code;
+            } else {
+                match = shortcut.pattern.key === keyEvent.key.toUpperCase();
+            }
+
+            match =
+                match &&
+                modifiers.has('CTRL') === keyEvent.ctrlKey &&
+                modifiers.has('SHIFT') === keyEvent.shiftKey &&
+                modifiers.has('META') === keyEvent.metaKey &&
+                modifiers.has('ALT') === keyEvent.altKey;
+
+            return match;
+        });
+        return matchingMappings && matchingMappings.boundCommand;
+    }
+
+    /**
+     * Parse a string that represend a pattern and return a `ShortuctPattern`.
+     * Supported pattern is: [modifier+]*[<code>|key]
+     *
+     * @param pattern
+     */
+    parsePattern(pattern: string): ShortcutPattern {
+        const tokens = pattern
+            .trim()
+            .replace(/cmd/gi, 'META')
+            .split(/[+]/);
+        const keyCode = tokens.pop();
+        const modifiers = new Set(tokens.map(token => token.toUpperCase()));
+        if (!keyCode) {
+            throw new Error('You must have at least one key or code.');
+        }
+        // There are two ways to specify a shortcut hotkey : key or code
+        // - "CTRL+1" is the modifier CTRL with the event.key "1".
+        // - "CTRL+<Key1>" is the modifier CTRL with the event.code "Key1"
+        const codeMatch = keyCode.match(/^<(\w+)>$/);
+        if (codeMatch && codeMatch.length > 1) {
+            return { code: codeMatch[1], modifiers };
+        } else {
+            return { key: keyCode.toUpperCase(), modifiers };
+        }
+    }
+}

--- a/packages/core/test/JWeditor.test.ts
+++ b/packages/core/test/JWeditor.test.ts
@@ -1,0 +1,264 @@
+import JWEditor from '../src/JWEditor';
+import { JWPlugin } from '../src/JWPlugin';
+import { expect } from 'chai';
+import { Platform } from '../src/JWEditor';
+import { keydown, testEditor } from '../../utils/src/testUtils';
+import { spy } from 'sinon';
+describe('core', () => {
+    describe('JWEditor', () => {
+        describe('addPlugin', () => {
+            describe('defaultShortcuts & loadConfig', () => {
+                it('should only register default mapping for pc and other', () => {
+                    const editor = new JWEditor();
+                    editor._platform = Platform.PC;
+                    editor.start();
+                    editor.addPlugin(
+                        class A extends JWPlugin {
+                            shortcuts = [
+                                {
+                                    pattern: 'cTrL+A',
+                                    commandId: 'command-all',
+                                },
+                                {
+                                    platform: Platform.PC,
+                                    pattern: 'aLt+b',
+                                    commandId: 'command-pc',
+                                },
+                                {
+                                    platform: Platform.MAC,
+                                    pattern: 'Alt+b',
+                                    commandId: 'command-mac',
+                                },
+                            ];
+                        },
+                    );
+                    const expectedCommands = editor.keymaps.default.shortcuts.map(
+                        l => l.boundCommand.commandId,
+                    );
+                    expect(expectedCommands).to.eql(['command-pc', 'command-all']);
+                });
+                it('should transform ctrl to CMD if no platform on mac', () => {
+                    const editor = new JWEditor();
+                    editor._platform = Platform.MAC;
+                    editor.start();
+                    editor.addPlugin(
+                        class A extends JWPlugin {
+                            shortcuts = [
+                                {
+                                    pattern: 'cTrL+A',
+                                    commandId: 'command-all',
+                                },
+                                {
+                                    pattern: 'ctrl+A',
+                                    commandId: 'command-all',
+                                },
+                                {
+                                    platform: Platform.PC,
+                                    pattern: 'cTrL+A',
+                                    commandId: 'command-all',
+                                },
+                                {
+                                    platform: Platform.MAC,
+                                    pattern: 'ctrl+a',
+                                    commandId: 'command-mac',
+                                },
+                            ];
+                        },
+                    );
+                    const expectedCommands = editor.keymaps.default.shortcuts.map(
+                        l => [...l.pattern.modifiers][0],
+                    );
+                    expect(expectedCommands).to.eql(['CTRL', 'META', 'META']);
+                });
+                it('should not transform ctrl to CMD if no platform on pc', () => {
+                    const editor = new JWEditor();
+                    editor._platform = Platform.PC;
+                    editor.start();
+                    editor.addPlugin(
+                        class A extends JWPlugin {
+                            shortcuts = [
+                                {
+                                    pattern: 'cTrL+A',
+                                    commandId: 'command-all',
+                                },
+                                {
+                                    pattern: 'ctrl+A',
+                                    commandId: 'command-all',
+                                },
+                                {
+                                    platform: Platform.PC,
+                                    pattern: 'cTrL+A',
+                                    commandId: 'command-all',
+                                },
+                                {
+                                    platform: Platform.MAC,
+                                    pattern: 'ctrl+a',
+                                    commandId: 'command-mac',
+                                },
+                            ];
+                        },
+                    );
+                    const expectedCommands = editor.keymaps.default.shortcuts.map(
+                        l => [...l.pattern.modifiers][0],
+                    );
+                    expect(expectedCommands).to.eql(['CTRL', 'CTRL', 'CTRL']);
+                });
+                it('should only register default mapping for mac and other', () => {
+                    const editor = new JWEditor();
+                    editor._platform = Platform.MAC;
+                    editor.start();
+                    editor.addPlugin(
+                        class A extends JWPlugin {
+                            shortcuts = [
+                                {
+                                    pattern: 'CtRl+a',
+                                    commandId: 'command-all',
+                                },
+                                {
+                                    platform: Platform.PC,
+                                    pattern: 'alT+B',
+                                    commandId: 'command-pc',
+                                },
+                                {
+                                    platform: Platform.MAC,
+                                    pattern: 'ALt+b',
+                                    commandId: 'command-mac',
+                                },
+                            ];
+                        },
+                    );
+                    const expectedCommands = editor.keymaps.default.shortcuts.map(
+                        l => l.boundCommand.commandId,
+                    );
+                    expect(expectedCommands).to.eql(['command-mac', 'command-all']);
+                });
+                it('should load the config for keymap', () => {
+                    const editor = new JWEditor();
+                    editor._platform = Platform.PC;
+                    editor.start();
+                    editor.loadConfig({
+                        debug: true,
+                        shortcuts: [
+                            {
+                                pattern: 'ctrL+a',
+                                commandId: 'command-all',
+                            },
+                            {
+                                platform: Platform.PC,
+                                pattern: 'ctrl+b',
+                                commandId: 'command-pc',
+                            },
+                            {
+                                platform: Platform.MAC,
+                                pattern: 'CTRL+B',
+                                commandId: 'command-mac',
+                            },
+                        ],
+                    });
+                    const expectedCommands = editor.keymaps.user.shortcuts.map(
+                        l => l.boundCommand.commandId,
+                    );
+                    expect(expectedCommands).to.eql(['command-pc', 'command-all']);
+                });
+                describe('onKeydown', () => {
+                    it('should trigger default shortuct', async () => {
+                        await testEditor(JWEditor, {
+                            contentBefore: '',
+                            stepFunction: async editor => {
+                                editor._platform = Platform.PC;
+                                // todo: to remove when the normalizer will
+                                //       not be in included by default
+                                editor.eventManager.eventNormalizer._triggerEvent = (): void => {};
+                                editor.addPlugin(
+                                    class A extends JWPlugin {
+                                        shortcuts = [
+                                            {
+                                                pattern: 'CTRL+A',
+                                                commandId: 'command-all',
+                                            },
+                                        ];
+                                    },
+                                );
+                                editor.execCommand = (): void => {};
+                                const execSpy = spy(editor, 'execCommand');
+                                await keydown(editor.editable, 'a', { ctrlKey: true });
+                                await keydown(editor.editable, 'b', { ctrlKey: true });
+                                expect(execSpy.args).to.eql([['command-all', undefined]]);
+                            },
+                        });
+                    });
+                    it('should trigger the binding from the user config rather the default', async () => {
+                        await testEditor(JWEditor, {
+                            contentBefore: '',
+                            stepFunction: async editor => {
+                                editor._platform = Platform.PC;
+                                // todo: to remove when the normalizer will
+                                //       not be in included by default
+                                editor.eventManager.eventNormalizer._triggerEvent = (): void => {};
+                                editor.addPlugin(
+                                    class A extends JWPlugin {
+                                        shortcuts = [
+                                            {
+                                                pattern: 'CTRL+A',
+                                                commandId: 'command-all',
+                                            },
+                                        ];
+                                    },
+                                );
+                                editor.loadConfig({
+                                    debug: true,
+                                    shortcuts: [
+                                        {
+                                            pattern: 'CTRL+A',
+                                            commandId: 'command-b',
+                                        },
+                                    ],
+                                });
+                                editor.execCommand = (): void => {};
+                                const execSpy = spy(editor, 'execCommand');
+                                await keydown(editor.editable, 'a', { ctrlKey: true });
+                                await keydown(editor.editable, 'b', { ctrlKey: true });
+                                expect(execSpy.args).to.eql([['command-b', undefined]]);
+                            },
+                        });
+                    });
+                    it('should remove the binding from the user config', async () => {
+                        await testEditor(JWEditor, {
+                            contentBefore: '',
+                            stepFunction: async editor => {
+                                editor._platform = Platform.PC;
+                                // todo: to remove when the normalizer will
+                                //       not be in included by default
+                                editor.eventManager.eventNormalizer._triggerEvent = (): void => {};
+                                editor.addPlugin(
+                                    class A extends JWPlugin {
+                                        shortcuts = [
+                                            {
+                                                pattern: 'CTRL+A',
+                                                commandId: 'command-all',
+                                            },
+                                        ];
+                                    },
+                                );
+                                editor.loadConfig({
+                                    debug: true,
+                                    shortcuts: [
+                                        {
+                                            pattern: 'CTRL+A',
+                                            commandId: undefined,
+                                        },
+                                    ],
+                                });
+                                editor.execCommand = (): void => {};
+                                const execSpy = spy(editor, 'execCommand');
+                                await keydown(editor.editable, 'a', { ctrlKey: true });
+                                await keydown(editor.editable, 'b', { ctrlKey: true });
+                                expect(execSpy.args).to.eql([]);
+                            },
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/packages/core/test/Keymap.test.ts
+++ b/packages/core/test/Keymap.test.ts
@@ -1,0 +1,189 @@
+import { Keymap, BoundCommand } from '../src/Keymap';
+import { expect } from 'chai';
+function keydownEvent(key, code, options = {}): KeyboardEvent {
+    return new KeyboardEvent('keydown', { ...options, key, code });
+}
+describe('core', () => {
+    describe('Keymap', () => {
+        let keymap: Keymap;
+        beforeEach(() => {
+            keymap = new Keymap();
+        });
+        it('should bindShortcut', () => {
+            const keymap = new Keymap();
+            keymap.bindShortcut('a', 'command');
+            expect(keymap.shortcuts.length === 1);
+        });
+        describe('parsePatter ', () => {
+            it('should transform everything to uppercase modifiers', () => {
+                const pattern = keymap.parsePattern('CtRl+a');
+                expect('key' in pattern).to.be.true;
+                if ('key' in pattern) {
+                    expect(pattern.key).to.deep.equal('A');
+                }
+                expect([...pattern.modifiers]).to.deep.equal(['CTRL']);
+            });
+            it('should transform CMD to META', () => {
+                const pattern = keymap.parsePattern('cMd+A');
+                expect([...pattern.modifiers]).to.deep.equal(['META']);
+            });
+            it('should get 0 modifiers and 1 key', () => {
+                keymap.bindShortcut('a', 'command');
+                const pattern = keymap.parsePattern('a');
+                expect('key' in pattern).to.be.true;
+                if ('key' in pattern) {
+                    expect(pattern.key).to.deep.equal('A');
+                }
+                expect([...pattern.modifiers]).to.deep.equal([]);
+            });
+            it('should get 1 modifiers and 1 key', () => {
+                const pattern = keymap.parsePattern('cTRl+a');
+                expect('key' in pattern).to.be.true;
+                if ('key' in pattern) {
+                    expect(pattern.key).to.deep.equal('A');
+                }
+                expect([...pattern.modifiers]).to.deep.equal(['CTRL']);
+            });
+            it('should get 2 modifiers and 1 key', () => {
+                const pattern = keymap.parsePattern('ctrl+sHift+a');
+                expect('key' in pattern).to.be.true;
+                if ('key' in pattern) {
+                    expect(pattern.key).to.deep.equal('A');
+                }
+                expect([...pattern.modifiers]).to.deep.equal(['CTRL', 'SHIFT']);
+            });
+            it('should get 0 modifiers and 1 code', () => {
+                keymap.bindShortcut('a', 'command');
+                const pattern = keymap.parsePattern('<KeyA>');
+                expect('code' in pattern).to.be.true;
+                if ('code' in pattern) {
+                    expect(pattern.code).to.deep.equal('KeyA');
+                }
+                expect([...pattern.modifiers]).to.deep.equal([]);
+            });
+            it('should get 1 modifiers and 1 code', () => {
+                const pattern = keymap.parsePattern('cTRl+<KeyB>');
+                expect('code' in pattern).to.be.true;
+                if ('code' in pattern) {
+                    expect(pattern.code).to.deep.equal('KeyB');
+                }
+                expect([...pattern.modifiers]).to.deep.equal(['CTRL']);
+            });
+            it('should get 2 modifiers and 1 code', () => {
+                const pattern = keymap.parsePattern('ctrl+sHift+<KeyC>');
+                expect('code' in pattern).to.be.true;
+                if ('code' in pattern) {
+                    expect(pattern.code).to.deep.equal('KeyC');
+                }
+                expect([...pattern.modifiers]).to.deep.equal(['CTRL', 'SHIFT']);
+            });
+            it('should normalize pattern and get 2 modifiers and 1 key', () => {
+                const pattern = keymap.parsePattern('cTrl+shiFt+a');
+                expect('key' in pattern).to.be.true;
+                if ('key' in pattern) {
+                    expect(pattern.key).to.deep.equal('A');
+                }
+                expect([...pattern.modifiers]).to.deep.equal(['CTRL', 'SHIFT']);
+            });
+            it('should throw an error because there is no key', () => {
+                expect(() => {
+                    keymap.parsePattern('');
+                }).to.throw();
+            });
+        });
+        describe('match', () => {
+            it('should match shortcuts with key', () => {
+                keymap.bindShortcut('a', 'command-a');
+                keymap.bindShortcut('b', 'command-b');
+                const call = keymap.match(keydownEvent('a', 'KeyA'));
+                const expectedCommand: BoundCommand = {
+                    commandId: 'command-a',
+                    commandArgs: undefined,
+                };
+                expect(call).to.deep.equal(expectedCommand);
+            });
+            it('should match shortcuts with code', () => {
+                keymap.bindShortcut('<KeyA>', 'command-a');
+                keymap.bindShortcut('b', 'command-b');
+                const call = keymap.match(keydownEvent('a', 'KeyA'));
+                const expectedCommand: BoundCommand = {
+                    commandId: 'command-a',
+                    commandArgs: undefined,
+                };
+                expect(call).to.deep.equal(expectedCommand);
+            });
+            it('should match shortcuts with command args', () => {
+                const args = { propA: 'valA' };
+                keymap.bindShortcut('<KeyA>', 'command-a', args);
+                const call = keymap.match(keydownEvent('a', 'KeyA'));
+                const expectedCommand: BoundCommand = {
+                    commandId: 'command-a',
+                    commandArgs: args,
+                };
+                expect(call).to.deep.equal(expectedCommand);
+            });
+            it('should not trigger the map with modifiers', () => {
+                const args = { propA: 'valA' };
+                keymap.bindShortcut('a', 'command-a', args);
+                keymap.bindShortcut('ctrl  +a', 'command-a', args);
+                const call = keymap.match(keydownEvent('a', 'KeyA'));
+                const expectedCommand: BoundCommand = {
+                    commandId: 'command-a',
+                    commandArgs: args,
+                };
+                expect(call).to.deep.equal(expectedCommand);
+            });
+            it('should match the last shortuct when both are found in the system', () => {
+                keymap.bindShortcut('A', 'command-a');
+                keymap.bindShortcut('A', 'command-b');
+                const call = keymap.match(keydownEvent('a', 'KeyA'));
+                const expectedCommand: BoundCommand = {
+                    commandId: 'command-b',
+                    commandArgs: undefined,
+                };
+                expect(call).to.deep.equal(expectedCommand);
+            });
+            it('should remove a shortuct if there is no commandIdentifier', () => {
+                keymap.bindShortcut('a', 'command-a');
+                keymap.bindShortcut('a');
+                keymap.bindShortcut('a', 'command-a');
+                keymap.bindShortcut('a');
+                const call = keymap.match(keydownEvent('a', 'KeyA'));
+                const expectedCommand: BoundCommand = {
+                    commandId: undefined,
+                    commandArgs: undefined,
+                };
+                expect(call).to.deep.equal(expectedCommand);
+            });
+            describe('modifier', () => {
+                it('should match shortcuts only when one modifier is active', () => {
+                    keymap.bindShortcut('ctRl+<KeyA>', 'command-a');
+                    const call = keymap.match(keydownEvent('a', 'KeyA', { ctrlKey: true }));
+                    const expectedCommand: BoundCommand = {
+                        commandId: 'command-a',
+                        commandArgs: undefined,
+                    };
+                    expect(call).to.deep.equal(expectedCommand);
+                });
+                it('should match shortcuts only when one modifier is active but not the others', () => {
+                    keymap.bindShortcut('cTrl+<KeyA>', 'command-a');
+                    const call = keymap.match(
+                        keydownEvent('a', 'KeyA', { ctrlKey: true, altKey: true }),
+                    );
+                    expect(call).to.deep.equal(undefined);
+                });
+                it('should match shortcuts only when multiples modifier are active', () => {
+                    keymap.bindShortcut('Ctrl+alt+<KeyA>', 'command-a');
+                    const call = keymap.match(
+                        keydownEvent('a', 'KeyA', { ctrlKey: true, altKey: true }),
+                    );
+                    const expectedCommand: BoundCommand = {
+                        commandId: 'command-a',
+                        commandArgs: undefined,
+                    };
+                    expect(call).to.deep.equal(expectedCommand);
+                });
+            });
+        });
+    });
+});

--- a/packages/plugin-char/Char.ts
+++ b/packages/plugin-char/Char.ts
@@ -22,6 +22,23 @@ export class Char extends JWPlugin {
             handler: this.applyFormat.bind(this),
         },
     };
+    shortcuts = [
+        {
+            pattern: 'CTRL+B',
+            commandId: 'applyFormat',
+            commandArgs: { format: 'bold' } as FormatParams,
+        },
+        {
+            pattern: 'CTRL+I',
+            commandId: 'applyFormat',
+            commandArgs: { format: 'italic' } as FormatParams,
+        },
+        {
+            pattern: 'CTRL+U',
+            commandId: 'applyFormat',
+            commandArgs: { format: 'underline' } as FormatParams,
+        },
+    ];
     static parse(context: ParsingContext): [ParsingContext, ParsingMap] {
         if (context.currentNode.nodeType === Node.TEXT_NODE) {
             const vNodes: CharNode[] = [];

--- a/packages/plugin-list/List.ts
+++ b/packages/plugin-list/List.ts
@@ -28,6 +28,18 @@ export class List extends JWPlugin {
             handler: this.toggleList.bind(this),
         },
     };
+    shortcuts = [
+        {
+            pattern: 'CTRL+SHIFT+<Digit7>',
+            commandId: 'toggleList',
+            commandArgs: { type: 'ordered' } as ListParams,
+        },
+        {
+            pattern: 'CTRL+SHIFT+<Digit8>',
+            commandId: 'toggleList',
+            commandArgs: { type: 'unordered' } as ListParams,
+        },
+    ];
     static readonly parsingFunctions: Array<ParsingFunction> = [List.parse];
     static parse(context: ParsingContext): [ParsingContext, ParsingMap] {
         if (listTags.includes(context.currentNode.nodeName)) {

--- a/packages/utils/src/testUtils.ts
+++ b/packages/utils/src/testUtils.ts
@@ -9,7 +9,7 @@ import { DevTools } from '../../plugin-devtools/src/DevTools';
 export interface TestEditorSpec {
     contentBefore: string;
     contentAfter?: string;
-    stepFunction?: (editor: JWEditor) => void;
+    stepFunction?: (editor: JWEditor) => void | Promise<void>;
     debug?: boolean;
 }
 
@@ -123,7 +123,7 @@ async function testSpec(editor: JWEditor, spec: TestEditorSpec): Promise<void> {
     // Start the editor and execute the step code.
     await editor.start();
     if (spec.stepFunction) {
-        spec.stepFunction(editor);
+        await spec.stepFunction(editor);
     }
 
     // Render the selection in the test container and test the result.
@@ -362,12 +362,13 @@ export async function click(el: Element, options?: MouseEventInit): Promise<void
  * @param el
  * @param options
  */
-export async function keydown(el: Element, key: string): Promise<void> {
+export async function keydown(el: Element, key: string, options = {}): Promise<void> {
     el.dispatchEvent(
         new KeyboardEvent('keydown', {
             key: key,
             code: key,
             bubbles: true,
+            ...options,
         }),
     );
     await nextTickFrame();


### PR DESCRIPTION
This keymap allows to:
- specify shortcuts from the config of the editor
- specify default shortcuts for plugins
- specify shortcuts and default shortcuts depending on the platform (mac
  or others)
- specify shortucts with javascript event 'key' or 'code'