### PR TITLE
[FIX] LineBreak: restore shortcut

### DIFF
--- a/packages/core/src/EventManager.ts
+++ b/packages/core/src/EventManager.ts
@@ -29,14 +29,12 @@ export class EventManager {
 
     _matchCommand(action: NormalizedAction): [CommandIdentifier, object] {
         switch (action.type) {
+            case 'insertLineBreak':
+                return ['insertLineBreak', {}];
             case 'insertText':
             case 'insertHtml':
-                if (action.text === '\n') {
-                    return ['insertLineBreak', {}];
-                } else {
                     const params: InsertTextParams = { text: action.text };
                     return ['insertText', params];
-                }
             case 'selectAll':
                 return ['selectAll', {}];
             case 'setSelection': {

--- a/packages/plugin-linebreak/src/LineBreak.ts
+++ b/packages/plugin-linebreak/src/LineBreak.ts
@@ -6,9 +6,10 @@ import { Core } from '../../core/src/Core';
 import { Loadables } from '../../core/src/JWEditor';
 import { Parser } from '../../plugin-parser/src/Parser';
 import { Renderer } from '../../plugin-renderer/src/Renderer';
+import { Keymap } from '../../plugin-keymap/src/Keymap';
 
 export class LineBreak<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T> {
-    readonly loadables: Loadables<Parser & Renderer> = {
+    readonly loadables: Loadables<Parser & Renderer & Keymap> = {
         parsers: [LineBreakDomParser],
         renderers: [LineBreakDomRenderer],
     };


### PR DESCRIPTION
The shortcut for inserting a line break (Shift+Enter) was somehow missing. This restores it, fixing issue #138 