### PR TITLE
[ADD] VNode, Format: basically handle many nodes

### DIFF
--- a/bundles/BasicEditor.ts
+++ b/bundles/BasicEditor.ts
@@ -16,6 +16,7 @@ import { Link } from '../packages/plugin-link/Link';
 import { Divider } from '../packages/plugin-divider/Divider';
 import { Image } from '../packages/plugin-image/Image';
 import { Subscript } from '../packages/plugin-subscript/Subscript';
+import { Superscript } from '../packages/plugin-superscript/Superscript';
 
 export class BasicEditor extends JWEditor {
     constructor(editable?: HTMLElement) {
@@ -40,6 +41,7 @@ export class BasicEditor extends JWEditor {
                 [Divider],
                 [Image],
                 [Subscript],
+                [Superscript],
             ],
         });
     }

--- a/bundles/BasicEditor.ts
+++ b/bundles/BasicEditor.ts
@@ -13,6 +13,7 @@ import { Italic } from '../packages/plugin-italic/Italic';
 import { Underline } from '../packages/plugin-underline/Underline';
 import { Inline } from '../packages/plugin-inline/Inline';
 import { Link } from '../packages/plugin-link/Link';
+import { Divider } from '../packages/plugin-divider/Divider';
 
 export class BasicEditor extends JWEditor {
     constructor(editable?: HTMLElement) {
@@ -34,6 +35,7 @@ export class BasicEditor extends JWEditor {
                 [Italic],
                 [Underline],
                 [Link],
+                [Divider],
             ],
         });
     }

--- a/bundles/BasicEditor.ts
+++ b/bundles/BasicEditor.ts
@@ -17,6 +17,7 @@ import { Divider } from '../packages/plugin-divider/Divider';
 import { Image } from '../packages/plugin-image/Image';
 import { Subscript } from '../packages/plugin-subscript/Subscript';
 import { Superscript } from '../packages/plugin-superscript/Superscript';
+import { Blockquote } from '../packages/plugin-blockquote/Blockquote';
 
 export class BasicEditor extends JWEditor {
     constructor(editable?: HTMLElement) {
@@ -42,6 +43,7 @@ export class BasicEditor extends JWEditor {
                 [Image],
                 [Subscript],
                 [Superscript],
+                [Blockquote],
             ],
         });
     }

--- a/bundles/BasicEditor.ts
+++ b/bundles/BasicEditor.ts
@@ -18,6 +18,7 @@ import { Image } from '../packages/plugin-image/Image';
 import { Subscript } from '../packages/plugin-subscript/Subscript';
 import { Superscript } from '../packages/plugin-superscript/Superscript';
 import { Blockquote } from '../packages/plugin-blockquote/Blockquote';
+import { Youtube } from '../packages/plugin-youtube/Youtube';
 
 export class BasicEditor extends JWEditor {
     constructor(editable?: HTMLElement) {
@@ -44,6 +45,7 @@ export class BasicEditor extends JWEditor {
                 [Subscript],
                 [Superscript],
                 [Blockquote],
+                [Youtube],
             ],
         });
     }

--- a/bundles/BasicEditor.ts
+++ b/bundles/BasicEditor.ts
@@ -19,6 +19,7 @@ import { Subscript } from '../packages/plugin-subscript/Subscript';
 import { Superscript } from '../packages/plugin-superscript/Superscript';
 import { Blockquote } from '../packages/plugin-blockquote/Blockquote';
 import { Youtube } from '../packages/plugin-youtube/Youtube';
+import { Table } from '../packages/plugin-table/Table';
 
 export class BasicEditor extends JWEditor {
     constructor(editable?: HTMLElement) {
@@ -46,6 +47,7 @@ export class BasicEditor extends JWEditor {
                 [Superscript],
                 [Blockquote],
                 [Youtube],
+                [Table],
             ],
         });
     }

--- a/bundles/BasicEditor.ts
+++ b/bundles/BasicEditor.ts
@@ -12,6 +12,7 @@ import { Bold } from '../packages/plugin-bold/Bold';
 import { Italic } from '../packages/plugin-italic/Italic';
 import { Underline } from '../packages/plugin-underline/Underline';
 import { Inline } from '../packages/plugin-inline/Inline';
+import { Link } from '../packages/plugin-link/Link';
 
 export class BasicEditor extends JWEditor {
     constructor(editable?: HTMLElement) {
@@ -32,6 +33,7 @@ export class BasicEditor extends JWEditor {
                 [Bold],
                 [Italic],
                 [Underline],
+                [Link],
             ],
         });
     }

--- a/bundles/BasicEditor.ts
+++ b/bundles/BasicEditor.ts
@@ -15,6 +15,7 @@ import { Inline } from '../packages/plugin-inline/Inline';
 import { Link } from '../packages/plugin-link/Link';
 import { Divider } from '../packages/plugin-divider/Divider';
 import { Image } from '../packages/plugin-image/Image';
+import { Subscript } from '../packages/plugin-subscript/Subscript';
 
 export class BasicEditor extends JWEditor {
     constructor(editable?: HTMLElement) {
@@ -38,6 +39,7 @@ export class BasicEditor extends JWEditor {
                 [Link],
                 [Divider],
                 [Image],
+                [Subscript],
             ],
         });
     }

--- a/bundles/BasicEditor.ts
+++ b/bundles/BasicEditor.ts
@@ -20,6 +20,7 @@ import { Superscript } from '../packages/plugin-superscript/Superscript';
 import { Blockquote } from '../packages/plugin-blockquote/Blockquote';
 import { Youtube } from '../packages/plugin-youtube/Youtube';
 import { Table } from '../packages/plugin-table/Table';
+import { Metadata } from '../packages/plugin-metadata/Metadata';
 
 export class BasicEditor extends JWEditor {
     constructor(editable?: HTMLElement) {
@@ -48,6 +49,7 @@ export class BasicEditor extends JWEditor {
                 [Blockquote],
                 [Youtube],
                 [Table],
+                [Metadata],
             ],
         });
     }

--- a/bundles/BasicEditor.ts
+++ b/bundles/BasicEditor.ts
@@ -14,6 +14,7 @@ import { Underline } from '../packages/plugin-underline/Underline';
 import { Inline } from '../packages/plugin-inline/Inline';
 import { Link } from '../packages/plugin-link/Link';
 import { Divider } from '../packages/plugin-divider/Divider';
+import { Image } from '../packages/plugin-image/Image';
 
 export class BasicEditor extends JWEditor {
     constructor(editable?: HTMLElement) {
@@ -36,6 +37,7 @@ export class BasicEditor extends JWEditor {
                 [Underline],
                 [Link],
                 [Divider],
+                [Image],
             ],
         });
     }

--- a/packages/core/src/ContextManager.ts
+++ b/packages/core/src/ContextManager.ts
@@ -120,29 +120,33 @@ export class ContextManager {
         for (const item of items) {
             const context = { ...this.defaultContext, ...item.context, ...paramsContext };
             let firstMatchDepth = -1;
-            let ancestorIndex = 0;
+            let index = 0;
             let match;
             const selector = item.selector || [];
             if (selector.length === 0) {
                 match = true;
             } else {
                 context.selector = [];
-                const range = context.range;
-                const ancestors = range.start.ancestors();
-                const maximumDepth = ancestors.length - 1;
+                const start = context.range.start;
+                const nodes = start.ancestors();
+                const node = start.previousSibling() || start.nextSibling();
+                if (node) {
+                    nodes.unshift(node);
+                }
+                const maximumDepth = nodes.length - 1;
                 for (const predicate of [...selector].reverse()) {
                     match = false;
-                    while (!match && ancestorIndex < ancestors.length) {
-                        if (ancestors[ancestorIndex].test(predicate)) {
+                    while (!match && index < nodes.length) {
+                        if (nodes[index].test(predicate)) {
                             match = true;
-                            context.selector.unshift(ancestors[ancestorIndex]);
+                            context.selector.unshift(nodes[index]);
                             if (firstMatchDepth === -1) {
                                 // Deeper match has higher specificity. So lower
                                 // index in ancestors, means higher specificity.
-                                firstMatchDepth = maximumDepth - ancestorIndex;
+                                firstMatchDepth = maximumDepth - index;
                             }
                         }
-                        ancestorIndex++;
+                        index++;
                     }
                     // Stop checking the predicates of this particular command
                     // since at least one of them don't match the context.

--- a/packages/core/src/VNodes/VNode.ts
+++ b/packages/core/src/VNodes/VNode.ts
@@ -230,10 +230,28 @@ export class VNode {
         return this.children()[n - 1];
     }
     /**
-     * Return this VNode's siblings.
+     * Return the siblings of this VNode which satisfy the given predicate.
      */
-    get siblings(): VNode[] {
-        return (this.parent && this.parent.children()) || [];
+    siblings(predicate?: Predicate): VNode[];
+    siblings<T extends VNode>(predicate?: Predicate<T>): T[];
+    siblings<T>(predicate?: Predicate<T>): VNode[];
+    siblings<T>(predicate?: Predicate<T>): VNode[] {
+        const siblings: VNode[] = [];
+        let sibling: VNode = this.previousSibling();
+        while (sibling) {
+            if (sibling.test(predicate)) {
+                siblings.unshift(sibling);
+            }
+            sibling = sibling.previousSibling();
+        }
+        sibling = this.nextSibling();
+        while (sibling) {
+            if (sibling.test(predicate)) {
+                siblings.push(sibling);
+            }
+            sibling = sibling.nextSibling();
+        }
+        return siblings;
     }
     /**
      * Return the first ancestor of this VNode that satisfies the given

--- a/packages/core/src/VNodes/VNode.ts
+++ b/packages/core/src/VNodes/VNode.ts
@@ -253,6 +253,25 @@ export class VNode {
         return siblings;
     }
     /**
+     * Return the nodes adjacent to this VNode that satisfy the given predicate.
+     */
+    adjacents<T extends VNode>(predicate?: Predicate<T>): T[];
+    adjacents<T>(predicate?: Predicate<T>): VNode[];
+    adjacents<T>(predicate?: Predicate<T>): VNode[] {
+        const adjacents: VNode[] = [];
+        let sibling: VNode = this.previousSibling();
+        while (sibling && sibling.test(predicate)) {
+            adjacents.unshift(sibling);
+            sibling = sibling.previousSibling();
+        }
+        sibling = this.nextSibling();
+        while (sibling && sibling.test(predicate)) {
+            adjacents.push(sibling);
+            sibling = sibling.nextSibling();
+        }
+        return adjacents;
+    }
+    /**
      * Return the first ancestor of this VNode that satisfies the given
      * predicate.
      *

--- a/packages/core/src/VNodes/VNode.ts
+++ b/packages/core/src/VNodes/VNode.ts
@@ -232,7 +232,6 @@ export class VNode {
     /**
      * Return the siblings of this VNode which satisfy the given predicate.
      */
-    siblings(predicate?: Predicate): VNode[];
     siblings<T extends VNode>(predicate?: Predicate<T>): T[];
     siblings<T>(predicate?: Predicate<T>): VNode[];
     siblings<T>(predicate?: Predicate<T>): VNode[] {
@@ -259,7 +258,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    ancestor(predicate?: Predicate): VNode;
     ancestor<T extends VNode>(predicate?: Predicate<T>): T;
     ancestor<T>(predicate?: Predicate<T>): VNode;
     ancestor<T>(predicate?: Predicate<T>): VNode {
@@ -275,7 +273,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    firstChild(predicate?: Predicate): VNode;
     firstChild<T extends VNode>(predicate?: Predicate<T>): T;
     firstChild<T>(predicate?: Predicate<T>): VNode;
     firstChild<T>(predicate?: Predicate<T>): VNode {
@@ -291,7 +288,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    lastChild(predicate?: Predicate): VNode;
     lastChild<T extends VNode>(predicate?: Predicate<T>): T;
     lastChild<T>(predicate?: Predicate<T>): VNode;
     lastChild<T>(predicate?: Predicate<T>): VNode {
@@ -307,7 +303,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    firstLeaf(predicate?: Predicate): VNode;
     firstLeaf<T extends VNode>(predicate?: Predicate<T>): T;
     firstLeaf<T>(predicate?: Predicate<T>): VNode;
     firstLeaf<T>(predicate?: Predicate<T>): VNode {
@@ -326,7 +321,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    lastLeaf(predicate?: Predicate): VNode;
     lastLeaf<T extends VNode>(predicate?: Predicate<T>): T;
     lastLeaf<T>(predicate?: Predicate<T>): VNode;
     lastLeaf<T>(predicate?: Predicate<T>): VNode {
@@ -345,7 +339,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    firstDescendant(predicate?: Predicate): VNode;
     firstDescendant<T extends VNode>(predicate?: Predicate<T>): T;
     firstDescendant<T>(predicate?: Predicate<T>): VNode;
     firstDescendant<T>(predicate?: Predicate<T>): VNode {
@@ -361,7 +354,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    lastDescendant(predicate?: Predicate): VNode;
     lastDescendant<T extends VNode>(predicate?: Predicate<T>): T;
     lastDescendant<T>(predicate?: Predicate<T>): VNode;
     lastDescendant<T>(predicate?: Predicate<T>): VNode {
@@ -380,7 +372,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    previousSibling(predicate?: Predicate): VNode;
     previousSibling<T extends VNode>(predicate?: Predicate<T>): T;
     previousSibling<T>(predicate?: Predicate<T>): VNode;
     previousSibling<T>(predicate?: Predicate<T>): VNode {
@@ -399,7 +390,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    nextSibling(predicate?: Predicate): VNode;
     nextSibling<T extends VNode>(predicate?: Predicate<T>): T;
     nextSibling<T>(predicate?: Predicate<T>): VNode;
     nextSibling<T>(predicate?: Predicate<T>): VNode {
@@ -419,7 +409,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    previous(predicate?: Predicate): VNode;
     previous<T extends VNode>(predicate?: Predicate<T>): T;
     previous<T>(predicate?: Predicate<T>): VNode;
     previous<T>(predicate?: Predicate<T>): VNode {
@@ -443,7 +432,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    next(predicate?: Predicate): VNode;
     next<T extends VNode>(predicate?: Predicate<T>): T;
     next<T>(predicate?: Predicate<T>): VNode;
     next<T>(predicate?: Predicate<T>): VNode {
@@ -474,7 +462,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    previousLeaf(predicate?: Predicate): VNode;
     previousLeaf<T extends VNode>(predicate?: Predicate<T>): T;
     previousLeaf<T>(predicate?: Predicate<T>): VNode;
     previousLeaf<T>(predicate?: Predicate<T>): VNode {
@@ -489,7 +476,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    nextLeaf(predicate?: Predicate): VNode;
     nextLeaf<T extends VNode>(predicate?: Predicate<T>): T;
     nextLeaf<T>(predicate?: Predicate<T>): VNode;
     nextLeaf<T>(predicate?: Predicate<T>): VNode {
@@ -504,7 +490,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    previousSiblings(predicate?: Predicate): VNode[];
     previousSiblings<T extends VNode>(predicate?: Predicate<T>): T[];
     previousSiblings<T>(predicate?: Predicate<T>): VNode[];
     previousSiblings<T>(predicate?: Predicate<T>): VNode[] {
@@ -525,7 +510,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    nextSiblings(predicate?: Predicate): VNode[];
     nextSiblings<T extends VNode>(predicate?: Predicate<T>): T[];
     nextSiblings<T>(predicate?: Predicate<T>): VNode[];
     nextSiblings<T>(predicate?: Predicate<T>): VNode[] {
@@ -545,7 +529,6 @@ export class VNode {
      *
      * @param predicate
      */
-    closest(predicate: Predicate): VNode;
     closest<T extends VNode>(predicate: Predicate<T>): T;
     closest<T>(predicate: Predicate<T>): VNode;
     closest<T>(predicate: Predicate<T>): VNode {
@@ -558,7 +541,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    ancestors(predicate?: Predicate): VNode[];
     ancestors<T extends VNode>(predicate?: Predicate<T>): T[];
     ancestors<T>(predicate?: Predicate<T>): VNode[];
     ancestors<T>(predicate?: Predicate<T>): VNode[] {
@@ -579,7 +561,6 @@ export class VNode {
      *
      * @param [predicate]
      */
-    descendants(predicate?: Predicate): VNode[];
     descendants<T extends VNode>(predicate?: Predicate<T>): T[];
     descendants<T>(predicate?: Predicate<T>): VNode[];
     descendants<T>(predicate?: Predicate<T>): VNode[] {
@@ -598,7 +579,6 @@ export class VNode {
      *
      * @param node
      */
-    commonAncestor(node: VNode, predicate?: Predicate): VNode;
     commonAncestor<T extends VNode>(node: VNode, predicate?: Predicate<T>): T;
     commonAncestor<T>(node: VNode, predicate?: Predicate<T>): VNode;
     commonAncestor<T>(node: VNode, predicate?: Predicate<T>): VNode {

--- a/packages/core/src/VRange.ts
+++ b/packages/core/src/VRange.ts
@@ -177,7 +177,11 @@ export class VRange {
      * @param [position]
      */
     setStart(reference: VNode, position = RelativePosition.BEFORE): void {
-        reference = reference.firstLeaf();
+        if (position === RelativePosition.BEFORE) {
+            reference = reference.firstLeaf();
+        } else {
+            reference = reference.lastLeaf();
+        }
         if (!reference.hasChildren() && !reference.atomic) {
             reference.prepend(this.start);
         } else if (position === RelativePosition.AFTER && reference !== this.end) {
@@ -199,7 +203,11 @@ export class VRange {
      * @param [position]
      */
     setEnd(reference: VNode, position = RelativePosition.AFTER): void {
-        reference = reference.lastLeaf();
+        if (position === RelativePosition.BEFORE) {
+            reference = reference.firstLeaf();
+        } else {
+            reference = reference.lastLeaf();
+        }
         if (!reference.hasChildren() && !reference.atomic) {
             reference.append(this.end);
         } else if (position === RelativePosition.BEFORE && reference !== this.start) {

--- a/packages/core/test/JWeditor.test.ts
+++ b/packages/core/test/JWeditor.test.ts
@@ -420,7 +420,8 @@ describe('core', () => {
                     editor.loadPlugin(B);
                     editor.loadPlugin(C);
                     await editor.start();
-                    expect(editor.plugins.map(p => p.constructor.name)).to.eql([
+                    const plugins = Array.from(editor.plugins.values());
+                    expect(plugins.map(p => p.constructor.name)).to.eql([
                         'CorePlugin',
                         'A',
                         'B',
@@ -434,7 +435,8 @@ describe('core', () => {
                     editor.loadPlugin(C);
                     editor.loadPlugin(E);
                     await editor.start();
-                    expect(editor.plugins.map(p => p.constructor.name)).to.eql([
+                    const plugins = Array.from(editor.plugins.values());
+                    expect(plugins.map(p => p.constructor.name)).to.eql([
                         'CorePlugin',
                         'A',
                         'B',
@@ -450,7 +452,8 @@ describe('core', () => {
                     editor.loadPlugin(C, { toto: 3 });
                     editor.loadPlugin(F);
                     await editor.start();
-                    expect(editor.plugins.map(p => p.constructor.name)).to.eql([
+                    const plugins = Array.from(editor.plugins.values());
+                    expect(plugins.map(p => p.constructor.name)).to.eql([
                         'CorePlugin',
                         'A',
                         'B',
@@ -458,7 +461,7 @@ describe('core', () => {
                         'D',
                         'F',
                     ]);
-                    const c = editor.plugins.find(p => p instanceof C);
+                    const c = editor.plugins.get(C);
                     expect((c.configuration as LocalConfig).toto).to.eql(3);
                 });
                 it('with dependencies without overwrite previous configuration but change order', async () => {
@@ -468,7 +471,8 @@ describe('core', () => {
                     editor.loadPlugin(B);
                     editor.loadPlugin(C, { toto: 3 });
                     await editor.start();
-                    expect(editor.plugins.map(p => p.constructor.name)).to.eql([
+                    const plugins = Array.from(editor.plugins.values());
+                    expect(plugins.map(p => p.constructor.name)).to.eql([
                         'CorePlugin',
                         'A',
                         'D',
@@ -476,7 +480,7 @@ describe('core', () => {
                         'F',
                         'B',
                     ]);
-                    const c = editor.plugins.find(p => p instanceof C);
+                    const c = editor.plugins.get(C);
                     expect((c.configuration as LocalConfig).toto).to.eql(3);
                 });
                 it('with dependencies without overwrite previous configuration but change order', async () => {
@@ -487,7 +491,8 @@ describe('core', () => {
                     editor.loadPlugin(B);
                     editor.loadPlugin(C, { toto: 3 });
                     await editor.start();
-                    expect(editor.plugins.map(p => p.constructor.name)).to.eql([
+                    const plugins = Array.from(editor.plugins.values());
+                    expect(plugins.map(p => p.constructor.name)).to.eql([
                         'CorePlugin',
                         'A',
                         'D',
@@ -496,7 +501,7 @@ describe('core', () => {
                         'F',
                         'B',
                     ]);
-                    const c = editor.plugins.find(p => p instanceof C);
+                    const c = editor.plugins.get(C);
                     expect((c.configuration as LocalConfig).toto).to.eql(3);
                 });
             });

--- a/packages/core/test/VNodes.test.ts
+++ b/packages/core/test/VNodes.test.ts
@@ -463,6 +463,33 @@ describe('core', () => {
                         expect(root.siblings()).to.deep.equal([]);
                     });
                 });
+                describe('adjacents', () => {
+                    it('should return the adjacent nodes', async () => {
+                        expect(h1.adjacents()).to.deep.equal([a, c, p]);
+                        expect(h1.adjacents(CharNode)).to.deep.equal([a, c]);
+                        expect(b.adjacents()).to.deep.equal([], 'siblings without the markers');
+                        expect(root.adjacents()).to.deep.equal([]);
+                    });
+                    it('should return the adjacent nodes', async () => {
+                        const container = new VNode();
+                        const a = new CharNode('a');
+                        container.append(a);
+                        const h2 = new HeadingNode(2);
+                        container.append(h2);
+                        const b = new CharNode('b');
+                        container.append(b);
+                        const c = new CharNode('c');
+                        container.append(c);
+                        const d = new CharNode('d');
+                        container.append(d);
+                        const h3 = new HeadingNode(3);
+                        container.append(h3);
+                        const e = new CharNode('e');
+                        container.append(e);
+                        expect(c.adjacents()).to.deep.equal([a, h2, b, d, h3, e]);
+                        expect(c.adjacents(CharNode)).to.deep.equal([b, d]);
+                    });
+                });
                 describe('firstChild', () => {
                     it('should return the firstChild node', async () => {
                         expect(root.firstChild()).to.deep.equal(a, 'root.firstChild = a');

--- a/packages/core/test/VNodes.test.ts
+++ b/packages/core/test/VNodes.test.ts
@@ -457,9 +457,10 @@ describe('core', () => {
                 });
                 describe('siblings', () => {
                     it('should return the node siblings', async () => {
-                        expect(h1.siblings).to.deep.equal([a, h1, c, p]);
-                        expect(b.siblings).to.deep.equal([b], 'siblings without the markers');
-                        expect(root.siblings).to.deep.equal([]);
+                        expect(h1.siblings()).to.deep.equal([a, c, p]);
+                        expect(h1.siblings(CharNode)).to.deep.equal([a, c]);
+                        expect(b.siblings()).to.deep.equal([], 'siblings without the markers');
+                        expect(root.siblings()).to.deep.equal([]);
                     });
                 });
                 describe('firstChild', () => {
@@ -959,7 +960,7 @@ describe('core', () => {
                         a.before(b);
                         const c = new CharNode('c');
                         a.before(c);
-                        expect(a.siblings).to.deep.equal([b, c, a]);
+                        expect(a.siblings()).to.deep.equal([b, c]);
                     });
                     it('should throw if no parent', async () => {
                         const root = new VNode();
@@ -978,7 +979,7 @@ describe('core', () => {
                         a.after(b);
                         const c = new CharNode('c');
                         a.after(c);
-                        expect(a.siblings).to.deep.equal([a, c, b]);
+                        expect(a.siblings()).to.deep.equal([c, b]);
                     });
                     it('should move a node after another', async () => {
                         const root = new VNode();
@@ -989,7 +990,7 @@ describe('core', () => {
                         const c = new CharNode('c');
                         root.append(c);
                         b.after(a);
-                        expect(a.siblings).to.deep.equal([b, a, c]);
+                        expect(a.siblings()).to.deep.equal([b, c]);
                     });
                     it('should throw if no parent', async () => {
                         const root = new VNode();
@@ -1008,7 +1009,7 @@ describe('core', () => {
                         root.insertBefore(b, a);
                         const c = new CharNode('c');
                         root.insertBefore(c, a);
-                        expect(a.siblings).to.deep.equal([b, c, a]);
+                        expect(a.siblings()).to.deep.equal([b, c]);
                     });
                     it('should throw when try to insert before unknown node', async () => {
                         expect(() => {
@@ -1025,7 +1026,7 @@ describe('core', () => {
                         root.insertAfter(b, a);
                         const c = new CharNode('c');
                         root.insertAfter(c, a);
-                        expect(a.siblings).to.deep.equal([a, c, b]);
+                        expect(a.siblings()).to.deep.equal([c, b]);
                     });
                     it('should throw when try to insert after unknown node', async () => {
                         expect(() => {
@@ -1042,9 +1043,9 @@ describe('core', () => {
                         root.append(b);
                         const c = new CharNode('c');
                         root.append(c);
-                        expect(a.siblings).to.deep.equal([a, b, c]);
+                        expect(a.siblings()).to.deep.equal([b, c]);
                         b.remove();
-                        expect(a.siblings).to.deep.equal([a, c]);
+                        expect(a.siblings()).to.deep.equal([c]);
                     });
                 });
                 describe('removeChild', () => {
@@ -1056,9 +1057,9 @@ describe('core', () => {
                         root.append(b);
                         const c = new CharNode('c');
                         root.append(c);
-                        expect(a.siblings).to.deep.equal([a, b, c]);
+                        expect(a.siblings()).to.deep.equal([b, c]);
                         root.removeChild(b);
-                        expect(a.siblings).to.deep.equal([a, c]);
+                        expect(a.siblings()).to.deep.equal([c]);
                     });
                     it('should throw when try to remove a unknown node', async () => {
                         expect(() => {

--- a/packages/plugin-blockquote/Blockquote.ts
+++ b/packages/plugin-blockquote/Blockquote.ts
@@ -1,0 +1,6 @@
+import { JWPlugin, JWPluginConfig } from '../core/src/JWPlugin';
+import { BlockquoteDomParser } from './BlockquoteDomParser';
+
+export class Blockquote<T extends JWPluginConfig> extends JWPlugin<T> {
+    readonly parsers = [BlockquoteDomParser];
+}

--- a/packages/plugin-blockquote/BlockquoteDomParser.ts
+++ b/packages/plugin-blockquote/BlockquoteDomParser.ts
@@ -1,0 +1,20 @@
+import { AbstractParser } from '../core/src/AbstractParser';
+import { DomParsingEngine } from '../plugin-dom/DomParsingEngine';
+import { BlockquoteNode } from './BlockquoteNode';
+
+export class BlockquoteDomParser extends AbstractParser<Node> {
+    static id = 'dom';
+    engine: DomParsingEngine;
+
+    predicate = (item: Node): boolean => {
+        return item instanceof Element && item.nodeName === 'BLOCKQUOTE';
+    };
+
+    async parse(item: Element): Promise<BlockquoteNode[]> {
+        const blockquote = new BlockquoteNode();
+        blockquote.attributes = this.engine.parseAttributes(item);
+        const nodes = await this.engine.parse(...item.childNodes);
+        blockquote.append(...nodes);
+        return [blockquote];
+    }
+}

--- a/packages/plugin-blockquote/BlockquoteDomParser.ts
+++ b/packages/plugin-blockquote/BlockquoteDomParser.ts
@@ -7,7 +7,7 @@ export class BlockquoteDomParser extends AbstractParser<Node> {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && item.nodeName === 'BLOCKQUOTE';
+        return item instanceof Element && item.tagName === 'BLOCKQUOTE';
     };
 
     async parse(item: Element): Promise<BlockquoteNode[]> {

--- a/packages/plugin-blockquote/BlockquoteNode.ts
+++ b/packages/plugin-blockquote/BlockquoteNode.ts
@@ -1,0 +1,7 @@
+import { VElement } from '../core/src/VNodes/VElement';
+
+export class BlockquoteNode extends VElement {
+    constructor() {
+        super('BLOCKQUOTE');
+    }
+}

--- a/packages/plugin-bold/BoldDomParser.ts
+++ b/packages/plugin-bold/BoldDomParser.ts
@@ -8,7 +8,7 @@ export class BoldDomParser extends FormatParser {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && (item.nodeName === 'B' || item.nodeName === 'STRONG');
+        return item instanceof Element && (item.tagName === 'B' || item.tagName === 'STRONG');
     };
 
     /**
@@ -17,7 +17,7 @@ export class BoldDomParser extends FormatParser {
      * @param item
      */
     async parse(item: Element): Promise<VNode[]> {
-        const bold = new BoldFormat(item.nodeName as 'B' | 'STRONG');
+        const bold = new BoldFormat(item.tagName as 'B' | 'STRONG');
         bold.attributes = this.engine.parseAttributes(item);
         const children = await this.engine.parse(...item.childNodes);
         this.applyFormat(bold, children);

--- a/packages/plugin-char/Char.ts
+++ b/packages/plugin-char/Char.ts
@@ -11,6 +11,7 @@ import { Formats } from '../plugin-inline/Formats';
 
 export interface InsertTextParams extends CommandParams {
     text: string;
+    formats?: Formats;
 }
 
 export class Char<T extends JWPluginConfig> extends JWPlugin<T> {
@@ -51,7 +52,10 @@ export class Char<T extends JWPluginConfig> extends JWPlugin<T> {
     insertText(params: InsertTextParams): void {
         const range = params.context.range;
         const text = params.text;
-        const formats = this.getCurrentFormats();
+        const formats = this.getCurrentFormats().clone();
+        for (const format of params.formats || []) {
+            formats.replace(format.constructor, format);
+        }
         // Remove the contents of the range if needed.
         if (!range.isCollapsed()) {
             range.empty();

--- a/packages/plugin-char/CharDomRenderer.ts
+++ b/packages/plugin-char/CharDomRenderer.ts
@@ -1,5 +1,6 @@
 import { AbstractRenderer } from '../core/src/AbstractRenderer';
 import { CharNode } from './CharNode';
+import { InlineNode } from '../plugin-inline/InlineNode';
 
 export class CharDomRenderer extends AbstractRenderer<Node[]> {
     static id = 'dom';
@@ -22,8 +23,15 @@ export class CharDomRenderer extends AbstractRenderer<Node[]> {
             }
             next = next.nextSibling();
         }
-        // Browsers don't render leading/trailing space chars otherwise.
-        text = text.replace(/^ | $/g, '\u00A0');
+        // Render block edge spaces as non-breakable space (otherwise browsers
+        // won't render them).
+        const previous = node.previousSibling();
+        if (!previous || !previous.is(InlineNode)) {
+            text = text.replace(/^ /g, '\u00A0');
+        }
+        if (!next || !next.is(InlineNode)) {
+            text = text.replace(/ $/g, '\u00A0');
+        }
         const rendering = Promise.resolve([document.createTextNode(text)]);
         return this.engine.rendered(charNodes, [this, rendering]);
     }

--- a/packages/plugin-char/CharFormatDomRenderer.ts
+++ b/packages/plugin-char/CharFormatDomRenderer.ts
@@ -1,9 +1,12 @@
 import { InlineFormatDomRenderer } from '../plugin-inline/InlineFormatDomRenderer';
 import { CharNode } from './CharNode';
+import { DomRenderingEngine } from '../plugin-dom/DomRenderingEngine';
 
 export class CharFormatDomRenderer extends InlineFormatDomRenderer {
     static id = 'dom';
+    engine: DomRenderingEngine;
     predicate = CharNode;
+
     async render(node: CharNode): Promise<Node[]> {
         const previousSibling = node.previousSibling();
         if (previousSibling && node.isSameTextNode(previousSibling)) {
@@ -18,12 +21,7 @@ export class CharFormatDomRenderer extends InlineFormatDomRenderer {
         const attributeNames = Object.keys(node.attributes);
         if (attributeNames.length) {
             const span = document.createElement('span');
-            for (const name of attributeNames) {
-                const value = node.attributes[name];
-                if (typeof value === 'string') {
-                    span.setAttribute(name, value);
-                }
-            }
+            this.engine.renderAttributes(node.attributes, span);
             textNode.forEach(child => span.appendChild(child));
             rendering = [span];
         } else {

--- a/packages/plugin-char/CharNode.ts
+++ b/packages/plugin-char/CharNode.ts
@@ -1,12 +1,12 @@
 import { MarkerNode } from '../core/src/VNodes/MarkerNode';
-import { Format } from '../plugin-inline/Format';
 import { InlineNode } from '../plugin-inline/InlineNode';
 import { VNode } from '../core/src/VNodes/VNode';
+import { Formats } from '../plugin-inline/Formats';
 
 export class CharNode extends InlineNode {
     static readonly atomic = true;
     readonly char: string;
-    constructor(char: string, format?: Format[]) {
+    constructor(char: string, format?: Formats) {
         super();
         if (char.length !== 1) {
             throw new Error(
@@ -32,7 +32,7 @@ export class CharNode extends InlineNode {
      * @override
      */
     clone(): this {
-        const clone = new this.constructor<typeof CharNode>(this.char, [...this.formats]);
+        const clone = new this.constructor<typeof CharNode>(this.char, this.formats.clone());
         clone.attributes = { ...this.attributes };
         return clone;
     }

--- a/packages/plugin-char/test/Char.test.ts
+++ b/packages/plugin-char/test/Char.test.ts
@@ -13,6 +13,7 @@ import { FormatParams } from '../../plugin-inline/Inline';
 import { Constructor } from '../../utils/src/utils';
 import { Format } from '../../plugin-inline/Format';
 import { UnderlineFormat } from '../../plugin-underline/UnderlineFormat';
+import { Formats } from '../../plugin-inline/Formats';
 
 const insertText = async function(editor, text: string): Promise<void> {
     const params: InsertTextParams = {
@@ -63,7 +64,7 @@ describePlugin(Char, testEditor => {
                 expect(c.length).to.equal(1);
             });
             it('should create a CharNode with format', async () => {
-                const c = new CharNode(' ', [new BoldFormat()]);
+                const c = new CharNode(' ', new Formats(BoldFormat));
                 expect(c.char).to.equal(' ');
                 expect(c.atomic).to.equal(true);
                 expect(c.formats.length).to.equal(1);
@@ -91,7 +92,7 @@ describePlugin(Char, testEditor => {
             });
             it('should duplicate a char with format', async () => {
                 const c = new CharNode('a');
-                c.formats = [new BoldFormat()];
+                c.formats = new Formats(BoldFormat);
                 const copy = c.clone();
                 expect(copy).to.not.equal(c);
                 expect(copy.char).to.equal(c.char);
@@ -101,7 +102,7 @@ describePlugin(Char, testEditor => {
             it('should mark as italic a duplicate a char', async () => {
                 const c = new CharNode('a');
                 const copy = c.clone();
-                copy.formats = [new ItalicFormat()];
+                copy.formats = new Formats(ItalicFormat);
                 expect(copy.formats.length).to.equal(1, 'copy now has one format');
                 expect(copy.formats[0].htmlTag).to.equal('I', 'copy is now italic');
                 expect(c.formats.length).to.equal(0, 'original char is not italic');
@@ -109,7 +110,7 @@ describePlugin(Char, testEditor => {
             it('should update the format for a duplicate a char', async () => {
                 const c = new CharNode('a');
                 const copy = c.clone();
-                copy.formats = [new ItalicFormat()];
+                copy.formats = new Formats(ItalicFormat);
                 expect(copy.formats.length).to.equal(1, 'copy now has one format');
                 expect(copy.formats[0].htmlTag).to.equal('I', 'copy is now italic');
                 expect(c.formats.length).to.equal(0, 'original char is not italic');

--- a/packages/plugin-devtools/assets/DevTools.css
+++ b/packages/plugin-devtools/assets/DevTools.css
@@ -40,6 +40,11 @@ jw-devtools .link {
     color: blue;
 }
 
+jw-devtools .subscript {
+    vertical-align: sub;
+    font-size: 0.7em;
+}
+
 jw-devtools .marker-node {
     color: red;
 }

--- a/packages/plugin-devtools/assets/DevTools.css
+++ b/packages/plugin-devtools/assets/DevTools.css
@@ -45,6 +45,11 @@ jw-devtools .subscript {
     font-size: 0.7em;
 }
 
+jw-devtools .superscript {
+    vertical-align: super;
+    font-size: 0.7em;
+}
+
 jw-devtools .marker-node {
     color: red;
 }

--- a/packages/plugin-devtools/assets/DevTools.css
+++ b/packages/plugin-devtools/assets/DevTools.css
@@ -35,6 +35,11 @@ jw-devtools .underline {
     text-decoration: underline;
 }
 
+jw-devtools .link {
+    text-decoration: underline;
+    color: blue;
+}
+
 jw-devtools .marker-node {
     color: red;
 }

--- a/packages/plugin-devtools/assets/DevTools.xml
+++ b/packages/plugin-devtools/assets/DevTools.xml
@@ -59,6 +59,7 @@
                     underline: isFormat(props.vNode, 'u'),
                     link: isFormat(props.vNode, 'link'),
                     subscript: isFormat(props.vNode, 'subscript'),
+                    superscript: isFormat(props.vNode, 'superscript'),
                     selected: props.selectedID == props.vNode.id,
                 }">
                 <t t-esc="repr()"/>
@@ -72,6 +73,7 @@
                         underline: isFormat(props.vNode, 'u'),
                         link: isFormat(props.vNode, 'link'),
                         subscript: isFormat(props.vNode, 'subscript'),
+                        superscript: isFormat(props.vNode, 'superscript'),
                         selected: props.selectedID == props.vNode.id,
                         'line-break': props.vNode.htmlTag === 'BR',
                     }">

--- a/packages/plugin-devtools/assets/DevTools.xml
+++ b/packages/plugin-devtools/assets/DevTools.xml
@@ -54,10 +54,11 @@
             <span t-elif="props.vNode.char" t-on-click="onClickNode"
                 t-on-dblclick="onDblClickNode"
                 class="selectable-line" t-att-class="{
-                    bold: isBold(props.vNode),
-                    italic: isItalic(props.vNode),
-                    underline: isUnderline(props.vNode),
-                    link: isLink(props.vNode),
+                    bold: isFormat(props.vNode, 'b'),
+                    italic: isFormat(props.vNode, 'i'),
+                    underline: isFormat(props.vNode, 'u'),
+                    link: isFormat(props.vNode, 'link'),
+                    subscript: isFormat(props.vNode, 'subscript'),
                     selected: props.selectedID == props.vNode.id,
                 }">
                 <t t-esc="repr()"/>
@@ -66,10 +67,11 @@
                 <span class="element-name selectable-line" t-on-click="onClickNode"
                     t-on-dblclick="onDblClickNode"
                     t-att-class="{
-                        bold: isBold(props.vNode),
-                        italic: isItalic(props.vNode),
-                        underline: isUnderline(props.vNode),
-                        link: isLink(props.vNode),
+                        bold: isFormat(props.vNode, 'b'),
+                        italic: isFormat(props.vNode, 'i'),
+                        underline: isFormat(props.vNode, 'u'),
+                        link: isFormat(props.vNode, 'link'),
+                        subscript: isFormat(props.vNode, 'subscript'),
                         selected: props.selectedID == props.vNode.id,
                         'line-break': props.vNode.htmlTag === 'BR',
                     }">

--- a/packages/plugin-devtools/assets/DevTools.xml
+++ b/packages/plugin-devtools/assets/DevTools.xml
@@ -57,6 +57,7 @@
                     bold: isBold(props.vNode),
                     italic: isItalic(props.vNode),
                     underline: isUnderline(props.vNode),
+                    link: isLink(props.vNode),
                     selected: props.selectedID == props.vNode.id,
                 }">
                 <t t-esc="repr()"/>
@@ -68,6 +69,7 @@
                         bold: isBold(props.vNode),
                         italic: isItalic(props.vNode),
                         underline: isUnderline(props.vNode),
+                        link: isLink(props.vNode),
                         selected: props.selectedID == props.vNode.id,
                         'line-break': props.vNode.htmlTag === 'BR',
                     }">

--- a/packages/plugin-devtools/src/components/TreeComponent.ts
+++ b/packages/plugin-devtools/src/components/TreeComponent.ts
@@ -119,36 +119,12 @@ export class TreeComponent extends OwlUIComponent<NodeProps> {
         this.state.folded = !this.state.folded;
     }
     /**
-     * Return true if the given node is bold.
+     * Return true if the given node has the given format.
      *
      * @param node
      */
-    isBold(node: VNode): boolean {
-        return node.is(InlineNode) && !!node.formats.find(format => format.name === 'b');
-    }
-    /**
-     * Return true if the given node is italic.
-     *
-     * @param node
-     */
-    isItalic(node: VNode): boolean {
-        return node.is(InlineNode) && !!node.formats.find(format => format.name === 'i');
-    }
-    /**
-     * Return true if the given node is underline.
-     *
-     * @param node
-     */
-    isUnderline(node: VNode): boolean {
-        return node.is(InlineNode) && !!node.formats.find(format => format.name === 'u');
-    }
-    /**
-     * Return true if the given node is underline.
-     *
-     * @param node
-     */
-    isLink(node: VNode): boolean {
-        return node.is(InlineNode) && !!node.formats.find(format => format.name === 'link');
+    isFormat(node: VNode, formatName: string): boolean {
+        return node.is(InlineNode) && !!node.formats.find(format => format.name === formatName);
     }
 
     //--------------------------------------------------------------------------

--- a/packages/plugin-devtools/src/components/TreeComponent.ts
+++ b/packages/plugin-devtools/src/components/TreeComponent.ts
@@ -145,7 +145,7 @@ export class TreeComponent extends OwlUIComponent<NodeProps> {
             return FOCUS_CHAR;
         }
         if (node.name) {
-            return toUnicode(node.name);
+            return toUnicode(node.name).replace(/Node/, '');
         }
         return '?';
     }

--- a/packages/plugin-devtools/src/components/TreeComponent.ts
+++ b/packages/plugin-devtools/src/components/TreeComponent.ts
@@ -142,6 +142,14 @@ export class TreeComponent extends OwlUIComponent<NodeProps> {
     isUnderline(node: VNode): boolean {
         return node.is(InlineNode) && !!node.formats.find(format => format.name === 'u');
     }
+    /**
+     * Return true if the given node is underline.
+     *
+     * @param node
+     */
+    isLink(node: VNode): boolean {
+        return node.is(InlineNode) && !!node.formats.find(format => format.name === 'link');
+    }
 
     //--------------------------------------------------------------------------
     // Private

--- a/packages/plugin-devtools/test/devtools.test.ts
+++ b/packages/plugin-devtools/test/devtools.test.ts
@@ -689,7 +689,7 @@ describe('Plugin: DevTools', () => {
             expect(button.classList.contains('selected')).to.equal(true, 'button is selected');
 
             const subpanel = devtools.querySelector('devtools-panel.active mainpane-contents');
-            expect(subpanel.firstElementChild.nodeName).to.equal('TABLE');
+            expect(subpanel.firstElementChild.tagName).to.equal('TABLE');
         });
         it('should change sub panel to "Registry"', async () => {
             await openDevTools(devtools);
@@ -701,7 +701,7 @@ describe('Plugin: DevTools', () => {
             await click(button);
             expect(button.classList.contains('selected')).to.equal(true, 'button is selected');
             const subpanel = devtools.querySelector('devtools-panel.active mainpane-contents');
-            expect(subpanel.firstElementChild.nodeName).to.equal('DIV');
+            expect(subpanel.firstElementChild.tagName).to.equal('DIV');
             expect(Array.from(subpanel.childNodes).map((n: Node) => n.textContent)).to.deep.equal([
                 'insert',
                 'insertParagraphBreak',

--- a/packages/plugin-devtools/test/devtools.test.ts
+++ b/packages/plugin-devtools/test/devtools.test.ts
@@ -716,6 +716,8 @@ describe('Plugin: DevTools', () => {
                 'toggleList',
                 'indent',
                 'outdent',
+                'link',
+                'unlink',
             ]);
         });
         it('should display the previous commands in "Queue" of "Commands" panel', async () => {

--- a/packages/plugin-divider/Divider.ts
+++ b/packages/plugin-divider/Divider.ts
@@ -1,0 +1,6 @@
+import { JWPlugin, JWPluginConfig } from '../core/src/JWPlugin';
+import { DividerDomParser } from './DividerDomParser';
+
+export class Divider<T extends JWPluginConfig> extends JWPlugin<T> {
+    readonly parsers = [DividerDomParser];
+}

--- a/packages/plugin-divider/DividerDomParser.ts
+++ b/packages/plugin-divider/DividerDomParser.ts
@@ -1,0 +1,20 @@
+import { AbstractParser } from '../core/src/AbstractParser';
+import { DomParsingEngine } from '../plugin-dom/DomParsingEngine';
+import { DividerNode } from './DividerNode';
+
+export class DividerDomParser extends AbstractParser<Node> {
+    static id = 'dom';
+    engine: DomParsingEngine;
+
+    predicate = (item: Node): boolean => {
+        return item instanceof Element && item.nodeName === 'DIV';
+    };
+
+    async parse(item: Element): Promise<DividerNode[]> {
+        const divider = new DividerNode();
+        divider.attributes = this.engine.parseAttributes(item);
+        const nodes = await this.engine.parse(...item.childNodes);
+        divider.append(...nodes);
+        return [divider];
+    }
+}

--- a/packages/plugin-divider/DividerDomParser.ts
+++ b/packages/plugin-divider/DividerDomParser.ts
@@ -7,7 +7,7 @@ export class DividerDomParser extends AbstractParser<Node> {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && item.nodeName === 'DIV';
+        return item instanceof Element && item.tagName === 'DIV';
     };
 
     async parse(item: Element): Promise<DividerNode[]> {

--- a/packages/plugin-divider/DividerNode.ts
+++ b/packages/plugin-divider/DividerNode.ts
@@ -1,0 +1,7 @@
+import { VElement } from '../core/src/VNodes/VElement';
+
+export class DividerNode extends VElement {
+    constructor() {
+        super('DIV');
+    }
+}

--- a/packages/plugin-dom/DefaultDomParser.ts
+++ b/packages/plugin-dom/DefaultDomParser.ts
@@ -1,11 +1,17 @@
 import { VNode } from '../core/src/VNodes/VNode';
 import { AbstractParser } from '../core/src/AbstractParser';
 import { VElement } from '../core/src/VNodes/VElement';
+import { DomParsingEngine } from './DomParsingEngine';
 
 export class DefaultDomParser extends AbstractParser<Node> {
     static id = 'dom';
+    engine: DomParsingEngine;
+
     async parse(item: Node): Promise<VNode[]> {
         const element = new VElement(item.nodeName);
+        if (item instanceof Element) {
+            element.attributes = this.engine.parseAttributes(item);
+        }
         // If the node could not be parsed, create a generic element node with
         // the HTML tag of the DOM Node. This way we may not support the node
         // but we don't break it either.

--- a/packages/plugin-dom/DefaultDomRenderer.ts
+++ b/packages/plugin-dom/DefaultDomRenderer.ts
@@ -2,9 +2,12 @@ import { AbstractRenderer } from '../core/src/AbstractRenderer';
 import { VNode, isMarker } from '../core/src/VNodes/VNode';
 import { FragmentNode } from '../core/src/VNodes/FragmentNode';
 import { VElement } from '../core/src/VNodes/VElement';
+import { DomRenderingEngine } from './DomRenderingEngine';
 
 export class DefaultDomRenderer extends AbstractRenderer<Node[]> {
     static id = 'dom';
+    engine: DomRenderingEngine;
+
     async render(node: VNode): Promise<Node[]> {
         let domNode: Node;
         if (isMarker(node)) {
@@ -20,12 +23,7 @@ export class DefaultDomRenderer extends AbstractRenderer<Node[]> {
                 nodeName = node.constructor.name.toUpperCase() + '-' + node.id;
             }
             const element = document.createElement(nodeName);
-            for (const name of Object.keys(node.attributes)) {
-                const value = node.attributes[name];
-                if (typeof value === 'string') {
-                    element.setAttribute(name, value);
-                }
-            }
+            this.engine.renderAttributes(node.attributes, element);
             domNode = element;
         }
         // If a node is empty but could accomodate children,

--- a/packages/plugin-dom/DomRenderingEngine.ts
+++ b/packages/plugin-dom/DomRenderingEngine.ts
@@ -4,4 +4,20 @@ import { DefaultDomRenderer } from './DefaultDomRenderer';
 export class DomRenderingEngine extends RenderingEngine<Node[]> {
     static readonly id = 'dom';
     static readonly defaultRenderer = DefaultDomRenderer;
+    /**
+     * Render the attributes of the given VNode onto the given DOM Element.
+     *
+     * @param node
+     */
+    renderAttributes(
+        attributes: Record<string, string | Record<string, string>>,
+        element: Element,
+    ): void {
+        for (const name of Object.keys(attributes)) {
+            const value = attributes[name];
+            if (typeof value === 'string') {
+                element.setAttribute(name, value);
+            }
+        }
+    }
 }

--- a/packages/plugin-heading/HeadingDomParser.ts
+++ b/packages/plugin-heading/HeadingDomParser.ts
@@ -9,11 +9,11 @@ export class HeadingDomParser extends AbstractParser<Node> {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && HeadingTags.includes(item.nodeName);
+        return item instanceof Element && HeadingTags.includes(item.tagName);
     };
 
     async parse(item: Element): Promise<HeadingNode[]> {
-        const heading = new HeadingNode(parseInt(item.nodeName[1], 10));
+        const heading = new HeadingNode(parseInt(item.tagName[1], 10));
         heading.attributes = this.engine.parseAttributes(item);
         const nodes = await this.engine.parse(...item.childNodes);
         heading.append(...nodes);

--- a/packages/plugin-image/Image.ts
+++ b/packages/plugin-image/Image.ts
@@ -1,0 +1,8 @@
+import { JWPlugin, JWPluginConfig } from '../core/src/JWPlugin';
+import { ImageDomParser } from './ImageDomParser';
+import { ImageDomRenderer } from './ImageDomRenderer';
+
+export class Image<T extends JWPluginConfig> extends JWPlugin<T> {
+    readonly parsers = [ImageDomParser];
+    readonly renderers = [ImageDomRenderer];
+}

--- a/packages/plugin-image/ImageDomParser.ts
+++ b/packages/plugin-image/ImageDomParser.ts
@@ -7,7 +7,7 @@ export class ImageDomParser extends AbstractParser<Node> {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && item.nodeName === 'IMG';
+        return item instanceof Element && item.tagName === 'IMG';
     };
 
     async parse(item: Element): Promise<ImageNode[]> {

--- a/packages/plugin-image/ImageDomParser.ts
+++ b/packages/plugin-image/ImageDomParser.ts
@@ -1,0 +1,18 @@
+import { ImageNode } from './ImageNode';
+import { AbstractParser } from '../core/src/AbstractParser';
+import { DomParsingEngine } from '../plugin-dom/DomParsingEngine';
+
+export class ImageDomParser extends AbstractParser<Node> {
+    static id = 'dom';
+    engine: DomParsingEngine;
+
+    predicate = (item: Node): boolean => {
+        return item instanceof Element && item.nodeName === 'IMG';
+    };
+
+    async parse(item: Element): Promise<ImageNode[]> {
+        const image = new ImageNode();
+        image.attributes = this.engine.parseAttributes(item);
+        return [image];
+    }
+}

--- a/packages/plugin-image/ImageDomRenderer.ts
+++ b/packages/plugin-image/ImageDomRenderer.ts
@@ -1,0 +1,15 @@
+import { AbstractRenderer } from '../core/src/AbstractRenderer';
+import { ImageNode } from './ImageNode';
+import { DomRenderingEngine } from '../plugin-dom/DomRenderingEngine';
+
+export class ImageDomRenderer extends AbstractRenderer<Node[]> {
+    static id = 'dom';
+    engine: DomRenderingEngine;
+    predicate = ImageNode;
+
+    async render(node: ImageNode): Promise<Node[]> {
+        const image = document.createElement('img');
+        this.engine.renderAttributes(node.attributes, image);
+        return [image];
+    }
+}

--- a/packages/plugin-image/ImageNode.ts
+++ b/packages/plugin-image/ImageNode.ts
@@ -1,0 +1,5 @@
+import { InlineNode } from '../plugin-inline/InlineNode';
+
+export class ImageNode extends InlineNode {
+    static readonly atomic = true;
+}

--- a/packages/plugin-inline/Format.ts
+++ b/packages/plugin-inline/Format.ts
@@ -1,6 +1,12 @@
-import { deepEqualObjects } from '../utils/src/utils';
+import { deepEqualObjects, Constructor } from '../utils/src/utils';
 import { InlineNode } from './InlineNode';
 
+interface FormatConstructor {
+    new <T extends Constructor<Format>>(...args: ConstructorParameters<T>): this;
+}
+export interface Format {
+    constructor: FormatConstructor & this;
+}
 export class Format {
     htmlTag: string; // TODO: remove this reference to DOM.
     attributes: Record<string, string> = {};
@@ -32,8 +38,8 @@ export class Format {
     applyTo(node: InlineNode): void {
         node.formats.unshift(this);
     }
-    clone(): Format {
-        const clone = new (this.constructor as typeof Format)();
+    clone(): this {
+        const clone = new this.constructor();
         clone.htmlTag = this.htmlTag;
         clone.attributes = { ...this.attributes };
         return clone;

--- a/packages/plugin-inline/Formats.ts
+++ b/packages/plugin-inline/Formats.ts
@@ -1,0 +1,140 @@
+import { Format } from './Format';
+import { Constructor } from '../utils/src/utils';
+
+export class Formats extends Array<Format> {
+    constructor(...formats: Array<Format | Constructor<Format>>) {
+        // Native Array constructor takes the length as argument.
+        const length = formats[0];
+        if (typeof length === 'number') {
+            super(length);
+        } else {
+            super(0);
+            this.append(...formats);
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * Append one or more formats to the array. If one of the given formats is a
+     * format class constructor, instantiate it.
+     *
+     * @param formats
+     */
+    append(...formats: Array<Format | Constructor<Format>>): void {
+        for (const format of formats) {
+            if (format instanceof Format) {
+                this.push(format);
+            } else {
+                this.push(new format());
+            }
+        }
+    }
+    /**
+     * Prepend one or more formats to the array. If one of the given formats is
+     * a format class constructor, instantiate it.
+     *
+     * @param formats
+     */
+    prepend(...formats: Array<Format | Constructor<Format>>): void {
+        for (const format of formats) {
+            if (format instanceof Format) {
+                this.unshift(format);
+            } else {
+                this.unshift(new format());
+            }
+        }
+    }
+    /**
+     * Return the first format in the array that is an instance of the given
+     * format class, if any. If the format passed is a format instance, return
+     * it if it was present in the array.
+     *
+     * @param format
+     */
+    get<T extends Format>(format: T | Constructor<T>): T {
+        if (format instanceof Format) {
+            return this.find(instance => instance === format) as T;
+        } else {
+            for (const instance of this) {
+                if (instance instanceof format) {
+                    return instance;
+                }
+            }
+        }
+    }
+    /**
+     * Remove the first format in the array that is an instance of the given
+     * format class. If a format instance is given, remove that particuar
+     * instance from the array. Return true if a format was removed, false
+     * otherwise.
+     *
+     * @param format
+     */
+    remove(format: Format | Constructor<Format>): boolean {
+        const formatIndex = this.findIndex(formatInstance => {
+            if (format instanceof Format) {
+                return formatInstance === format;
+            } else {
+                return formatInstance instanceof format;
+            }
+        });
+        if (formatIndex === -1) {
+            return false;
+        } else {
+            this.splice(formatIndex, 1);
+            return true;
+        }
+    }
+    /**
+     * Replace the first format in the array that is an instance of the given
+     * format class or that matches the particular instance passed with the
+     * given format instance. If the new format passed is a class, instantiate
+     * it. If no format was found, simply push the new format on the array.
+     *
+     * Return true if a format was replaced, false if the format was simply
+     * added.
+     *
+     * @param oldFormat
+     * @param newFormat
+     */
+    replace(
+        oldFormat: Format | Constructor<Format>,
+        newFormat: Format | Constructor<Format>,
+    ): boolean {
+        const oldFormatIndex = this.findIndex(formatInstance => {
+            if (oldFormat instanceof Format) {
+                return formatInstance === oldFormat;
+            } else {
+                return formatInstance instanceof oldFormat;
+            }
+        });
+        if (oldFormatIndex === -1) {
+            this.append(newFormat);
+            return false;
+        } else {
+            const format = newFormat instanceof Format ? newFormat : new newFormat();
+            this[oldFormatIndex] = format;
+            return true;
+        }
+    }
+    /**
+     * Remove the first format in the array that is an instance of the given
+     * format class or that matches the particular instance passed.
+     * If no format was found, add the given format instead.
+     * If the given new format is a class, instantiate it.
+     *
+     * @param format
+     */
+    toggle(format: Format | Constructor<Format>): void {
+        this.remove(format) || this.append(format);
+    }
+    /**
+     * Return a new instance of the Formats class containing the same formats.
+     */
+    clone(): Formats {
+        return new Formats(...this);
+    }
+}

--- a/packages/plugin-inline/Inline.ts
+++ b/packages/plugin-inline/Inline.ts
@@ -35,25 +35,24 @@ export class Inline<T extends JWPluginConfig> extends JWPlugin<T> {
         // If every char in the range has the format `FormatClass`, remove
         // the format for all of them.
         const allHaveFormat = selectedInlines.every(inline => {
-            return !!inline.formats.find(f => f instanceof FormatClass);
+            return !!inline.formats.get(FormatClass);
         });
         if (allHaveFormat) {
             for (const inline of selectedInlines) {
-                const index = inline.formats.findIndex(f => f instanceof FormatClass);
                 // Apply the attributes of the format we're about to remove to
                 // the inline itself.
-                const matchingFormat = inline.formats[index];
+                const matchingFormat = inline.formats.get(FormatClass);
                 for (const key of Object.keys(matchingFormat.attributes)) {
                     inline.attributes[key] = matchingFormat.attributes[key];
                 }
                 // Remove the format.
-                inline.formats.splice(index, 1);
+                inline.formats.remove(matchingFormat);
             }
         } else {
             // If there is at least one char in the range without the format
             // `FormatClass`, set the format for all nodes.
             for (const inline of selectedInlines) {
-                if (!inline.formats.find(f => f instanceof FormatClass)) {
+                if (!inline.formats.get(FormatClass)) {
                     new FormatClass().applyTo(inline);
                 }
             }

--- a/packages/plugin-inline/InlineNode.ts
+++ b/packages/plugin-inline/InlineNode.ts
@@ -1,6 +1,6 @@
 import { VNode } from '../core/src/VNodes/VNode';
-import { Format } from './Format';
+import { Formats } from './Formats';
 
 export class InlineNode extends VNode {
-    formats: Format[] = [];
+    formats = new Formats();
 }

--- a/packages/plugin-italic/ItalicDomParser.ts
+++ b/packages/plugin-italic/ItalicDomParser.ts
@@ -8,7 +8,7 @@ export class ItalicDomParser extends FormatParser {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && (item.nodeName === 'I' || item.nodeName === 'EM');
+        return item instanceof Element && (item.tagName === 'I' || item.tagName === 'EM');
     };
 
     /**
@@ -17,7 +17,7 @@ export class ItalicDomParser extends FormatParser {
      * @param item
      */
     async parse(item: Element): Promise<VNode[]> {
-        const italic = new ItalicFormat(item.nodeName as 'I' | 'EM');
+        const italic = new ItalicFormat(item.tagName as 'I' | 'EM');
         italic.attributes = this.engine.parseAttributes(item);
         const children = await this.engine.parse(...item.childNodes);
         this.applyFormat(italic, children);

--- a/packages/plugin-linebreak/LineBreakDomParser.ts
+++ b/packages/plugin-linebreak/LineBreakDomParser.ts
@@ -8,7 +8,7 @@ export class LineBreakDomParser extends AbstractParser<Node> {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && item.nodeName === 'BR';
+        return item instanceof Element && item.tagName === 'BR';
     };
 
     async parse(item: Element): Promise<LineBreakNode[]> {

--- a/packages/plugin-linebreak/LineBreakDomRenderer.ts
+++ b/packages/plugin-linebreak/LineBreakDomRenderer.ts
@@ -1,8 +1,10 @@
 import { AbstractRenderer } from '../core/src/AbstractRenderer';
 import { LineBreakNode } from './LineBreakNode';
+import { DomRenderingEngine } from '../plugin-dom/DomRenderingEngine';
 
 export class LineBreakDomRenderer extends AbstractRenderer<Node[]> {
     static id = 'dom';
+    engine: DomRenderingEngine;
     predicate = LineBreakNode;
 
     /**
@@ -10,12 +12,7 @@ export class LineBreakDomRenderer extends AbstractRenderer<Node[]> {
      */
     async render(node: LineBreakNode): Promise<Node[]> {
         const br = document.createElement('br');
-        for (const name of Object.keys(node.attributes)) {
-            const value = node.attributes[name];
-            if (typeof value === 'string') {
-                br.setAttribute(name, value);
-            }
-        }
+        this.engine.renderAttributes(node.attributes, br);
         const rendering = [br];
         if (!node.nextSibling()) {
             // If a LineBreakNode has no next sibling, it must be rendered

--- a/packages/plugin-link/Link.ts
+++ b/packages/plugin-link/Link.ts
@@ -1,0 +1,99 @@
+import { JWPlugin, JWPluginConfig } from '../core/src/JWPlugin';
+import { Inline } from '../plugin-inline/Inline';
+import { LinkDomParser } from './LinkDomParser';
+import { CommandParams } from '../core/src/Dispatcher';
+import { InlineNode } from '../plugin-inline/InlineNode';
+import { LinkFormat } from './LinkFormat';
+import { InsertTextParams } from '../plugin-char/Char';
+import { Formats } from '../plugin-inline/Formats';
+import { VNode, Typeguard } from '../core/src/VNodes/VNode';
+
+export interface LinkParams extends CommandParams {
+    label?: string;
+    url?: string;
+}
+
+export class Link<T extends JWPluginConfig> extends JWPlugin<T> {
+    static isLink(node: VNode): node is InlineNode;
+    static isLink(link: LinkFormat, node: VNode): node is InlineNode;
+    static isLink(link: LinkFormat | VNode, node?: VNode): node is InlineNode {
+        if (link instanceof VNode) {
+            node = link;
+        }
+        const format = node.is(InlineNode) && node.formats.get(LinkFormat);
+        return link instanceof VNode ? !!format : format === link;
+    }
+    static dependencies = [Inline];
+    readonly parsers = [LinkDomParser];
+    commands = {
+        link: {
+            handler: this.link.bind(this),
+        },
+        unlink: {
+            handler: this.unlink.bind(this),
+        },
+    };
+    shortcuts = [
+        {
+            pattern: 'CTRL+K',
+            selector: [(node: VNode): boolean => !Link.isLink(node)],
+            commandId: 'link',
+            // TODO: use dialog to get params
+            commandArgs: {
+                url: 'https://en.wikipedia.org/wiki/Jabberwocky',
+                label: 'Jabberwockipedia',
+            },
+        },
+        {
+            pattern: 'CTRL+K',
+            selector: [Link.isLink],
+            commandId: 'unlink',
+        },
+    ];
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    link(params: LinkParams): void {
+        const range = params.context.range;
+        const selectedInlines = range.selectedNodes(InlineNode);
+
+        let link: LinkFormat;
+        if (params.url) {
+            link = new LinkFormat(params.url);
+        } else {
+            // Reuse the url of the first link found in range.
+            const firstLink = selectedInlines.find(node => node.formats.get(LinkFormat));
+            link = firstLink && firstLink.formats.get(LinkFormat).clone();
+        }
+
+        // TODO: modal re-using url
+        if (!link) return;
+
+        if (range.isCollapsed()) {
+            const insertParams: InsertTextParams = {
+                text: params.label || link.url,
+                formats: new Formats(link),
+            };
+            this.editor.execCommand('insertText', insertParams);
+        } else {
+            for (const inline of selectedInlines) {
+                inline.formats.replace(LinkFormat, link);
+            }
+        }
+    }
+    unlink(params: LinkParams): void {
+        const range = params.context.range;
+        const node = range.start.previousSibling() || range.start.nextSibling();
+        if (!node.is(InlineNode)) return;
+
+        const link = node.formats.get(LinkFormat);
+        if (!link) return;
+
+        const sameLink: Typeguard<InlineNode> = Link.isLink.bind(Link, link);
+        for (const inline of [node, ...node.adjacents(sameLink)]) {
+            inline.formats.remove(link);
+        }
+    }
+}

--- a/packages/plugin-link/LinkDomParser.ts
+++ b/packages/plugin-link/LinkDomParser.ts
@@ -1,0 +1,22 @@
+import { FormatParser } from '../plugin-inline/FormatParser';
+import { DomParsingEngine } from '../plugin-dom/DomParsingEngine';
+import { VNode } from '../core/src/VNodes/VNode';
+import { LinkFormat } from './LinkFormat';
+
+export class LinkDomParser extends FormatParser {
+    static id = 'dom';
+    engine: DomParsingEngine;
+
+    predicate = (item: Node): boolean => {
+        return item instanceof Element && item.nodeName === 'A';
+    };
+
+    async parse(item: Element): Promise<VNode[]> {
+        const link = new LinkFormat();
+        link.attributes = this.engine.parseAttributes(item);
+        const children = await this.engine.parse(...item.childNodes);
+        this.applyFormat(link, children);
+
+        return children;
+    }
+}

--- a/packages/plugin-link/LinkDomParser.ts
+++ b/packages/plugin-link/LinkDomParser.ts
@@ -8,7 +8,7 @@ export class LinkDomParser extends FormatParser {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && item.nodeName === 'A';
+        return item instanceof Element && item.tagName === 'A';
     };
 
     async parse(item: Element): Promise<VNode[]> {

--- a/packages/plugin-link/LinkFormat.ts
+++ b/packages/plugin-link/LinkFormat.ts
@@ -1,0 +1,14 @@
+import { Format } from '../plugin-inline/Format';
+
+export class LinkFormat extends Format {
+    constructor(url?: string) {
+        super('A');
+        this.url = url;
+    }
+    get url(): string {
+        return this.attributes.href;
+    }
+    set url(url: string) {
+        this.attributes.href = url;
+    }
+}

--- a/packages/plugin-list/ListDomParser.ts
+++ b/packages/plugin-list/ListDomParser.ts
@@ -10,7 +10,7 @@ export class ListDomParser extends AbstractParser<Node> {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && listTags.includes(item.nodeName);
+        return item instanceof Element && listTags.includes(item.tagName);
     };
 
     /**
@@ -19,10 +19,8 @@ export class ListDomParser extends AbstractParser<Node> {
      * @param context
      */
     async parse(item: Element): Promise<VNode[]> {
-        if (!listTags.includes(item.nodeName)) {
-            return;
-        }
-        const listType = item.nodeName === 'UL' ? ListType.UNORDERED : ListType.ORDERED;
+        if (!listTags.includes(item.tagName)) return;
+        const listType = item.tagName === 'UL' ? ListType.UNORDERED : ListType.ORDERED;
         const listNode = new ListNode(listType);
         listNode.attributes = this.engine.parseAttributes(item);
         const nodes = await this.engine.parse(...item.childNodes);

--- a/packages/plugin-list/ListDomRenderer.ts
+++ b/packages/plugin-list/ListDomRenderer.ts
@@ -1,23 +1,16 @@
 import { AbstractRenderer } from '../core/src/AbstractRenderer';
 import { ListNode, ListType } from './ListNode';
+import { DomRenderingEngine } from '../plugin-dom/DomRenderingEngine';
 
 export class ListDomRenderer extends AbstractRenderer<Node[]> {
     static id = 'dom';
+    engine: DomRenderingEngine;
     predicate = ListNode;
 
-    /**
-     * Render the ListNode in currentContext.
-     */
     async render(node: ListNode): Promise<Node[]> {
         const tag = node.listType === ListType.ORDERED ? 'OL' : 'UL';
         const domListNode = document.createElement(tag);
-        // Render the list's attributes.
-        for (const name of Object.keys(node.attributes)) {
-            const value = node.attributes[name];
-            if (typeof value === 'string') {
-                domListNode.setAttribute(name, value);
-            }
-        }
+        this.engine.renderAttributes(node.attributes, domListNode);
 
         for (const child of node.children) {
             const renderedChild = await this.engine.render(child);

--- a/packages/plugin-list/ListItemDomParser.ts
+++ b/packages/plugin-list/ListItemDomParser.ts
@@ -8,7 +8,7 @@ export class ListItemDomParser extends AbstractParser<Node> {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && item.nodeName === 'LI';
+        return item instanceof Element && item.tagName === 'LI';
     };
 
     /**

--- a/packages/plugin-list/ListItemDomRenderer.ts
+++ b/packages/plugin-list/ListItemDomRenderer.ts
@@ -3,9 +3,11 @@ import { VNode } from '../core/src/VNodes/VNode';
 import { ListNode } from './ListNode';
 import { VElement } from '../core/src/VNodes/VElement';
 import { List } from './List';
+import { DomRenderingEngine } from '../plugin-dom/DomRenderingEngine';
 
 export class ListItemDomRenderer extends AbstractRenderer<Node[]> {
     static id = 'dom';
+    engine: DomRenderingEngine;
     predicate = List.isListItem;
 
     async render(node: VNode): Promise<Node[]> {
@@ -45,13 +47,9 @@ export class ListItemDomRenderer extends AbstractRenderer<Node[]> {
         }
         // Render the node's attributes that were stored on the technical key
         // that specifies those attributes belong on the list item.
-        if (node.attributes['li-attributes']) {
-            for (const name of Object.keys(node.attributes['li-attributes'])) {
-                const value = node.attributes['li-attributes'][name];
-                if (typeof value === 'string') {
-                    domListItem.setAttribute(name, value);
-                }
-            }
+        const liAttributes = node.attributes['li-attributes'];
+        if (liAttributes && typeof liAttributes !== 'string') {
+            this.engine.renderAttributes(liAttributes, domListItem);
         }
         return [domListItem];
     }

--- a/packages/plugin-list/test/ListDomRenderer.test.ts
+++ b/packages/plugin-list/test/ListDomRenderer.test.ts
@@ -6,6 +6,7 @@ import { ListNode, ListType } from '../ListNode';
 import { VElement } from '../../core/src/VNodes/VElement';
 import { CharNode } from '../../plugin-char/CharNode';
 import { BoldFormat } from '../../plugin-bold/BoldFormat';
+import { Formats } from '../../plugin-inline/Formats';
 
 describe('ListDomRenderer', () => {
     describe('render', () => {
@@ -56,7 +57,7 @@ describe('ListDomRenderer', () => {
             const ul = new ListNode(ListType.UNORDERED);
             const p2 = new VElement('P');
             p2.append(new CharNode('a'));
-            p2.append(new CharNode('.', [new BoldFormat()]));
+            p2.append(new CharNode('.', new Formats(BoldFormat)));
             p2.append(new CharNode('a'));
             ul.append(p2);
 

--- a/packages/plugin-metadata/MetaDataDomRenderer.ts
+++ b/packages/plugin-metadata/MetaDataDomRenderer.ts
@@ -1,0 +1,16 @@
+import { AbstractRenderer } from '../core/src/AbstractRenderer';
+import { DomRenderingEngine } from '../plugin-dom/DomRenderingEngine';
+import { MetadataNode } from './MetadataNode';
+
+export class MetadataDomRenderer extends AbstractRenderer<Node[]> {
+    static id = 'dom';
+    engine: DomRenderingEngine;
+    predicate = MetadataNode;
+
+    async render(node: MetadataNode): Promise<Node[]> {
+        const domNode = document.createElement(node.htmlTag);
+        this.engine.renderAttributes(node.attributes, domNode);
+        domNode.innerHTML = node.contents;
+        return [domNode];
+    }
+}

--- a/packages/plugin-metadata/Metadata.ts
+++ b/packages/plugin-metadata/Metadata.ts
@@ -1,0 +1,8 @@
+import { JWPlugin, JWPluginConfig } from '../core/src/JWPlugin';
+import { MetadataDomParser } from './MetadataDomParser';
+import { MetadataDomRenderer } from './MetaDataDomRenderer';
+
+export class Metadata<T extends JWPluginConfig> extends JWPlugin<T> {
+    readonly parsers = [MetadataDomParser];
+    readonly renderers = [MetadataDomRenderer];
+}

--- a/packages/plugin-metadata/MetadataDomParser.ts
+++ b/packages/plugin-metadata/MetadataDomParser.ts
@@ -19,11 +19,11 @@ export class MetadataDomParser extends AbstractParser<Node> {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && METADATA_NODENAMES.includes(item.nodeName);
+        return item instanceof Element && METADATA_NODENAMES.includes(item.tagName);
     };
 
     async parse(item: Element): Promise<MetadataNode[]> {
-        const technical = new MetadataNode(item.nodeName as 'SCRIPT' | 'STYLE');
+        const technical = new MetadataNode(item.tagName as 'SCRIPT' | 'STYLE');
         technical.attributes = this.engine.parseAttributes(item);
         technical.contents = item.innerHTML;
         return [technical];

--- a/packages/plugin-metadata/MetadataDomParser.ts
+++ b/packages/plugin-metadata/MetadataDomParser.ts
@@ -1,0 +1,31 @@
+import { AbstractParser } from '../core/src/AbstractParser';
+import { DomParsingEngine } from '../plugin-dom/DomParsingEngine';
+import { MetadataNode } from './MetadataNode';
+
+// See https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Metadata_content
+const METADATA_NODENAMES = [
+    'BASE',
+    'COMMAND',
+    'LINK',
+    'META',
+    'NOSCRIPT',
+    'SCRIPT',
+    'STYLE',
+    'TITLE',
+];
+
+export class MetadataDomParser extends AbstractParser<Node> {
+    static id = 'dom';
+    engine: DomParsingEngine;
+
+    predicate = (item: Node): boolean => {
+        return item instanceof Element && METADATA_NODENAMES.includes(item.nodeName);
+    };
+
+    async parse(item: Element): Promise<MetadataNode[]> {
+        const technical = new MetadataNode(item.nodeName as 'SCRIPT' | 'STYLE');
+        technical.attributes = this.engine.parseAttributes(item);
+        technical.contents = item.innerHTML;
+        return [technical];
+    }
+}

--- a/packages/plugin-metadata/MetadataNode.ts
+++ b/packages/plugin-metadata/MetadataNode.ts
@@ -1,0 +1,14 @@
+import { MarkerNode } from '../core/src/VNodes/MarkerNode';
+
+export class MetadataNode extends MarkerNode {
+    static readonly atomic = true;
+    htmlTag: string;
+    contents = '';
+    constructor(htmlTag: string) {
+        super();
+        this.htmlTag = htmlTag;
+    }
+    get name(): string {
+        return this.constructor.name + ': ' + this.htmlTag;
+    }
+}

--- a/packages/plugin-paragraph/ParagraphDomParser.ts
+++ b/packages/plugin-paragraph/ParagraphDomParser.ts
@@ -7,7 +7,7 @@ export class ParagraphDomParser extends AbstractParser<Node> {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && item.nodeName === 'P';
+        return item instanceof Element && item.tagName === 'P';
     };
 
     async parse(item: Element): Promise<ParagraphNode[]> {

--- a/packages/plugin-span/SpanDomParser.ts
+++ b/packages/plugin-span/SpanDomParser.ts
@@ -8,7 +8,7 @@ export class SpanDomParser extends FormatParser {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && (item.nodeName === 'SPAN' || item.nodeName === 'FONT');
+        return item instanceof Element && (item.tagName === 'SPAN' || item.tagName === 'FONT');
     };
 
     /**
@@ -17,7 +17,7 @@ export class SpanDomParser extends FormatParser {
      * @param item
      */
     async parse(item: Element): Promise<VNode[]> {
-        const span = new SpanFormat(item.nodeName as 'SPAN' | 'FONT');
+        const span = new SpanFormat(item.tagName as 'SPAN' | 'FONT');
         span.attributes = this.engine.parseAttributes(item);
         const children = await this.engine.parse(...item.childNodes);
         this.applyFormat(span, children);

--- a/packages/plugin-subscript/Subscript.ts
+++ b/packages/plugin-subscript/Subscript.ts
@@ -1,0 +1,8 @@
+import { JWPlugin, JWPluginConfig } from '../core/src/JWPlugin';
+import { SubscriptDomParser } from './SubscriptDomParser';
+import { Inline } from '../plugin-inline/Inline';
+
+export class Subscript<T extends JWPluginConfig> extends JWPlugin<T> {
+    static dependencies = [Inline];
+    readonly parsers = [SubscriptDomParser];
+}

--- a/packages/plugin-subscript/SubscriptDomParser.ts
+++ b/packages/plugin-subscript/SubscriptDomParser.ts
@@ -8,7 +8,7 @@ export class SubscriptDomParser extends FormatParser {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && item.nodeName === 'SUB';
+        return item instanceof Element && item.tagName === 'SUB';
     };
 
     /**

--- a/packages/plugin-subscript/SubscriptDomParser.ts
+++ b/packages/plugin-subscript/SubscriptDomParser.ts
@@ -1,0 +1,27 @@
+import { FormatParser } from '../plugin-inline/FormatParser';
+import { VNode } from '../core/src/VNodes/VNode';
+import { SubscriptFormat } from './SubscriptFormat';
+import { DomParsingEngine } from '../plugin-dom/DomParsingEngine';
+
+export class SubscriptDomParser extends FormatParser {
+    static id = 'dom';
+    engine: DomParsingEngine;
+
+    predicate = (item: Node): boolean => {
+        return item instanceof Element && item.nodeName === 'SUB';
+    };
+
+    /**
+     * Parse a span node.
+     *
+     * @param item
+     */
+    async parse(item: Element): Promise<VNode[]> {
+        const subscript = new SubscriptFormat();
+        subscript.attributes = this.engine.parseAttributes(item);
+        const children = await this.engine.parse(...item.childNodes);
+        this.applyFormat(subscript, children);
+
+        return children;
+    }
+}

--- a/packages/plugin-subscript/SubscriptFormat.ts
+++ b/packages/plugin-subscript/SubscriptFormat.ts
@@ -1,0 +1,7 @@
+import { Format } from '../plugin-inline/Format';
+
+export class SubscriptFormat extends Format {
+    constructor() {
+        super('SUB');
+    }
+}

--- a/packages/plugin-superscript/Superscript.ts
+++ b/packages/plugin-superscript/Superscript.ts
@@ -1,0 +1,8 @@
+import { JWPlugin, JWPluginConfig } from '../core/src/JWPlugin';
+import { SuperscriptDomParser } from './SuperscriptDomParser';
+import { Inline } from '../plugin-inline/Inline';
+
+export class Superscript<T extends JWPluginConfig> extends JWPlugin<T> {
+    static dependencies = [Inline];
+    readonly parsers = [SuperscriptDomParser];
+}

--- a/packages/plugin-superscript/SuperscriptDomParser.ts
+++ b/packages/plugin-superscript/SuperscriptDomParser.ts
@@ -8,7 +8,7 @@ export class SuperscriptDomParser extends FormatParser {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && item.nodeName === 'SUP';
+        return item instanceof Element && item.tagName === 'SUP';
     };
 
     /**

--- a/packages/plugin-superscript/SuperscriptDomParser.ts
+++ b/packages/plugin-superscript/SuperscriptDomParser.ts
@@ -1,0 +1,27 @@
+import { FormatParser } from '../plugin-inline/FormatParser';
+import { VNode } from '../core/src/VNodes/VNode';
+import { SuperscriptFormat } from './SuperscriptFormat';
+import { DomParsingEngine } from '../plugin-dom/DomParsingEngine';
+
+export class SuperscriptDomParser extends FormatParser {
+    static id = 'dom';
+    engine: DomParsingEngine;
+
+    predicate = (item: Node): boolean => {
+        return item instanceof Element && item.nodeName === 'SUP';
+    };
+
+    /**
+     * Parse a span node.
+     *
+     * @param item
+     */
+    async parse(item: Element): Promise<VNode[]> {
+        const subscript = new SuperscriptFormat();
+        subscript.attributes = this.engine.parseAttributes(item);
+        const children = await this.engine.parse(...item.childNodes);
+        this.applyFormat(subscript, children);
+
+        return children;
+    }
+}

--- a/packages/plugin-superscript/SuperscriptFormat.ts
+++ b/packages/plugin-superscript/SuperscriptFormat.ts
@@ -1,0 +1,7 @@
+import { Format } from '../plugin-inline/Format';
+
+export class SuperscriptFormat extends Format {
+    constructor() {
+        super('SUP');
+    }
+}

--- a/packages/plugin-table/Table.ts
+++ b/packages/plugin-table/Table.ts
@@ -1,0 +1,6 @@
+import { JWPlugin, JWPluginConfig } from '../core/src/JWPlugin';
+import { TableDomParser } from './TableDomParser';
+
+export class Table<T extends JWPluginConfig> extends JWPlugin<T> {
+    readonly parsers = [TableDomParser];
+}

--- a/packages/plugin-table/TableDomParser.ts
+++ b/packages/plugin-table/TableDomParser.ts
@@ -1,0 +1,20 @@
+import { AbstractParser } from '../core/src/AbstractParser';
+import { DomParsingEngine } from '../plugin-dom/DomParsingEngine';
+import { TableNode } from './TableNode';
+
+export class TableDomParser extends AbstractParser<Node> {
+    static id = 'dom';
+    engine: DomParsingEngine;
+
+    predicate = (item: Node): boolean => {
+        return item instanceof Element && item.nodeName === 'TABLE';
+    };
+
+    async parse(item: Element): Promise<TableNode[]> {
+        const table = new TableNode();
+        table.attributes = this.engine.parseAttributes(item);
+        const nodes = await this.engine.parse(...item.childNodes);
+        table.append(...nodes);
+        return [table];
+    }
+}

--- a/packages/plugin-table/TableDomParser.ts
+++ b/packages/plugin-table/TableDomParser.ts
@@ -7,7 +7,7 @@ export class TableDomParser extends AbstractParser<Node> {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && item.nodeName === 'TABLE';
+        return item instanceof Element && item.tagName === 'TABLE';
     };
 
     async parse(item: Element): Promise<TableNode[]> {

--- a/packages/plugin-table/TableNode.ts
+++ b/packages/plugin-table/TableNode.ts
@@ -1,0 +1,7 @@
+import { VElement } from '../core/src/VNodes/VElement';
+
+export class TableNode extends VElement {
+    constructor() {
+        super('TABLE');
+    }
+}

--- a/packages/plugin-underline/UnderlineDomParser.ts
+++ b/packages/plugin-underline/UnderlineDomParser.ts
@@ -8,7 +8,7 @@ export class UnderlineDomParser extends FormatParser {
     engine: DomParsingEngine;
 
     predicate = (item: Node): boolean => {
-        return item instanceof Element && item.nodeName === 'U';
+        return item instanceof Element && item.tagName === 'U';
     };
 
     /**

--- a/packages/plugin-youtube/Youtube.ts
+++ b/packages/plugin-youtube/Youtube.ts
@@ -1,0 +1,8 @@
+import { JWPlugin, JWPluginConfig } from '../core/src/JWPlugin';
+import { YoutubeDomParser } from './YoutubeDomParser';
+import { YoutubeDomRenderer } from './YoutubeDomRenderer';
+
+export class Youtube<T extends JWPluginConfig> extends JWPlugin<T> {
+    readonly parsers = [YoutubeDomParser];
+    readonly renderers = [YoutubeDomRenderer];
+}

--- a/packages/plugin-youtube/YoutubeDomParser.ts
+++ b/packages/plugin-youtube/YoutubeDomParser.ts
@@ -1,0 +1,22 @@
+import { YoutubeNode } from './YoutubeNode';
+import { AbstractParser } from '../core/src/AbstractParser';
+import { DomParsingEngine } from '../plugin-dom/DomParsingEngine';
+
+export class YoutubeDomParser extends AbstractParser<Node> {
+    static id = 'dom';
+    engine: DomParsingEngine;
+
+    predicate = (item: Node): boolean => {
+        const isYoutubeVideo =
+            item instanceof Element &&
+            item.nodeName === 'IFRAME' &&
+            item.getAttribute('src').includes('youtu');
+        return isYoutubeVideo;
+    };
+
+    async parse(item: Element): Promise<YoutubeNode[]> {
+        const youtube = new YoutubeNode();
+        youtube.attributes = this.engine.parseAttributes(item);
+        return [youtube];
+    }
+}

--- a/packages/plugin-youtube/YoutubeDomParser.ts
+++ b/packages/plugin-youtube/YoutubeDomParser.ts
@@ -9,7 +9,7 @@ export class YoutubeDomParser extends AbstractParser<Node> {
     predicate = (item: Node): boolean => {
         const isYoutubeVideo =
             item instanceof Element &&
-            item.nodeName === 'IFRAME' &&
+            item.tagName === 'IFRAME' &&
             item.getAttribute('src').includes('youtu');
         return isYoutubeVideo;
     };

--- a/packages/plugin-youtube/YoutubeDomRenderer.ts
+++ b/packages/plugin-youtube/YoutubeDomRenderer.ts
@@ -1,0 +1,15 @@
+import { AbstractRenderer } from '../core/src/AbstractRenderer';
+import { YoutubeNode } from './YoutubeNode';
+import { DomRenderingEngine } from '../plugin-dom/DomRenderingEngine';
+
+export class YoutubeDomRenderer extends AbstractRenderer<Node[]> {
+    static id = 'dom';
+    engine: DomRenderingEngine;
+    predicate = YoutubeNode;
+
+    async render(node: YoutubeNode): Promise<Node[]> {
+        const youtube = document.createElement('iframe');
+        this.engine.renderAttributes(node.attributes, youtube);
+        return [youtube];
+    }
+}

--- a/packages/plugin-youtube/YoutubeNode.ts
+++ b/packages/plugin-youtube/YoutubeNode.ts
@@ -1,0 +1,5 @@
+import { InlineNode } from '../plugin-inline/InlineNode';
+
+export class YoutubeNode extends InlineNode {
+    static readonly atomic = true;
+}

--- a/packages/plugin-youtube/test/YouTube.test.ts
+++ b/packages/plugin-youtube/test/YouTube.test.ts
@@ -1,0 +1,26 @@
+/* eslint-disable max-nested-callbacks */
+import { expect } from 'chai';
+import { describePlugin } from '../../utils/src/testUtils';
+import { Youtube } from '../Youtube';
+import { DomParsingEngine } from '../../plugin-dom/DomParsingEngine';
+import JWEditor from '../../core/src/JWEditor';
+import { YoutubeDomParser } from '../YoutubeDomParser';
+
+describePlugin(Youtube, () => {
+    describe('parser', () => {
+        it('should parse a youtube video', async () => {
+            const editor = new JWEditor();
+            const engine = new DomParsingEngine(editor);
+            engine.register(YoutubeDomParser);
+            const element = document.createElement('div');
+            element.innerHTML =
+                '<iframe src="https://www.youtube-nocookie.com/embed/Ih8K2SKHJPI?start=15"></iframe>';
+            const node = (await engine.parse(element))[0];
+            expect(node.children().length).to.equal(1);
+            expect(node.children()[0].toString()).to.equal('YoutubeNode');
+            expect(node.children()[0].attributes).to.deep.equal({
+                src: 'https://www.youtube-nocookie.com/embed/Ih8K2SKHJPI?start=15',
+            });
+        });
+    });
+});

--- a/packages/utils/src/isBlock.ts
+++ b/packages/utils/src/isBlock.ts
@@ -60,7 +60,7 @@ export function isBlock(node: Node): boolean {
         if (style.display) {
             result = style.display.includes('block') || style.display.includes('list');
         } else {
-            result = blockTagNames.includes(node.nodeName);
+            result = blockTagNames.includes(node.tagName);
         }
     } else {
         result = false;

--- a/packages/utils/src/isBlock.ts
+++ b/packages/utils/src/isBlock.ts
@@ -58,7 +58,7 @@ export function isBlock(node: Node): boolean {
         }
         // The node might not be in the DOM, in which case it has no CSS values.
         if (style.display) {
-            result = style.display.includes('block') || style.display.includes('list');
+            result = !style.display.includes('inline') && style.display !== 'contents';
         } else {
             result = blockTagNames.includes(node.tagName);
         }


### PR DESCRIPTION
Many of these will not change. Some will change significantly (`table`). These are placeholders for many of the most common nodes and formats from the DOM:
- Format: Link (a, button)
- Divider (div)
- Image (img)
- Format: Subscript (sub)
- Format: Superscript (sup)
- Blockquote (blockquote)
- Youtube (iframe src="...youtu...")
- Table (table) - naive: no contents
- Metadata (script, style, ...) - naive: no rendering

This also includes plenty of fixes of problems that were revealed in the process of implementing these.