### PR TITLE
[FIX] EventNormalizer: restore insertLineBreak

### DIFF
--- a/packages/core/src/EventManager.ts
+++ b/packages/core/src/EventManager.ts
@@ -29,14 +29,13 @@ export class EventManager {
 
     _matchCommand(action: NormalizedAction): [CommandIdentifier, object] {
         switch (action.type) {
+            case 'insertLineBreak':
+                return ['insertLineBreak', {}];
             case 'insertText':
-            case 'insertHtml':
-                if (action.text === '\n') {
-                    return ['insertLineBreak', {}];
-                } else {
-                    const params: InsertTextParams = { text: action.text };
-                    return ['insertText', params];
-                }
+            case 'insertHtml': {
+                const params: InsertTextParams = { text: action.text };
+                return ['insertText', params];
+            }
             case 'selectAll':
                 return ['selectAll', {}];
             case 'setSelection': {


### PR DESCRIPTION
In a previous refactoring of the normalizer, the command
'insertLineBreak' was triggered by an action 'insertText' or
'insertHTML', now the normalizer send directly the action
'insertLineBreak'.