### PR TITLE
[FIX] EventNormalizer: paste with context menu

### DIFF
--- a/packages/core/src/EventNormalizer.ts
+++ b/packages/core/src/EventNormalizer.ts
@@ -1475,7 +1475,9 @@ export class EventNormalizer {
      * @param {MouseEvent} ev
      */
     _onContextMenu(ev: MouseEvent): void {
-        this._pointerSelectionTimeout.fire({ actions: [] });
+        if (this._pointerSelectionTimeout?.pending) {
+            this._pointerSelectionTimeout.fire();
+        }
         this._pointerSelectionTimeout = new Timeout(() => {
             if (!this._selectionHasChanged || this._currentlySelectingAll) {
                 return { actions: [] };

--- a/packages/core/test/EventNormalizerPointer.test.ts
+++ b/packages/core/test/EventNormalizerPointer.test.ts
@@ -1602,7 +1602,6 @@ describe('utils', () => {
                     await nextTick();
                     ctx.eventBatches.splice(0);
                     triggerEvent(p, 'mousedown', { button: 2, detail: 1 });
-                    setSelection(text, 1, text, 1);
                     triggerEvent(p, 'contextmenu', { button: 2, detail: 0 });
                     await nextTick();
                     await nextTick();
@@ -1622,21 +1621,6 @@ describe('utils', () => {
                     ];
 
                     const batchEvents: EventBatch[] = [
-                        {
-                            actions: [
-                                {
-                                    type: 'setSelection',
-                                    domSelection: {
-                                        anchorNode: text,
-                                        anchorOffset: 1,
-                                        focusNode: text,
-                                        focusOffset: 1,
-                                        direction: Direction.FORWARD,
-                                    },
-                                },
-                            ],
-                            mutatedElements: new Set([]),
-                        },
                         {
                             actions: normalizedActions,
                             mutatedElements: new Set([]),


### PR DESCRIPTION
Concerning the test, I see no reason why we should expect a `setSelection`. If @Goaman (who wrote the test) confirms then I believe we can merge as is.