### PR TITLE
[IMP] JWEditor: user can not change config when the editor is started

### DIFF
--- a/packages/core/src/JWEditor.ts
+++ b/packages/core/src/JWEditor.ts
@@ -18,6 +18,11 @@ export enum Platform {
     PC = 'pc',
 }
 
+enum Mode {
+    CONFIGURATION = 'configuration',
+    EDITION = 'edition',
+}
+
 export interface Shortcut extends BoundCommand {
     platform?: Platform;
     pattern: string;
@@ -33,6 +38,7 @@ export interface JWEditorConfig {
 }
 
 export class JWEditor {
+    private _mode: Mode = Mode.CONFIGURATION;
     el: HTMLElement;
     _originalEditable: HTMLElement;
     editable: HTMLElement;
@@ -83,6 +89,7 @@ export class JWEditor {
      * Start the editor on the editable DOM node set on this editor instance.
      */
     async start(): Promise<void> {
+        this._mode = Mode.EDITION;
         const root = new FragmentNode();
         if (this._originalEditable.innerHTML !== '') {
             if (!this.parsers.dom) {
@@ -152,6 +159,10 @@ export class JWEditor {
      * @param Plugin
      */
     addPlugin(Plugin: typeof JWPlugin): void {
+        if (this._mode === Mode.EDITION) {
+            throw new Error("You can't add plugin when the editor is already started");
+        }
+
         // Resolve dependencies.
         const pluginsToLoad = [Plugin];
         let offset = 1;
@@ -235,6 +246,11 @@ export class JWEditor {
      * @param config
      */
     loadConfig(config: JWEditorConfig): void {
+        if (this._mode === Mode.EDITION) {
+            throw new Error(
+                "You can't change the configuration when the editor is already started",
+            );
+        }
         if (config.autoFocus) {
             this.autoFocus = config.autoFocus;
         }
@@ -272,6 +288,7 @@ export class JWEditor {
         this._originalEditable.id = this.editable.id;
         this._originalEditable.style.display = this.editable.style.display;
         this.el.remove();
+        this._mode = Mode.CONFIGURATION;
     }
 
     //--------------------------------------------------------------------------

--- a/packages/core/test/JWeditor.test.ts
+++ b/packages/core/test/JWeditor.test.ts
@@ -11,11 +11,27 @@ import { RenderingEngine } from '../src/RenderingEngine';
 describe('core', () => {
     describe('JWEditor', () => {
         describe('addPlugin', () => {
+            it('should throw an error if the editor is already started', async () => {
+                const editor = new JWEditor();
+                await editor.start();
+                expect(() => {
+                    editor.addPlugin(
+                        class A extends JWPlugin {
+                            shortcuts = [
+                                {
+                                    pattern: 'cTrL+A',
+                                    commandId: 'command-all',
+                                },
+                            ];
+                        },
+                    );
+                }).to.throw(/plugin.*already started/i);
+            });
+
             describe('defaultShortcuts & loadConfig', () => {
                 it('should only register default mapping for pc and other', () => {
                     const editor = new JWEditor();
                     editor._platform = Platform.PC;
-                    editor.start();
                     editor.addPlugin(
                         class A extends JWPlugin {
                             shortcuts = [
@@ -36,6 +52,7 @@ describe('core', () => {
                             ];
                         },
                     );
+                    editor.start();
                     const expectedCommands = editor.keymaps.default.shortcuts.map(
                         l => l.boundCommand.commandId,
                     );
@@ -44,7 +61,6 @@ describe('core', () => {
                 it('should transform ctrl to CMD if no platform on mac', () => {
                     const editor = new JWEditor();
                     editor._platform = Platform.MAC;
-                    editor.start();
                     editor.addPlugin(
                         class A extends JWPlugin {
                             shortcuts = [
@@ -69,6 +85,7 @@ describe('core', () => {
                             ];
                         },
                     );
+                    editor.start();
                     const expectedCommands = editor.keymaps.default.shortcuts.map(
                         l => [...l.pattern.modifiers][0],
                     );
@@ -77,7 +94,6 @@ describe('core', () => {
                 it('should not transform ctrl to CMD if no platform on pc', () => {
                     const editor = new JWEditor();
                     editor._platform = Platform.PC;
-                    editor.start();
                     editor.addPlugin(
                         class A extends JWPlugin {
                             shortcuts = [
@@ -102,6 +118,7 @@ describe('core', () => {
                             ];
                         },
                     );
+                    editor.start();
                     const expectedCommands = editor.keymaps.default.shortcuts.map(
                         l => [...l.pattern.modifiers][0],
                     );
@@ -110,7 +127,6 @@ describe('core', () => {
                 it('should only register default mapping for mac and other', () => {
                     const editor = new JWEditor();
                     editor._platform = Platform.MAC;
-                    editor.start();
                     editor.addPlugin(
                         class A extends JWPlugin {
                             shortcuts = [
@@ -131,6 +147,7 @@ describe('core', () => {
                             ];
                         },
                     );
+                    editor.start();
                     const expectedCommands = editor.keymaps.default.shortcuts.map(
                         l => l.boundCommand.commandId,
                     );
@@ -139,7 +156,6 @@ describe('core', () => {
                 it('should load the config for keymap', () => {
                     const editor = new JWEditor();
                     editor._platform = Platform.PC;
-                    editor.start();
                     editor.loadConfig({
                         debug: true,
                         shortcuts: [
@@ -159,6 +175,7 @@ describe('core', () => {
                             },
                         ],
                     });
+                    editor.start();
                     const expectedCommands = editor.keymaps.user.shortcuts.map(
                         l => l.boundCommand.commandId,
                     );
@@ -168,11 +185,7 @@ describe('core', () => {
                     it('should trigger default shortuct', async () => {
                         await testEditor(JWEditor, {
                             contentBefore: '',
-                            stepFunction: async editor => {
-                                editor._platform = Platform.PC;
-                                // todo: to remove when the normalizer will
-                                //       not be in included by default
-                                editor.eventManager.eventNormalizer._triggerEvent = (): void => {};
+                            beforeStart: async editor => {
                                 editor.addPlugin(
                                     class A extends JWPlugin {
                                         shortcuts = [
@@ -183,6 +196,12 @@ describe('core', () => {
                                         ];
                                     },
                                 );
+                            },
+                            stepFunction: async editor => {
+                                editor._platform = Platform.PC;
+                                // todo: to remove when the normalizer will
+                                //       not be in included by default
+                                editor.eventManager.eventNormalizer._triggerEvent = (): void => {};
                                 editor.execCommand = (): Promise<void> => Promise.resolve();
                                 const execSpy = spy(editor, 'execCommand');
                                 await keydown(editor.editable, 'a', { ctrlKey: true });
@@ -197,11 +216,7 @@ describe('core', () => {
                     it('should trigger the binding from the user config rather the default', async () => {
                         await testEditor(JWEditor, {
                             contentBefore: '',
-                            stepFunction: async editor => {
-                                editor._platform = Platform.PC;
-                                // todo: to remove when the normalizer will
-                                //       not be in included by default
-                                editor.eventManager.eventNormalizer._triggerEvent = (): void => {};
+                            beforeStart: async editor => {
                                 editor.addPlugin(
                                     class A extends JWPlugin {
                                         shortcuts = [
@@ -221,6 +236,12 @@ describe('core', () => {
                                         },
                                     ],
                                 });
+                            },
+                            stepFunction: async editor => {
+                                editor._platform = Platform.PC;
+                                // todo: to remove when the normalizer will
+                                //       not be in included by default
+                                editor.eventManager.eventNormalizer._triggerEvent = (): void => {};
                                 editor.execCommand = (): Promise<void> => Promise.resolve();
                                 const execSpy = spy(editor, 'execCommand');
                                 await keydown(editor.editable, 'a', { ctrlKey: true });
@@ -235,11 +256,7 @@ describe('core', () => {
                     it('should remove the binding from the user config', async () => {
                         await testEditor(JWEditor, {
                             contentBefore: '',
-                            stepFunction: async editor => {
-                                editor._platform = Platform.PC;
-                                // todo: to remove when the normalizer will
-                                //       not be in included by default
-                                editor.eventManager.eventNormalizer._triggerEvent = (): void => {};
+                            beforeStart: async editor => {
                                 editor.addPlugin(
                                     class A extends JWPlugin {
                                         shortcuts = [
@@ -259,6 +276,12 @@ describe('core', () => {
                                         },
                                     ],
                                 });
+                            },
+                            stepFunction: async editor => {
+                                editor._platform = Platform.PC;
+                                // todo: to remove when the normalizer will
+                                //       not be in included by default
+                                editor.eventManager.eventNormalizer._triggerEvent = (): void => {};
                                 editor.execCommand = (): Promise<void> => Promise.resolve();
                                 const execSpy = spy(editor, 'execCommand');
                                 await keydown(editor.editable, 'a', { ctrlKey: true });
@@ -268,6 +291,23 @@ describe('core', () => {
                         });
                     });
                 });
+            });
+        });
+        describe('loadConfig', () => {
+            it('should throw an error if the editor is already started', async () => {
+                const editor = new JWEditor();
+                await editor.start();
+                expect(() => {
+                    editor.loadConfig({
+                        debug: true,
+                        shortcuts: [
+                            {
+                                pattern: 'CTRL+A',
+                                commandId: 'command-all',
+                            },
+                        ],
+                    });
+                }).to.throw(/config.*already started/i);
             });
         });
         describe('render', () => {

--- a/packages/utils/src/testUtils.ts
+++ b/packages/utils/src/testUtils.ts
@@ -11,6 +11,7 @@ import { Dom } from '../../plugin-dom/Dom';
 export interface TestEditorSpec {
     contentBefore: string;
     contentAfter?: string;
+    beforeStart?: (editor: JWEditor) => void | Promise<void>;
     stepFunction?: (editor: JWEditor) => void | Promise<void>;
     debug?: boolean;
 }
@@ -135,6 +136,10 @@ async function testSpec(editor: JWEditor, spec: TestEditorSpec): Promise<void> {
     // Forward debug mode from the spec to the editor.
     if (spec.debug) {
         editor.addPlugin(DevTools);
+    }
+
+    if (spec.beforeStart) {
+        await spec.beforeStart(editor);
     }
 
     // Start the editor and execute the step code.


### PR DESCRIPTION

The plugins start is done in the editor's start. Therefore if a plugin is
added after, it is built (new) but the start method is never called.
Adding a throw prevents this kind of error from the developer.