### PR TITLE
[FIX] Indent: fix indent behavior

### DIFF
--- a/bundles/BasicEditor.ts
+++ b/bundles/BasicEditor.ts
@@ -5,12 +5,13 @@ import { LineBreak } from '../packages/plugin-linebreak/LineBreak';
 import { Heading } from '../packages/plugin-heading/Heading';
 import { Paragraph } from '../packages/plugin-paragraph/Paragraph';
 import { List } from '../packages/plugin-list/List';
+import { Indent } from '../packages/plugin-indent/src/Indent';
 
 export class BasicEditor extends JWEditor {
     constructor(editable?: HTMLElement) {
         super(editable);
         this.loadConfig({
-            plugins: [Dom, Char, LineBreak, Heading, Paragraph, List],
+            plugins: [Dom, Char, LineBreak, Heading, Paragraph, List, Indent],
         });
     }
 }

--- a/packages/core/src/EventManager.ts
+++ b/packages/core/src/EventManager.ts
@@ -28,6 +28,12 @@ export class EventManager {
     async _onNormalizedEvent(customEvent: CustomEvent): Promise<void> {
         const payload = customEvent.detail;
         switch (customEvent.type) {
+            case 'tab':
+                if (customEvent.detail.shiftKey) {
+                    return this.editor.execCommand('outdent');
+                } else {
+                    return this.editor.execCommand('indent');
+                }
             case 'enter':
                 if (customEvent.detail.shiftKey) {
                     return this.editor.execCommand('insertLineBreak');

--- a/packages/core/src/VRange.ts
+++ b/packages/core/src/VRange.ts
@@ -89,7 +89,24 @@ export class VRange {
         return this.startContainer.children[startIndex + 1] === this.end;
     }
     /**
-     * Return a list of all the nodes between the start and end of this range.
+     * Return a list of all the nodes traversed from start to end of this range.
+     */
+    retractedNodes(predicate?: Predicate): VNode[];
+    retractedNodes<T extends VNode>(predicate?: Constructor<T>): T[];
+    retractedNodes<T>(predicate?: Predicate<T>): VNode[];
+    retractedNodes<T>(predicate?: Predicate<T>): VNode[] {
+        const selectedNodes: VNode[] = [];
+        let node = this.start;
+        const bound = this.end.next();
+        while ((node = node.next()) && node !== bound) {
+            if (node.test(predicate)) {
+                selectedNodes.push(node);
+            }
+        }
+        return selectedNodes;
+    }
+    /**
+     * Return a list of all nodes that are fully selected by this range.
      */
     selectedNodes(predicate?: Predicate): VNode[];
     selectedNodes<T extends VNode>(predicate?: Constructor<T>): T[];
@@ -141,6 +158,8 @@ export class VRange {
             // We check that `reference` isn't `this.end` to avoid a backward
             // collapsed range.
             reference.after(this.start);
+        } else if (position === RelativePosition.INSIDE) {
+            reference.append(this.start);
         } else {
             reference.before(this.start);
         }
@@ -163,6 +182,8 @@ export class VRange {
             // We check that `reference` isn't `this.start` to avoid a backward
             // collapsed range.
             reference.before(this.end);
+        } else if (position === RelativePosition.INSIDE) {
+            reference.append(this.end);
         } else {
             reference.after(this.end);
         }

--- a/packages/plugin-devtools/test/devtools.test.ts
+++ b/packages/plugin-devtools/test/devtools.test.ts
@@ -707,6 +707,8 @@ describe('Plugin: DevTools', () => {
                 'applyFormat',
                 'insertLineBreak',
                 'toggleList',
+                'indent',
+                'outdent',
                 'insert',
                 'insertParagraphBreak',
                 'setSelection',

--- a/packages/plugin-indent/test/Indent.test.ts
+++ b/packages/plugin-indent/test/Indent.test.ts
@@ -50,6 +50,14 @@ describePlugin(Indent, testEditor => {
                     '<p>&nbsp;&nbsp; &nbsp;cd</p>' +
                     '<p>&nbsp;&nbsp; &nbsp;e]f</p>',
             });
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>a[b</p><p><br/></p><p>e]f</p>',
+                stepFunction: indent,
+                contentAfter:
+                    '<p>&nbsp;&nbsp; &nbsp;a[b</p>' +
+                    '<p>&nbsp;&nbsp; &nbsp;</p>' +
+                    '<p>&nbsp;&nbsp; &nbsp;e]f</p>',
+            });
         });
         it('should indent with a fake range', async function() {
             await testEditor(BasicEditor, {
@@ -69,16 +77,48 @@ describePlugin(Indent, testEditor => {
         });
     });
     describe('outdent', async function() {
-        it('should do nothing when only one parent selected', async function() {
+        it('should do nothing if no space at the beginning of line', async function() {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>a[]b<br>&nbsp;&nbsp; &nbsp;cd</p>',
+                stepFunction: outdent,
+                contentAfter: '<p>a[]b<br>&nbsp;&nbsp; &nbsp;cd</p>',
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>a[]b</p><p>&nbsp;&nbsp; &nbsp;cd</p>',
+                stepFunction: outdent,
+                contentAfter: '<p>a[]b</p><p>&nbsp;&nbsp; &nbsp;cd</p>',
+            });
+        });
+        it('should outdent when only one parent selected', async function() {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>&nbsp;&nbsp; &nbsp;a[]b</p>',
+                stepFunction: outdent,
+                contentAfter: '<p>a[]b</p>',
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>&nbsp;&nbsp; a[]b</p>',
+                stepFunction: outdent,
+                contentAfter: '<p>a[]b</p>',
+            });
             await testEditor(BasicEditor, {
                 contentBefore: '<p>&nbsp;&nbsp; &nbsp;a[b]</p>',
                 stepFunction: outdent,
-                contentAfter: '<p>&nbsp;&nbsp; &nbsp;a[b]</p>',
+                contentAfter: '<p>a[b]</p>',
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>&nbsp;&nbsp; a[b]</p>',
+                stepFunction: outdent,
+                contentAfter: '<p>a[b]</p>',
             });
         });
         it('should outdent(up to 4 spaces) when selection in multiples lines', async function() {
             await testEditor(BasicEditor, {
                 contentBefore: '<p>&nbsp;&nbsp; &nbsp;a[b<br/>&nbsp;&nbsp; &nbsp;c]d</p>',
+                stepFunction: outdent,
+                contentAfter: '<p>a[b<br>c]d</p>',
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>&nbsp;&nbsp; &nbsp;a[b<br/>&nbsp;&nbsp; c]d</p>',
                 stepFunction: outdent,
                 contentAfter: '<p>a[b<br>c]d</p>',
             });
@@ -88,6 +128,19 @@ describePlugin(Indent, testEditor => {
                 contentBefore: '<p>&nbsp;&nbsp; &nbsp;a[b<br/>&nbsp;&nbsp; &nbsp;c]d</p>',
                 stepFunction: outdent,
                 contentAfter: '<p>a[b<br>c]d</p>',
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>&nbsp;&nbsp; a[b<br/>&nbsp;&nbsp; &nbsp;c]d</p>',
+                stepFunction: outdent,
+                contentAfter: '<p>a[b<br>c]d</p>',
+            });
+            await testEditor(BasicEditor, {
+                contentBefore:
+                    '<p>&nbsp;&nbsp; &nbsp;a[b</p>' +
+                    '<p>&nbsp;&nbsp; &nbsp;</p>' +
+                    '<p>&nbsp;&nbsp; &nbsp;e]f</p>',
+                stepFunction: outdent,
+                contentAfter: '<p>a[b</p><p><br></p><p>e]f</p>',
             });
         });
         it('should outdent with a fake range', async function() {


### PR DESCRIPTION
The indent command now acts like tab does in code editors.
We might want to move this into a Code plugin later when we
implement the standard paragraph/list indent behavior.

One of the issues of indent was the new `selectedNodes` semantic
which does not return nodes that are only partially selected.

To solve this, I added a `retractedNodes` function on VRange which
returns the nodes that would be retracted from the DFS traversal
algorithm when the VRange is seen as a retraction of the document
tree, which is in fact equivalent to the old `selectedNodes` behavior.