### PR TITLE
[REF] core: refactor dispatcher to merge command and handlers

### DIFF
--- a/packages/core/src/Dispatcher.ts
+++ b/packages/core/src/Dispatcher.ts
@@ -16,8 +16,7 @@ export class Dispatcher {
     __nextHandlerTokenID = 0;
     editor: JWEditor;
     el: Element;
-    commands: Record<CommandIdentifier, CommandDefinition> = {};
-    handlers: Record<CommandIdentifier, CommandHandler[]> = {};
+    commands: Record<CommandIdentifier, CommandDefinition[]> = {};
 
     constructor(editor: JWEditor) {
         this.editor = editor;
@@ -35,10 +34,10 @@ export class Dispatcher {
      * @param args The arguments of the command.
      */
     async dispatch(commandId: CommandIdentifier, args: CommandArgs = {}): Promise<void> {
-        const handlers = this.handlers[commandId];
-        if (handlers) {
-            for (const handlerCallback of handlers) {
-                await handlerCallback(args);
+        const commands = this.commands[commandId];
+        if (commands) {
+            for (const command of commands) {
+                await command.handler(args);
             }
         }
     }
@@ -49,25 +48,10 @@ export class Dispatcher {
      *
      */
     registerCommand(id: CommandIdentifier, def: CommandDefinition): void {
-        if (this.commands[id]) {
-            throw new Error(`Command ${id} already exists. Hook it instead.`);
-        }
-        this.commands[id] = def;
-        // Commands always have at least one handler for their identifier which
-        // is their own internal implementation. Additional handlers registered
-        // by calling `registerHook` will be pushed after it, thus constructing
-        // a queue of callbacks to call in order to execute a given command.
-        this.handlers[id] = [def.handler];
-    }
-
-    /**
-     * Register `CommandHook` for a `Command`.
-     */
-    registerHook(id: CommandIdentifier, handler: CommandHandler): void {
         if (!this.commands[id]) {
-            throw new Error(`Failed to hook command ${id}. Command not found.`);
+            this.commands[id] = [def];
         } else {
-            this.handlers[id].push(handler);
+            this.commands[id].push(def);
         }
     }
 }

--- a/packages/core/src/JWEditor.ts
+++ b/packages/core/src/JWEditor.ts
@@ -160,10 +160,6 @@ export class JWEditor {
             Object.keys(plugin.commands).forEach(key => {
                 this.dispatcher.registerCommand(key, plugin.commands[key]);
             });
-            // Register the hooks of this plugin.
-            Object.keys(plugin.commandHooks).forEach(key => {
-                this.dispatcher.registerHook(key, plugin.commandHooks[key]);
-            });
             // register the shortcuts for this plugin.
             if (plugin.shortcuts) {
                 for (const shortcut of plugin.shortcuts) {

--- a/packages/core/src/JWPlugin.ts
+++ b/packages/core/src/JWPlugin.ts
@@ -16,7 +16,6 @@ export class JWPlugin {
     name: string;
     editor: JWEditor;
     commands: Record<CommandIdentifier, CommandDefinition> = {};
-    commandHooks: Record<CommandIdentifier, CommandHandler> = {};
     shortcuts: Shortcut[];
 
     constructor(editor: JWEditor, options: JWPluginConfig = {}) {

--- a/packages/core/test/Dispatcher.test.ts
+++ b/packages/core/test/Dispatcher.test.ts
@@ -6,7 +6,7 @@ import { Dispatcher, CommandDefinition } from '../src/Dispatcher';
 describe('utils', () => {
     describe('Dispatcher', () => {
         describe('dispatch()', () => {
-            it('dispatch an event with argument', () => {
+            it('dispatch an event with argument', async () => {
                 const callback = sinon.fake();
                 const editor = new JWEditor();
                 const dispatcher = new Dispatcher(editor);
@@ -14,11 +14,11 @@ describe('utils', () => {
                     handler: callback,
                 };
                 dispatcher.registerCommand('myCommand', command);
-                dispatcher.dispatch('myCommand', { arrayArg: ['argOne', 'argTwo'] });
+                await dispatcher.dispatch('myCommand', { arrayArg: ['argOne', 'argTwo'] });
                 expect(callback.callCount).to.eql(1);
                 expect(callback.args[0][0]).to.eql({ arrayArg: ['argOne', 'argTwo'] });
             });
-            it('dispatch an event without argument', () => {
+            it('dispatch an event without argument', async () => {
                 const callback = sinon.fake();
                 const editor = new JWEditor();
                 const dispatcher = new Dispatcher(editor);
@@ -26,40 +26,26 @@ describe('utils', () => {
                     handler: callback,
                 };
                 dispatcher.registerCommand('myCommand', command);
-                dispatcher.dispatch('myCommand');
+                await dispatcher.dispatch('myCommand');
                 expect(callback.callCount).to.eql(1);
                 expect(callback.args[0][0]).to.eql({});
             });
-            it('dispatch an event that has one hook', async () => {
+            it('dispatch an event that trigger two callbacks', async () => {
                 const callbackCommand = sinon.fake();
-                const callbackHook = sinon.fake();
+                const callbackCommand2 = sinon.fake();
                 const editor = new JWEditor();
                 const dispatcher = new Dispatcher(editor);
                 const command: CommandDefinition = {
                     handler: callbackCommand,
                 };
-                dispatcher.registerCommand('myCommand', command);
-                dispatcher.registerHook('myCommand', callbackHook);
-                await dispatcher.dispatch('myCommand');
-                expect(callbackCommand.callCount).to.eql(1);
-                expect(callbackHook.callCount).to.eql(1);
-            });
-            it('dispatch an event that has multiples hook', async () => {
-                const callbackCommand = sinon.fake();
-                const callbackHook1 = sinon.fake();
-                const callbackHook2 = sinon.fake();
-                const editor = new JWEditor();
-                const dispatcher = new Dispatcher(editor);
-                const command: CommandDefinition = {
-                    handler: callbackCommand,
+                const command2: CommandDefinition = {
+                    handler: callbackCommand2,
                 };
                 dispatcher.registerCommand('myCommand', command);
-                dispatcher.registerHook('myCommand', callbackHook1);
-                dispatcher.registerHook('myCommand', callbackHook2);
+                dispatcher.registerCommand('myCommand', command2);
                 await dispatcher.dispatch('myCommand');
                 expect(callbackCommand.callCount).to.eql(1);
-                expect(callbackHook1.callCount).to.eql(1);
-                expect(callbackHook2.callCount).to.eql(1);
+                expect(callbackCommand2.callCount).to.eql(1);
             });
         });
     });

--- a/packages/plugin-devtools/assets/DevTools.xml
+++ b/packages/plugin-devtools/assets/DevTools.xml
@@ -218,7 +218,7 @@
         t-att-class="{active: props.isOpen}" tabindex="1"
         t-on-keydown="onKeydown">
         <devtools-contents t-if="props.isOpen">
-            <t t-set="handlers" t-value="state.handlers[state.selectedCommandIdentifier]"/>
+            <t t-set="selectedCommandDefinitions" t-value="state.registry[state.selectedCommandIdentifier]"/>
             <devtools-mainpane style="overflow: hidden">
                 <devtools-navbar>
                     <button t-on-click="openTab('queue')" t-att-class="{
@@ -266,7 +266,7 @@
                                 <t t-set="payload" t-value="selectedCommand[1]"/>
                                 <t t-call="commandArgs"/>
                             </t>
-                            <t t-call="commandHandlers"/>
+                            <t t-call="selectedCommandTable"/>
                         </div>
                     </div>
                 </devtools-info>
@@ -276,7 +276,7 @@
                             <span class="type">Command</span> <t t-esc="state.selectedCommandIdentifier"/>
                         </div>
                         <div class="properties" t-if="state.selectedCommandIdentifier">
-                            <t t-call="commandHandlers"/>
+                            <t t-call="selectedCommandTable"/>
                         </div>
                     </t>
                 </devtools-info>
@@ -332,18 +332,18 @@
         </table>
     </t>
 
-    <t t-name="commandHandlers">
-        <div class="divider" t-if="handlers">Handlers</div>
-        <table t-if="handlers">
+    <t t-name="selectedCommandTable">
+        <div class="divider">Command definitions</div>
+        <table>
             <tbody>
-                <tr t-foreach="handlers"
-                    t-as="handler" t-key="handler_index"
+                <tr t-foreach="selectedCommandDefinitions"
+                    t-as="selectedCommandDefinition" t-key="selectedCommandDefinition_index"
                     class="selectable-line"
                     t-att-class="{
-                        selected: state.selectedHandlerIndex == handlerIndex,
+                        selected: state.selectedCommandDefinitionIndex == handlerIndex,
                     }">
-                    <td><t t-esc="handler.name"/></td>
-                    <td><t t-esc="handler"/></td>
+                    <td><t t-esc="selectedCommandDefinition.handler.name"/></td>
+                    <td><t t-esc="selectedCommandDefinition.handler"/></td>
                 </tr>
             </tbody>
         </table>

--- a/packages/plugin-devtools/src/components/CommandsComponent.ts
+++ b/packages/plugin-devtools/src/components/CommandsComponent.ts
@@ -1,18 +1,12 @@
 import { OwlUIComponent } from '../../../owl-ui/src/OwlUIComponent';
-import {
-    CommandIdentifier,
-    CommandHandler,
-    CommandArgs,
-    CommandDefinition,
-} from '../../../core/src/Dispatcher';
+import { CommandIdentifier, CommandArgs, CommandDefinition } from '../../../core/src/Dispatcher';
 
 interface CommandsState {
     currentTab: string;
-    registry: Record<CommandIdentifier, CommandDefinition>;
-    handlers: Record<CommandIdentifier, CommandHandler[]>;
+    registry: Record<CommandIdentifier, CommandDefinition[]>;
     selectedCommandIndex: number;
     selectedCommandIdentifier: string;
-    selectedHandlerIndex: number;
+    selectedCommandDefinitionIndex: number;
 }
 interface CommandsProps {
     // Stack of all commands executed since init.
@@ -23,10 +17,9 @@ export class CommandsComponent extends OwlUIComponent<CommandsProps> {
     state: CommandsState = {
         currentTab: 'queue',
         registry: this.env.editor.dispatcher.commands,
-        handlers: this.env.editor.dispatcher.handlers,
         selectedCommandIndex: null, // Index of the selected command in the stack
-        selectedCommandIdentifier: null, // Token of the selected handler
-        selectedHandlerIndex: null, // Index of the selected handler
+        selectedCommandIdentifier: null, // Identifier of the selected command
+        selectedCommandDefinitionIndex: null, // Index of the selected command definition
     };
     localStorage = ['currentTab'];
 


### PR DESCRIPTION
The previous version had generated confusion in the code.
Now, instead of having commands and handlers on plugin, there is only
commands.