### PR TITLE
[IMP] Modifiers: introduce CSSStyle and ClassList

### DIFF
--- a/packages/core/src/Modifiers.ts
+++ b/packages/core/src/Modifiers.ts
@@ -2,15 +2,35 @@ import { Modifier } from './Modifier';
 import { Constructor, isConstructor } from '../../utils/src/utils';
 
 export class Modifiers {
-    _contents: Modifier[] = [];
+    private _contents: Modifier[] = [];
     constructor(...modifiers: Array<Modifier | Constructor<Modifier>>) {
         const clonedModifiers = modifiers.map(mod => {
             return mod instanceof Modifier ? mod.clone() : mod;
         });
         this.append(...clonedModifiers);
     }
+
+    //--------------------------------------------------------------------------
+    // Getters
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return the length of the array.
+     */
     get length(): number {
         return this._contents.length;
+    }
+
+    //--------------------------------------------------------------------------
+    // Lifecycle
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return a new instance of the Modifiers class containing the same
+     * modifiers.
+     */
+    clone(): Modifiers {
+        return new Modifiers(...this._contents.map(mod => mod.clone()));
     }
 
     //--------------------------------------------------------------------------
@@ -66,10 +86,8 @@ export class Modifiers {
             return this._contents.find(instance => instance === modifier) as T;
         } else if (isConstructor<typeof Modifier>(modifier, Modifier)) {
             // `modifier` is a `Modifier` class -> find its first instance in
-            // the array. If an instance couldn't be found, find the first
-            // instance of an extension of the given class.
-            return (this._contents.find(mod => mod.constructor.name === modifier.name) ||
-                this._contents.find(mod => mod instanceof modifier)) as T;
+            // the array.
+            return this._contents.find(mod => mod.constructor.name === modifier.name) as T;
         } else if (modifier instanceof Function) {
             // `modifier` is a callback -> call `find` natively on the array.
             return this._contents.find(modifier) as T;
@@ -190,13 +208,6 @@ export class Modifiers {
      */
     toggle(modifier: Modifier | Constructor<Modifier>): void {
         this.remove(modifier) || this.append(modifier);
-    }
-    /**
-     * Return a new instance of the Modifiers class containing the same
-     * modifiers.
-     */
-    clone(): Modifiers {
-        return new Modifiers(...this._contents);
     }
     /**
      * Return true if the modifiers in this array are the same as the modifiers

--- a/packages/plugin-align/src/Align.ts
+++ b/packages/plugin-align/src/Align.ts
@@ -4,7 +4,6 @@ import { CommandParams } from '../../core/src/Dispatcher';
 import { Keymap } from '../../plugin-keymap/src/Keymap';
 import { VNode } from '../../core/src/VNodes/VNode';
 import { ContainerNode } from '../../core/src/VNodes/ContainerNode';
-import { setStyle } from '../../utils/src/utils';
 import { Attributes } from '../../plugin-xml/src/Attributes';
 
 export enum AlignType {
@@ -62,16 +61,8 @@ export class Align<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T
      * @param [type]
      */
     static isAligned(node: VNode, type?: AlignType): boolean {
-        const styles = node.modifiers
-            .find(Attributes)
-            ?.get('style')
-            ?.split(';');
-        if (styles) {
-            const align = styles.find(style => style.includes('text-align'));
-            return type ? align?.includes(type) : !!align;
-        } else {
-            return false;
-        }
+        const align = node.modifiers.find(Attributes)?.style.get('text-align');
+        return type ? align?.includes(type) : !!align;
     }
     /**
      * Align text.
@@ -85,18 +76,12 @@ export class Align<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T
             const alignedAncestor = node.ancestor(Align.isAligned);
 
             // Compute current alignment.
-            let currentAlignment: string;
-            const styles = alignedAncestor?.modifiers
+            const currentAlignment = alignedAncestor?.modifiers
                 ?.find(Attributes)
-                ?.get('style')
-                ?.split(';');
-            if (styles) {
-                const alignment = styles.find(style => style.includes('text-align'));
-                currentAlignment = alignment?.replace(/text-align\s*:|;/, '').trim();
-            }
+                ?.style.get('text-align');
 
             if (!alignedAncestor || currentAlignment !== type) {
-                setStyle(node, 'text-align', type.toLowerCase());
+                node.modifiers.get(Attributes).style.set('text-align', type.toLowerCase());
             }
         }
     }

--- a/packages/plugin-backgroundcolor/test/BackgroundColor.test.ts
+++ b/packages/plugin-backgroundcolor/test/BackgroundColor.test.ts
@@ -130,7 +130,7 @@ describePlugin(BackgroundColor, testEditor => {
                         await insertText(editor, 'b');
                     },
                     contentAfter:
-                        '<p style="background-color: red">a<span style="background-color: white;">b[]</span>c</p>',
+                        '<p style="background-color: red;">a<span style="background-color: white;">b[]</span>c</p>',
                 });
             });
             it('should write two characters in white background', async () => {
@@ -142,7 +142,7 @@ describePlugin(BackgroundColor, testEditor => {
                         await insertText(editor, 'c');
                     },
                     contentAfter:
-                        '<p style="background-color: red">a<span style="background-color: white;">bc[]</span>d</p>',
+                        '<p style="background-color: red;">a<span style="background-color: white;">bc[]</span>d</p>',
                 });
             });
         });

--- a/packages/plugin-char/src/Char.ts
+++ b/packages/plugin-char/src/Char.ts
@@ -9,7 +9,7 @@ import { Modifiers } from '../../core/src/Modifiers';
 import { Loadables } from '../../core/src/JWEditor';
 import { Parser } from '../../plugin-parser/src/Parser';
 import { Renderer } from '../../plugin-renderer/src/Renderer';
-import { setStyles } from '../../utils/src/utils';
+import { Attributes } from '../../plugin-xml/src/Attributes';
 
 export interface InsertTextParams extends CommandParams {
     text: string;
@@ -51,7 +51,7 @@ export class Char<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
         if (params.formats) {
             modifiers.append(...params.formats.map(format => format.clone()));
         }
-        const styles = inline.getCurrentStyles(range);
+        const style = inline.getCurrentStyle(range);
         // Remove the contents of the range if needed.
         if (!range.isCollapsed()) {
             range.empty();
@@ -60,7 +60,7 @@ export class Char<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
         const characters = text.split('');
         characters.forEach(char => {
             const vNode = new CharNode({ char: char, modifiers: modifiers.clone() });
-            setStyles(vNode, styles);
+            vNode.modifiers.get(Attributes).style = style;
             range.start.before(vNode);
         });
         inline.resetCache();

--- a/packages/plugin-dom-editable/test/DomEditable.test.ts
+++ b/packages/plugin-dom-editable/test/DomEditable.test.ts
@@ -58,7 +58,7 @@ describe('DomEditable', () => {
             editor.configure(DomLayout, { location: [section, 'replace'] });
             await editor.start();
             expect(container.innerHTML).to.equal(
-                '<jw-editor><jw-editable contenteditable="true" style="display: block;"><br></jw-editable></jw-editor>',
+                '<jw-editor><jw-editable style="display: block;" contenteditable="true"><br></jw-editable></jw-editor>',
             );
             await editor.stop();
             expect(container.innerHTML).to.equal('<section></section>');
@@ -109,7 +109,7 @@ describe('DomEditable', () => {
         afterEach(async () => {
             return editor.stop();
         });
-        describe('hande user events with EventNormalizer', () => {
+        describe('handle user events with EventNormalizer', () => {
             beforeEach(async () => {
                 editor = new JWEditor();
                 editor.load(Char);

--- a/packages/plugin-fontawesome/test/FontAwesome.test.ts
+++ b/packages/plugin-fontawesome/test/FontAwesome.test.ts
@@ -70,16 +70,14 @@ describePlugin(FontAwesome, testEditor => {
             await testEditor(BasicEditor, {
                 contentBefore: `<p><i class="fas
                                 fa-pastafarianism"></i></p>`,
-                contentAfter: `<p>\u200b<i class="fas
-                                fa-pastafarianism"></i>\u200b</p>`,
+                contentAfter: `<p>\u200b<i class="fas fa-pastafarianism"></i>\u200b</p>`,
             });
         });
         it('should parse a fontawesome with more multi-line classes', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: `<p><i class="red fas bordered
                                 big fa-pastafarianism scary"></i></p>`,
-                contentAfter: `<p>\u200b<i class="red fas bordered
-                                big fa-pastafarianism scary"></i>\u200b</p>`,
+                contentAfter: `<p>\u200b<i class="red fas bordered big fa-pastafarianism scary"></i>\u200b</p>`,
             });
         });
         it('should parse a fontawesome at the beginning of a paragraph', async () => {

--- a/packages/plugin-html/src/HtmlDomRenderingEngine.ts
+++ b/packages/plugin-html/src/HtmlDomRenderingEngine.ts
@@ -15,12 +15,26 @@ export class HtmlDomRenderingEngine extends RenderingEngine<Node[]> {
      * @param node
      * @param element
      */
-    renderAttributes<T extends typeof Attributes>(Class: T, node: VNode, element: Element): void {
+    renderAttributes<T extends typeof Attributes>(
+        Class: T,
+        node: VNode,
+        element: HTMLElement,
+    ): void {
         const attributes = node.modifiers.find(Class);
         if (attributes) {
-            for (const name of attributes.keys().sort()) {
+            for (const name of attributes.keys()) {
                 const value = attributes.get(name);
                 element.setAttribute(name, value);
+            }
+            if (attributes.style.length) {
+                for (const name of attributes.style.keys()) {
+                    element.style.setProperty(name, attributes.style.get(name));
+                }
+            }
+            if (attributes.classList.length) {
+                for (const className of attributes.classList.items()) {
+                    element.classList.add(className);
+                }
             }
         }
     }

--- a/packages/plugin-inline/src/Format.ts
+++ b/packages/plugin-inline/src/Format.ts
@@ -32,14 +32,24 @@ export class Format extends Modifier {
     //--------------------------------------------------------------------------
 
     render(): Element {
-        const node = document.createElement(this.htmlTag);
+        const domNode = document.createElement(this.htmlTag);
         const attributes = this.modifiers.find(Attributes);
         if (attributes) {
             for (const name of attributes.keys()) {
-                node.setAttribute(name, attributes.get(name));
+                domNode.setAttribute(name, attributes.get(name));
+            }
+            if (attributes.style.length) {
+                for (const name of attributes.style.keys().sort()) {
+                    domNode.style.setProperty(name, attributes.style.get(name));
+                }
+            }
+            if (attributes.classList.length) {
+                for (const className of attributes.classList.items()) {
+                    domNode.classList.add(className);
+                }
             }
         }
-        return node;
+        return domNode;
     }
     clone(): this {
         const clone = new this.constructor();

--- a/packages/plugin-inline/src/Inline.ts
+++ b/packages/plugin-inline/src/Inline.ts
@@ -7,14 +7,14 @@ import { InlineNode } from './InlineNode';
 import { Constructor } from '../../utils/src/utils';
 import { VNode } from '../../core/src/VNodes/VNode';
 import { Modifiers } from '../../core/src/Modifiers';
-import { getStyles } from '../../utils/src/utils';
+import { CssStyle } from '../../plugin-xml/src/CssStyle';
 
 export interface FormatParams extends CommandParams {
     FormatClass: Constructor<Format>;
 }
 interface InlineCache {
     modifiers: Modifiers | null;
-    style: Record<string, string> | null;
+    style: CssStyle | null;
 }
 
 export class Inline<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T> {
@@ -70,8 +70,8 @@ export class Inline<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<
             if (allHaveFormat) {
                 for (const inline of selectedInlines) {
                     const format = inline.modifiers.find(FormatClass);
-                    // Apply the attributes of the format we're about to remove to
-                    // the inline itself.
+                    // Apply the attributes of the format we're about to remove
+                    // to the inline itself.
                     const attributes = inline.modifiers.get(Attributes);
                     const matchingFormatAttributes = format.modifiers.find(Attributes);
                     if (matchingFormatAttributes) {
@@ -130,22 +130,21 @@ export class Inline<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<
     /**
      * Get the styles for the next insertion.
      */
-    getCurrentStyles(range = this.editor.selection.range): Record<string, string> {
+    getCurrentStyle(range = this.editor.selection.range): CssStyle {
         if (this.cache.style) {
             return this.cache.style;
         }
 
-        let inlineToCopyStyles: VNode;
+        let inlineToCopyStyle: VNode;
         if (range.isCollapsed()) {
-            inlineToCopyStyles = range.start.previousSibling() || range.start.nextSibling();
+            inlineToCopyStyle = range.start.previousSibling() || range.start.nextSibling();
         } else {
-            inlineToCopyStyles = range.start.nextSibling();
+            inlineToCopyStyle = range.start.nextSibling();
         }
-        if (inlineToCopyStyles && inlineToCopyStyles.is(InlineNode)) {
-            return getStyles(inlineToCopyStyles);
+        if (inlineToCopyStyle && inlineToCopyStyle.is(InlineNode)) {
+            return inlineToCopyStyle.modifiers.find(Attributes)?.style.clone() || new CssStyle();
         }
-
-        return {};
+        return new CssStyle();
     }
     /**
      * Each time the selection changes, we reset its format and style.

--- a/packages/plugin-inline/test/Inline.test.ts
+++ b/packages/plugin-inline/test/Inline.test.ts
@@ -69,7 +69,7 @@ describePlugin(Inline, testEditor => {
                         await toggleFormat(editor, BoldFormat);
                     },
                     contentAfter:
-                        'a<b style="color: red">b[</b><span style="color: red">cd</span><span style="color: green">ef]</span><b style="color: green">g</b>',
+                        'a<b style="color: red;">b[</b><span style="color: red;">cd</span><span style="color: green;">ef]</span><b style="color: green;">g</b>',
                 });
             });
         });

--- a/packages/plugin-list/src/ListItemXmlDomParser.ts
+++ b/packages/plugin-list/src/ListItemXmlDomParser.ts
@@ -4,6 +4,7 @@ import { nodeName } from '../../utils/src/utils';
 import { AbstractParser } from '../../plugin-parser/src/AbstractParser';
 import { XmlDomParsingEngine } from '../../plugin-xml/src/XmlDomParsingEngine';
 import { Attributes } from '../../plugin-xml/src/Attributes';
+import { Modifiers } from '../../core/src/Modifiers';
 
 export class ListItemAttributes extends Attributes {}
 
@@ -30,7 +31,7 @@ export class ListItemXmlDomParser extends AbstractParser<Node> {
         let inlinesContainer: VNode;
         // Parse the list item's attributes into the node's ListItemAttributes,
         // which will be read only by ListItemDomRenderer.
-        const itemAttributes = this.engine.parseAttributes(item);
+        const itemModifiers = new Modifiers(this.engine.parseAttributes(item));
         const Container = this.engine.editor.configuration.defaults.Container;
         for (let childIndex = 0; childIndex < children.length; childIndex++) {
             const domChild = children[childIndex];
@@ -41,9 +42,8 @@ export class ListItemXmlDomParser extends AbstractParser<Node> {
                     // wrapped together in a base container.
                     if (!inlinesContainer) {
                         inlinesContainer = new Container();
-                        inlinesContainer.modifiers.replace(
-                            ListItemAttributes,
-                            new ListItemAttributes(itemAttributes),
+                        inlinesContainer.modifiers.append(
+                            new ListItemAttributes(itemModifiers.get(Attributes)),
                         );
                         nodes.push(inlinesContainer);
                     }
@@ -53,7 +53,7 @@ export class ListItemXmlDomParser extends AbstractParser<Node> {
                     for (const child of parsedChild) {
                         child.modifiers.replace(
                             ListItemAttributes,
-                            new ListItemAttributes(itemAttributes),
+                            new ListItemAttributes(itemModifiers.get(Attributes)),
                         );
                     }
                     nodes.push(...parsedChild);

--- a/packages/plugin-shadow/test/DomShadow.test.ts
+++ b/packages/plugin-shadow/test/DomShadow.test.ts
@@ -127,16 +127,18 @@ describe('DomShadow', async () => {
                 expect(link.is(MetadataNode) && link.htmlTag).to.equal('LINK');
 
                 expect(link.modifiers.find(Attributes).name).to.equal(
-                    'rel: stylesheet; href: #href1',
+                    '{rel: "stylesheet", href: "#href1"}',
                 );
                 const link2 = shadow.childVNodes[1];
                 expect(link2.is(MetadataNode) && link2.htmlTag).to.equal('LINK');
                 expect(link2.modifiers.find(Attributes).name).to.equal(
-                    'rel: stylesheet; href: #href2',
+                    '{rel: "stylesheet", href: "#href2"}',
                 );
                 const link3 = shadow.childVNodes[2];
                 expect(link3.is(MetadataNode) && link3.htmlTag).to.equal('LINK');
-                expect(link3.modifiers.find(Attributes).name).to.equal('rel: help; href: /help/');
+                expect(link3.modifiers.find(Attributes).name).to.equal(
+                    '{rel: "help", href: "/help/"}',
+                );
                 const section = shadow.firstChild();
                 expect(section.is(VElement) && section.htmlTag).to.equal('SECTION');
             });
@@ -164,7 +166,7 @@ describe('DomShadow', async () => {
                 const link = shadow.childVNodes[0];
                 expect(link.is(MetadataNode) && link.htmlTag).to.equal('LINK');
                 expect(link.modifiers.find(Attributes).name).to.equal(
-                    'rel: stylesheet; href: #href1',
+                    '{rel: "stylesheet", href: "#href1"}',
                 );
                 const style = shadow.childVNodes[1];
                 expect(style.is(MetadataNode) && style.htmlTag).to.equal('STYLE');
@@ -172,7 +174,7 @@ describe('DomShadow', async () => {
                 const link2 = shadow.childVNodes[2];
                 expect(link2.is(MetadataNode) && link2.htmlTag).to.equal('LINK');
                 expect(link2.modifiers.find(Attributes).name).to.equal(
-                    'rel: stylesheet; href: #href2',
+                    '{rel: "stylesheet", href: "#href2"}',
                 );
                 const section = shadow.firstChild();
                 expect(section.is(VElement) && section.htmlTag).to.equal('SECTION');
@@ -321,16 +323,18 @@ describe('DomShadow', async () => {
                 const link = shadow.childVNodes[0];
                 expect(link.is(MetadataNode) && link.htmlTag).to.equal('LINK');
                 expect(link.modifiers.find(Attributes).name).to.equal(
-                    'rel: stylesheet; href: #href1',
+                    '{rel: "stylesheet", href: "#href1"}',
                 );
                 const link2 = shadow.childVNodes[1];
                 expect(link2.is(MetadataNode) && link2.htmlTag).to.equal('LINK');
                 expect(link2.modifiers.find(Attributes).name).to.equal(
-                    'rel: stylesheet; href: #href2',
+                    '{rel: "stylesheet", href: "#href2"}',
                 );
                 const link3 = shadow.childVNodes[2];
                 expect(link3.is(MetadataNode) && link3.htmlTag).to.equal('LINK');
-                expect(link3.modifiers.find(Attributes).name).to.equal('rel: help; href: /help/');
+                expect(link3.modifiers.find(Attributes).name).to.equal(
+                    '{rel: "help", href: "/help/"}',
+                );
                 const section = shadow.firstChild();
                 expect(section.is(VElement) && section.htmlTag).to.equal('SECTION');
             });
@@ -369,7 +373,7 @@ describe('DomShadow', async () => {
                 const link = shadow.childVNodes[0];
                 expect(link.is(MetadataNode) && link.htmlTag).to.equal('LINK');
                 expect(link.modifiers.find(Attributes).name).to.equal(
-                    'rel: stylesheet; href: #href1',
+                    '{rel: "stylesheet", href: "#href1"}',
                 );
                 const style = shadow.childVNodes[1];
                 expect(style.is(MetadataNode) && style.htmlTag).to.equal('STYLE');
@@ -377,7 +381,7 @@ describe('DomShadow', async () => {
                 const link2 = shadow.childVNodes[2];
                 expect(link2.is(MetadataNode) && link2.htmlTag).to.equal('LINK');
                 expect(link2.modifiers.find(Attributes).name).to.equal(
-                    'rel: stylesheet; href: #href2',
+                    '{rel: "stylesheet", href: "#href2"}',
                 );
                 const section = shadow.firstChild();
                 expect(section.is(VElement) && section.htmlTag).to.equal('SECTION');
@@ -504,7 +508,7 @@ describe('DomShadow', async () => {
             await editor.start();
             expect(container.innerHTML).to.equal('<jw-editor><jw-shadow></jw-shadow></jw-editor>');
             expect(container.querySelector('jw-shadow').shadowRoot.innerHTML).to.equal(
-                '<link href="#1" rel="stylesheet"><link href="#2" rel="stylesheet"><section contenteditable="true"><p>abc</p><p>def</p></section>',
+                '<link rel="stylesheet" href="#1"><link rel="stylesheet" href="#2"><section contenteditable="true"><p>abc</p><p>def</p></section>',
             );
             await editor.stop();
         });

--- a/packages/plugin-table/src/TableRowXmlDomParser.ts
+++ b/packages/plugin-table/src/TableRowXmlDomParser.ts
@@ -3,6 +3,7 @@ import { XmlDomParsingEngine } from '../../plugin-xml/src/XmlDomParsingEngine';
 import { TableRowNode } from './TableRowNode';
 import { nodeName } from '../../utils/src/utils';
 import { Attributes } from '../../plugin-xml/src/Attributes';
+import { Modifiers } from '../../core/src/Modifiers';
 
 export class TableSectionAttributes extends Attributes {}
 
@@ -46,19 +47,18 @@ export class TableRowXmlDomParser extends AbstractParser<Node> {
             parsedNodes.push(...(await this.engine.parse(child)));
         }
 
-        // Parse the <tbody> or <thead>'s attributes into a technical key of the
-        // node's attributes, that will be read only by `TableRowDomRenderer`.
-        const containerAttributes = this.engine.parseAttributes(tableSection);
+        // Parse the <tbody> or <thead>'s modifiers.
+        const containerModifiers = new Modifiers(this.engine.parseAttributes(tableSection));
 
-        // Apply the attributes and `header` property of the container to each
-        // row.
+        // Apply the attributes, style and `header` property of the container to
+        // each row.
         const name = nodeName(tableSection);
         for (const parsedNode of parsedNodes) {
             if (parsedNode.is(TableRowNode)) {
                 parsedNode.header = name === 'THEAD';
                 parsedNode.modifiers.replace(
                     TableSectionAttributes,
-                    new TableSectionAttributes(containerAttributes),
+                    new TableSectionAttributes(containerModifiers.get(Attributes)),
                 );
             }
         }

--- a/packages/plugin-table/test/Table.test.ts
+++ b/packages/plugin-table/test/Table.test.ts
@@ -815,7 +815,7 @@ describePlugin(Table, testEditor => {
                         'new row has table container attributes',
                     );
                     expect(
-                        insertedRow.modifiers.find(TableSectionAttributes).get('style'),
+                        insertedRow.modifiers.find(TableSectionAttributes)?.style.cssText,
                     ).to.equal('background-color: red;', 'new row preserved styles of thead');
 
                     // Test individual cells
@@ -854,7 +854,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -914,7 +914,7 @@ describePlugin(Table, testEditor => {
                         '2th row is the old row',
                     );
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         'background-color: green;',
                         'row preserved style',
                     );
@@ -962,7 +962,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -1022,7 +1022,7 @@ describePlugin(Table, testEditor => {
                         '3th row is the old row',
                     );
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes)?.get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -1065,7 +1065,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -1125,7 +1125,7 @@ describePlugin(Table, testEditor => {
                         '4th row is the old row',
                     );
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -1172,7 +1172,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">[](3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -1232,7 +1232,7 @@ describePlugin(Table, testEditor => {
                         '5th row is the old row',
                     );
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -1284,7 +1284,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="4" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="4">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -1349,7 +1349,7 @@ describePlugin(Table, testEditor => {
                         '6th row is the old row',
                     );
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -1404,7 +1404,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="4" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="4">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -1468,7 +1468,7 @@ describePlugin(Table, testEditor => {
                         '7th row is the old row',
                     );
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -1518,7 +1518,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -1583,7 +1583,7 @@ describePlugin(Table, testEditor => {
                         '8th row is the old row',
                     );
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -1620,7 +1620,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -1685,7 +1685,7 @@ describePlugin(Table, testEditor => {
                         '9th row is the old row',
                     );
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -1732,7 +1732,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -1796,7 +1796,7 @@ describePlugin(Table, testEditor => {
                         '10th row is the old row',
                     );
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -1833,7 +1833,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -1898,7 +1898,7 @@ describePlugin(Table, testEditor => {
                         '11th row is the old row',
                     );
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -1945,7 +1945,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -2020,7 +2020,7 @@ describePlugin(Table, testEditor => {
                         'new row has table container attributes',
                     );
                     expect(
-                        insertedRow.modifiers.find(TableSectionAttributes).get('style'),
+                        insertedRow.modifiers.find(TableSectionAttributes)?.style.cssText,
                     ).to.equal('background-color: red;', 'new row preserved styles of thead');
 
                     // Test individual cells
@@ -2059,7 +2059,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -2119,7 +2119,7 @@ describePlugin(Table, testEditor => {
                     );
                     expect(insertedRow).to.not.equal(row1, '2th row is a new row');
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         'background-color: green;',
                         'row preserved style',
                     );
@@ -2167,7 +2167,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -2227,7 +2227,7 @@ describePlugin(Table, testEditor => {
                     );
                     expect(insertedRow).to.not.equal(row2, '3th row is a new row');
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -2270,7 +2270,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -2330,7 +2330,7 @@ describePlugin(Table, testEditor => {
                     );
                     expect(insertedRow).to.not.equal(row3, '4th row is a new row');
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -2383,7 +2383,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">[](3, 0)</td>',
-                                '<td rowspan="4" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="4">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -2447,7 +2447,7 @@ describePlugin(Table, testEditor => {
                     );
                     expect(insertedRow).to.not.equal(row4, '5th row is a new row');
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -2503,7 +2503,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="4" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="4">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -2567,7 +2567,7 @@ describePlugin(Table, testEditor => {
                     );
                     expect(insertedRow).to.not.equal(row5, '6th row is a new row');
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -2614,7 +2614,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -2679,7 +2679,7 @@ describePlugin(Table, testEditor => {
                     );
                     expect(insertedRow).to.not.equal(row6, '7th row is a new row');
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -2716,7 +2716,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -2782,7 +2782,7 @@ describePlugin(Table, testEditor => {
                     );
                     expect(insertedRow).to.not.equal(row7, '8th row is a new row');
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -2830,7 +2830,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -2894,7 +2894,7 @@ describePlugin(Table, testEditor => {
                     );
                     expect(insertedRow).to.not.equal(row8, '9th row is a new row');
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -2936,7 +2936,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -3001,7 +3001,7 @@ describePlugin(Table, testEditor => {
                     );
                     expect(insertedRow).to.not.equal(row9, '10th row is a new row');
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -3049,7 +3049,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -3121,7 +3121,7 @@ describePlugin(Table, testEditor => {
                         '11th row is a new row',
                     );
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -3158,7 +3158,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -3227,7 +3227,7 @@ describePlugin(Table, testEditor => {
                         '11th row is a new row',
                     );
                     expect(insertedRow.header).to.equal(false, 'new row is not a header row');
-                    expect(insertedRow.modifiers.find(Attributes).get('style')).to.equal(
+                    expect(insertedRow.modifiers.find(Attributes)?.style.cssText).to.equal(
                         undefined,
                         'row preserved style',
                     );
@@ -3264,7 +3264,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -3379,7 +3379,7 @@ describePlugin(Table, testEditor => {
                             '<tr>',
                                 '<td><br></td>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -3500,7 +3500,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="3">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -3617,8 +3617,8 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;"><br></td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3"><br></td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -3720,7 +3720,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td><br></td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
@@ -3846,7 +3846,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="3">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -3971,7 +3971,7 @@ describePlugin(Table, testEditor => {
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
                                 '<td><br></td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -4085,8 +4085,8 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
-                                '<td rowspan="3" style="background-color: yellow;"><br></td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3"><br></td>',
                                 '<td>(3, 3)</td>',
                             '</tr>',
                             '<tr>',
@@ -4189,7 +4189,7 @@ describePlugin(Table, testEditor => {
                             '</tr>',
                             '<tr>',
                                 '<td colspan="2">(3, 0)</td>',
-                                '<td rowspan="3" style="background-color: yellow;">(3, 2)</td>',
+                                '<td style="background-color: yellow;" rowspan="3">(3, 2)</td>',
                                 '<td>(3, 3)</td>',
                                 '<td><br></td>',
                             '</tr>',

--- a/packages/plugin-table/test/tableTestUtils.ts
+++ b/packages/plugin-table/test/tableTestUtils.ts
@@ -37,7 +37,7 @@ export function testStyles(cells: TableCellNode[], expected: string[]): void {
     for (let i = 0; i < cells.length; i += 1) {
         const desc = `${i}th cell preserved style`;
         const attributes = cells[i].modifiers.find(Attributes);
-        expect(attributes?.get('style')).to.equal(expected[i], desc);
+        expect(attributes?.style.cssText).to.equal(expected[i], desc);
     }
 }
 export function testManagers(

--- a/packages/plugin-textcolor/test/TextColor.test.ts
+++ b/packages/plugin-textcolor/test/TextColor.test.ts
@@ -130,7 +130,7 @@ describePlugin(TextColor, testEditor => {
                         await insertText(editor, 'b');
                     },
                     contentAfter:
-                        '<p style="color: red">a<span style="color: black;">b[]</span>c</p>',
+                        '<p style="color: red;">a<span style="color: black;">b[]</span>c</p>',
                 });
             });
             it('should write two characters in black background', async () => {
@@ -142,7 +142,7 @@ describePlugin(TextColor, testEditor => {
                         await insertText(editor, 'c');
                     },
                     contentAfter:
-                        '<p style="color: red">a<span style="color: black;">bc[]</span>d</p>',
+                        '<p style="color: red;">a<span style="color: black;">bc[]</span>d</p>',
                 });
             });
         });

--- a/packages/plugin-xml/src/ClassList.ts
+++ b/packages/plugin-xml/src/ClassList.ts
@@ -1,0 +1,135 @@
+export class ClassList {
+    private _classList = new Set<string>();
+    constructor(...classList: string[]) {
+        for (const className of classList) {
+            this.add(className);
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Getters
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return the number of classes in the set.
+     */
+    get length(): number {
+        return this._classList.size;
+    }
+    /**
+     * Return a textual representation of the set.
+     */
+    get className(): string {
+        if (!this._classList.size) return;
+        return Array.from(this._classList).join(' ');
+    }
+    /**
+     * Reinitialize the set with a new set of classes, from a string to parse.
+     */
+    set className(className: string) {
+        this.reset(className);
+    }
+
+    //--------------------------------------------------------------------------
+    // Lifecycle
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return a new set of classes, parsed from a className string.
+     *
+     * @param className
+     */
+    parseClassName(className: string): Set<string> {
+        return new Set(
+            className
+                .trim()
+                .split(/\s+/)
+                .filter(c => c.length),
+        );
+    }
+    /**
+     * Return a clone of this list.
+     */
+    clone(): ClassList {
+        const clone = new ClassList();
+        clone._classList = new Set(this._classList);
+        return clone;
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return true if the set has the given class, false otherwise.
+     *
+     * @param name
+     */
+    has(name: string): boolean {
+        return this._classList.has(name);
+    }
+    /**
+     * Return an array containing all the items in the list.
+     */
+    items(): string[] {
+        return Array.from(this._classList);
+    }
+    /**
+     * Add the given class(s) to the set.
+     *
+     * @param className
+     */
+    add(className: string): void {
+        const classes = this.parseClassName(className);
+        for (const name of classes) {
+            this._classList.add(name);
+        }
+    }
+    /**
+     * Remove the given class(es) from the set.
+     *
+     * @param className
+     */
+    remove(className: string): void {
+        const classes = this.parseClassName(className);
+        for (const name of classes) {
+            this._classList.delete(name);
+        }
+    }
+    /**
+     * Clear the set of all its classes.
+     */
+    clear(): void {
+        this._classList = new Set();
+    }
+    /**
+     * Reinitialize the set with a new set of classes (empty if no argument is
+     * passed). The argument can be a set of classes or a string to parse.
+     *
+     * @param classList
+     */
+    reset(...classList: string[]): void {
+        this._classList.clear();
+        for (const className of classList) {
+            this.add(className);
+        }
+    }
+    /**
+     * For each given class, add it to the set if it doesn't have it yet,
+     * otherwise remove it.
+     *
+     * @param classes
+     */
+    toggle(...classes: string[]): void {
+        for (const className of classes) {
+            const parsed = this.parseClassName(className);
+            for (const name of parsed) {
+                if (this._classList.has(name)) {
+                    this._classList.delete(name);
+                } else {
+                    this._classList.add(name);
+                }
+            }
+        }
+    }
+}

--- a/packages/plugin-xml/src/CssStyle.ts
+++ b/packages/plugin-xml/src/CssStyle.ts
@@ -1,0 +1,143 @@
+export class CssStyle {
+    private _style: Record<string, string> = {};
+    constructor(style?: string | Record<string, string>) {
+        if (style) {
+            this.reset(style);
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Getters
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return the number of styles in the set.
+     */
+    get length(): number {
+        return Object.keys(this._style).length;
+    }
+    /**
+     * Return a textual representation of the CSS declaration block.
+     */
+    get cssText(): string {
+        const keys = Object.keys(this._style);
+        if (!Object.keys(this._style).length) return;
+        const valueRepr = [];
+        for (const key of keys) {
+            valueRepr.push(`${key}: ${this._style[key]}`);
+        }
+        let result = valueRepr.join('; ');
+        if (valueRepr.length) {
+            result += ';';
+        }
+        return result;
+    }
+    /**
+     * Reinitialize the record with a new record of styles, from a string to
+     * parse.
+     */
+    set cssText(cssText: string) {
+        this.reset(cssText);
+    }
+
+    //--------------------------------------------------------------------------
+    // Lifecycle
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return a new record of styles, parsed from a cssText string.
+     *
+     * @param className
+     */
+    parseCssText(cssText: string): Record<string, string> {
+        const style: Record<string, string> = {};
+        return cssText
+            .split(';')
+            .map(style => style.trim())
+            .filter(style => style.length)
+            .reduce((accumulator, value) => {
+                const [key, v] = value.split(':');
+                style[key.trim()] = v.trim();
+                return accumulator;
+            }, style);
+    }
+    /**
+     * Return a clone of this record.
+     */
+    clone(): CssStyle {
+        const clone = new CssStyle();
+        clone._style = { ...this._style };
+        return clone;
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * Return true if the record has the given style, false otherwise.
+     *
+     * @param key
+     */
+    has(key: string): boolean {
+        return !!this._style[key];
+    }
+    /**
+     * Return an array containing all the keys in the record.
+     */
+    keys(): string[] {
+        return Object.keys(this._style);
+    }
+    /**
+     * Return an array containing all the values in the record.
+     */
+    values(): string[] {
+        return Object.values(this._style);
+    }
+    /**
+     * Return the record matching the given name.
+     *
+     * @param name
+     */
+    get(name: string): string {
+        return this._style[name];
+    }
+    /**
+     * Set the record with the given name to the given value.
+     *
+     * @param name
+     * @param value
+     */
+    set(name: string, value: string): void {
+        this._style[name] = value;
+    }
+    /**
+     * Remove the record(s) with the given name(s).
+     *
+     * @param name
+     */
+    remove(...names: string[]): void {
+        for (const name of names) {
+            delete this._style[name];
+        }
+    }
+    /**
+     * Clear the record of all its styles.
+     */
+    clear(): void {
+        this._style = {};
+    }
+    /**
+     * Reinitialize the record with a new record of styles (empty if no argument
+     * is passed). The argument can be a record of styles or a string to parse.
+     *
+     * @param style
+     */
+    reset(style: Record<string, string> | string = {}): void {
+        if (typeof style === 'object') {
+            this._style = style;
+        } else {
+            this._style = this.parseCssText(style);
+        }
+    }
+}

--- a/packages/plugin-xml/src/XmlDomParsingEngine.ts
+++ b/packages/plugin-xml/src/XmlDomParsingEngine.ts
@@ -11,10 +11,6 @@ export class XmlDomParsingEngine<T extends Node = Node> extends ParsingEngine<T>
      * @param node
      */
     parseAttributes(node: Element): Attributes {
-        const attributes = new Attributes();
-        for (const attribute of Array.from(node.attributes)) {
-            attributes.set(attribute.name, attribute.value);
-        }
-        return attributes;
+        return new Attributes(node.attributes);
     }
 }

--- a/packages/plugin-xml/test/Xml.test.ts
+++ b/packages/plugin-xml/test/Xml.test.ts
@@ -1,0 +1,726 @@
+import { expect } from 'chai';
+import { describePlugin, testEditor } from '../../utils/src/testUtils';
+import { Xml } from '../src/Xml';
+import { BasicEditor } from '../../../bundles/BasicEditor';
+import { Attributes } from '../src/Attributes';
+import { CssStyle } from '../src/CssStyle';
+import { ClassList } from '../src/ClassList';
+
+describePlugin(Xml, () => {
+    describe('Attributes', () => {
+        describe('parse/render', () => {
+            it('should parse attributes and render them', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore:
+                        '<p style="  width:  800px;  color: red" height="5em"  class="how many roads must a man go down"  disabled>42</p>',
+                    contentAfter:
+                        '<p style="width: 800px; color: red;" height="5em" class="how many roads must a man go down" disabled="">42</p>',
+                });
+            });
+        });
+        describe('constructor', () => {
+            it('should create a new empty Attributes', async () => {
+                const attributes = new Attributes();
+                expect(attributes instanceof Attributes).to.be.true;
+                expect(attributes.length).to.equal(0);
+            });
+            it('should create a new Attributes from another', async () => {
+                const attributes = new Attributes({
+                    'eye-color': 'green',
+                    style: 'color: pink;',
+                    class: 'super classy',
+                });
+                const newAttributes = new Attributes(attributes);
+                expect(newAttributes instanceof Attributes).to.be.true;
+                expect(newAttributes.length).to.equal(3);
+                expect(newAttributes.keys()).to.deep.equal(['eye-color', 'style', 'class']);
+                expect(newAttributes.values()).to.deep.equal([
+                    'green',
+                    'color: pink;',
+                    'super classy',
+                ]);
+                expect(newAttributes.style.length).to.equal(1);
+                expect(newAttributes.style.cssText).to.equal('color: pink;');
+                expect(newAttributes.classList.length).to.equal(2);
+                expect(newAttributes.classList.className).to.equal('super classy');
+                expect(newAttributes.get('eye-color')).to.equal('green');
+                expect(newAttributes.get('style')).to.equal('color: pink;');
+                expect(newAttributes.get('class')).to.equal('super classy');
+            });
+        });
+        describe('name', () => {
+            it('should show the attributes as one string', async () => {
+                const attributes = new Attributes({
+                    'nose-type': 'crooked',
+                    'eye-color': 'green',
+                });
+                expect(attributes.name).to.equal('{nose-type: "crooked", eye-color: "green"}');
+            });
+            it('should show the attributes as one string (with style and classes)', async () => {
+                const attributes = new Attributes({
+                    'nose-type': 'crooked',
+                    'eye-color': 'green',
+                    style: 'color: pink;',
+                    class: 'super classy',
+                });
+                expect(attributes.name).to.equal(
+                    '{nose-type: "crooked", eye-color: "green", style: "color: pink;", class: "super classy"}',
+                );
+            });
+        });
+        describe('clone', () => {
+            it('should clone Attributes', async () => {
+                const attributes = new Attributes({
+                    'eye-color': 'green',
+                    style: 'color: pink;',
+                    class: 'super classy',
+                });
+                const newAttributes = attributes.clone();
+                expect(newAttributes instanceof Attributes).to.be.true;
+                expect(newAttributes.length).to.equal(3);
+                expect(newAttributes.keys()).to.deep.equal(['eye-color', 'style', 'class']);
+                expect(newAttributes.values()).to.deep.equal([
+                    'green',
+                    'color: pink;',
+                    'super classy',
+                ]);
+                expect(newAttributes.style.length).to.equal(1);
+                expect(newAttributes.style.cssText).to.equal('color: pink;');
+                expect(newAttributes.classList.length).to.equal(2);
+                expect(newAttributes.classList.className).to.equal('super classy');
+                expect(newAttributes.get('eye-color')).to.equal('green');
+                expect(newAttributes.get('style')).to.equal('color: pink;');
+                expect(newAttributes.get('class')).to.equal('super classy');
+            });
+        });
+        describe('has', () => {
+            it('should find that the Attributes have a key', async () => {
+                const attributes = new Attributes({
+                    'eye-color': 'green',
+                    style: 'color: pink;',
+                    class: 'super classy',
+                });
+                expect(attributes.has('eye-color')).to.be.true;
+                expect(attributes.has('style')).to.be.true;
+                expect(attributes.has('class')).to.be.true;
+            });
+            it("should find that the Attributes doesn't have a key", async () => {
+                const attributes = new Attributes({
+                    'eye-color': 'green',
+                    style: 'color: pink;',
+                });
+                expect(attributes.has('nose-type')).to.be.false;
+                expect(attributes.has(' ')).to.be.false;
+                expect(attributes.has('class')).to.be.false;
+                expect(attributes.has('styles')).to.be.false;
+            });
+            it('should find that the Attributes have a style but no class', async () => {
+                const attributes = new Attributes({
+                    style: 'color: pink;',
+                });
+                attributes.style.set('color', 'pink');
+                expect(attributes.has('style')).to.be.true;
+                expect(attributes.has('class')).to.be.false;
+            });
+        });
+        describe('keys', () => {
+            it('should return the keys in the Attributes record', async () => {
+                const attributes = new Attributes({
+                    'eye-color': 'green',
+                    style: 'color: pink;',
+                });
+                expect(attributes.keys()).to.deep.equal(['eye-color', 'style']);
+            });
+        });
+        describe('values', () => {
+            it('should return the values in the Attributes record', async () => {
+                const attributes = new Attributes({
+                    'eye-color': 'green',
+                    style: 'color: pink;',
+                    class: 'super classy',
+                });
+                expect(attributes.values()).to.deep.equal([
+                    'green',
+                    'color: pink;',
+                    'super classy',
+                ]);
+            });
+        });
+        describe('get', () => {
+            it('should get a specific attribute', async () => {
+                const attributes = new Attributes({
+                    'eye-color': 'green',
+                    style: 'color: pink;',
+                    class: 'super classy',
+                });
+                expect(attributes.get('eye-color')).to.equal('green');
+                expect(attributes.get('style')).to.equal('color: pink;');
+                expect(attributes.get('class')).to.equal('super classy');
+            });
+            it("should not get an attribute that doesn't exist", async () => {
+                const attributes = new Attributes({
+                    'eye-color': 'green',
+                    style: 'color: pink;',
+                    class: 'super classy',
+                });
+                expect(attributes.get('color')).to.be.undefined;
+            });
+        });
+        describe('set', () => {
+            it('should set a key in the record', async () => {
+                const attributes = new Attributes();
+                expect(attributes.length).to.equal(0);
+                expect(attributes.keys()).to.deep.equal([]);
+                attributes.set('eye-color', 'green');
+                expect(attributes.length).to.equal(1);
+                expect(attributes.keys()).to.deep.equal(['eye-color']);
+                expect(attributes.values()).to.deep.equal(['green']);
+                expect(attributes.get('eye-color')).to.equal('green');
+            });
+            it('should set the style key in the record', async () => {
+                const attributes = new Attributes();
+                expect(attributes.length).to.equal(0);
+                expect(attributes.keys()).to.deep.equal([]);
+                attributes.set('style', ' width : 500px;  color: green   ');
+                expect(attributes.length).to.equal(1);
+                expect(attributes.keys()).to.deep.equal(['style']);
+                expect(attributes.values()).to.deep.equal(['width: 500px; color: green;']);
+                expect(attributes.get('style')).to.equal('width: 500px; color: green;');
+                expect(attributes.style.length).to.equal(2);
+                expect(attributes.style.keys()).to.deep.equal(['width', 'color']);
+                expect(attributes.style.values()).to.deep.equal(['500px', 'green']);
+                expect(attributes.style.get('width')).to.equal('500px');
+                expect(attributes.style.get('color')).to.equal('green');
+            });
+        });
+        describe('remove', () => {
+            it('should remove a key from the record', async () => {
+                const attributes = new Attributes({
+                    'eye-color': 'red',
+                    'nose-type': 'none',
+                });
+                expect(attributes.length).to.equal(2);
+                expect(attributes.keys()).to.deep.equal(['eye-color', 'nose-type']);
+                attributes.remove('eye-color');
+                expect(attributes.length).to.equal(1);
+                expect(attributes.keys()).to.deep.equal(['nose-type']);
+            });
+            it('should remove the style', async () => {
+                const attributes = new Attributes({
+                    style: 'color: red; background-color: yellow',
+                });
+                expect(attributes.length).to.equal(1);
+                expect(attributes.keys()).to.deep.equal(['style']);
+                expect(attributes.style.length).to.equal(2);
+                attributes.remove('style');
+                expect(attributes.length).to.equal(0);
+                expect(attributes.style instanceof CssStyle).to.be.true;
+                expect(attributes.style.length).to.equal(0);
+                expect(attributes.get('style')).to.be.undefined;
+            });
+            it('should remove the classList', async () => {
+                const attributes = new Attributes({
+                    class: 'cool stuff',
+                });
+                expect(attributes.length).to.equal(1);
+                expect(attributes.keys()).to.deep.equal(['class']);
+                expect(attributes.classList.length).to.equal(2);
+                attributes.remove('class');
+                expect(attributes.length).to.equal(0);
+                expect(attributes.classList instanceof ClassList).to.be.true;
+                expect(attributes.classList.length).to.equal(0);
+                expect(attributes.get('class')).to.be.undefined;
+            });
+            it('should remove two keys from the record', async () => {
+                const attributes = new Attributes({
+                    'eye-color': 'red',
+                    'nose-type': 'none',
+                });
+                expect(attributes.length).to.equal(2);
+                expect(attributes.keys()).to.deep.equal(['eye-color', 'nose-type']);
+                attributes.remove('nose-type', 'eye-color');
+                expect(attributes.length).to.equal(0);
+                expect(attributes.keys()).to.deep.equal([]);
+            });
+            it('should not remove a key', async () => {
+                const attributes = new Attributes({
+                    'eye-color': 'red',
+                    'nose-type': 'none',
+                });
+                expect(attributes.length).to.equal(2);
+                expect(attributes.keys()).to.deep.equal(['eye-color', 'nose-type']);
+                attributes.remove('nose-color');
+                expect(attributes.length).to.equal(2);
+                expect(attributes.keys()).to.deep.equal(['eye-color', 'nose-type']);
+            });
+            it('should remove one key but not another', async () => {
+                const attributes = new Attributes({
+                    'eye-color': 'red',
+                    'nose-type': 'none',
+                });
+                expect(attributes.length).to.equal(2);
+                expect(attributes.keys()).to.deep.equal(['eye-color', 'nose-type']);
+                attributes.remove('nose-color', 'eye-color');
+                expect(attributes.length).to.equal(1);
+                expect(attributes.keys()).to.deep.equal(['nose-type']);
+            });
+        });
+        describe('clear', () => {
+            it('should remove all the keys in the record', async () => {
+                const attributes = new Attributes({
+                    'eye-color': 'red',
+                    'nose-type': 'none',
+                    style: 'color: white;',
+                });
+                expect(attributes.length).to.equal(3);
+                attributes.clear();
+                expect(attributes.length).to.equal(0);
+                expect(attributes.keys()).to.deep.equal([]);
+                expect(attributes.style.length).to.equal(0);
+                expect(attributes.classList.length).to.equal(0);
+            });
+        });
+    });
+    describe('CssStyle', () => {
+        describe('parse/render', () => {
+            it('should parse a style and render it', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p style="  width:  800px;  color: red">Stylish</p>',
+                    contentAfter: '<p style="width: 800px; color: red;">Stylish</p>',
+                });
+            });
+        });
+        describe('constructor', () => {
+            it('should create a new empty CssStyle', async () => {
+                const style = new CssStyle();
+                expect(style instanceof CssStyle).to.be.true;
+                expect(style.length).to.equal(0);
+            });
+            it('should create a new CssStyle from a string', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style instanceof CssStyle).to.be.true;
+                expect(style.length).to.equal(2);
+                expect(style.keys()).to.deep.equal(['width', 'color']);
+                expect(style.values()).to.deep.equal(['800px', 'red']);
+            });
+            it('should create a new CssStyle from a record', async () => {
+                const style = new CssStyle({
+                    width: '800px',
+                    color: 'red',
+                });
+                expect(style instanceof CssStyle).to.be.true;
+                expect(style.length).to.equal(2);
+                expect(style.keys()).to.deep.equal(['width', 'color']);
+                expect(style.values()).to.deep.equal(['800px', 'red']);
+            });
+        });
+        describe('cssText', () => {
+            it('should show the styles as one string (get)', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.cssText).to.equal('width: 800px; color: red;');
+            });
+            it('should reinitialize the set with the given string (set)', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                style.cssText = ' color :  blue;  height: 5em   ';
+                expect(style.cssText).to.equal('color: blue; height: 5em;');
+                expect(style.length).to.equal(2);
+            });
+        });
+        describe('parseCssText', () => {
+            it('should parse a style and render it', async () => {
+                const style = new CssStyle();
+                const parsedRecord = style.parseCssText(' color :  blue;  height: 5em  ; ');
+                expect(parsedRecord).to.deep.equal({
+                    color: 'blue',
+                    height: '5em',
+                });
+            });
+        });
+        describe('clone', () => {
+            it('should clone a style', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                const clone = style.clone();
+                expect(clone.length).to.equal(style.length);
+                expect(clone.cssText).to.equal(style.cssText);
+                expect(clone.keys()).to.deep.equal(style.keys());
+                expect(clone.values()).to.deep.equal(style.values());
+            });
+        });
+        describe('has', () => {
+            it('should find that the style has a key', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.has('width')).to.be.true;
+                expect(style.has('color')).to.be.true;
+            });
+            it("should find that the style doesn't have a key", async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.has('height')).to.be.false;
+                expect(style.has(' ')).to.be.false;
+                expect(style.has('background color')).to.be.false;
+                expect(style.has('colors')).to.be.false;
+            });
+        });
+        describe('keys', () => {
+            it('should return the keys in the style record', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.keys()).to.deep.equal(['width', 'color']);
+            });
+        });
+        describe('values', () => {
+            it('should return the values in the style record', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.values()).to.deep.equal(['800px', 'red']);
+            });
+        });
+        describe('get', () => {
+            it('should get a specific style', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.get('color')).to.equal('red');
+            });
+            it("should not get a style that doesn't exist", async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.get('background-color')).to.be.undefined;
+            });
+        });
+        describe('set', () => {
+            it('should set a key in the record', async () => {
+                const style = new CssStyle();
+                expect(style.length).to.equal(0);
+                expect(style.keys()).to.deep.equal([]);
+                style.set('color', 'red');
+                expect(style.length).to.equal(1);
+                expect(style.keys()).to.deep.equal(['color']);
+                expect(style.values()).to.deep.equal(['red']);
+                expect(style.get('color')).to.equal('red');
+            });
+        });
+        describe('remove', () => {
+            it('should remove a key from the record', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.length).to.equal(2);
+                expect(style.keys()).to.deep.equal(['width', 'color']);
+                style.remove('color');
+                expect(style.length).to.equal(1);
+                expect(style.keys()).to.deep.equal(['width']);
+                expect(style.values()).to.deep.equal(['800px']);
+                expect(style.get('width')).to.equal('800px');
+                style.remove('width');
+                expect(style.length).to.equal(0);
+                expect(style.keys()).to.deep.equal([]);
+            });
+            it('should remove two keys from the record', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.length).to.equal(2);
+                expect(style.keys()).to.deep.equal(['width', 'color']);
+                style.remove('color', 'width');
+                expect(style.length).to.equal(0);
+                expect(style.keys()).to.deep.equal([]);
+            });
+            it('should not remove a key', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.length).to.equal(2);
+                expect(style.keys()).to.deep.equal(['width', 'color']);
+                style.remove('background-color');
+                expect(style.length).to.equal(2);
+                expect(style.keys()).to.deep.equal(['width', 'color']);
+            });
+            it('should remove one key but not another', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.length).to.equal(2);
+                expect(style.keys()).to.deep.equal(['width', 'color']);
+                style.remove('color', 'background-color');
+                expect(style.length).to.equal(1);
+                expect(style.keys()).to.deep.equal(['width']);
+            });
+        });
+        describe('clear', () => {
+            it('should remove all the keys in the record', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.length).to.equal(2);
+                style.clear();
+                expect(style.length).to.equal(0);
+                expect(style.keys()).to.deep.equal([]);
+            });
+        });
+        describe('reset', () => {
+            it('should remove all the keys in the record', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.length).to.equal(2);
+                style.reset();
+                expect(style.length).to.equal(0);
+                expect(style.keys()).to.deep.equal([]);
+            });
+            it('should remove all the keys and replace them with a new record of styles', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.length).to.equal(2);
+                style.reset({
+                    height: '5em',
+                    'background-color': 'blue',
+                });
+                expect(style.length).to.equal(2);
+                expect(style.keys()).to.deep.equal(['height', 'background-color']);
+                expect(style.get('height')).to.equal('5em');
+                expect(style.get('background-color')).to.equal('blue');
+            });
+            it('should remove all the keys and replace them with a new parsed record of styles', async () => {
+                const style = new CssStyle('  width:  800px;  color: red');
+                expect(style.length).to.equal(2);
+                style.reset('height : 5em;background-color: blue ');
+                expect(style.length).to.equal(2);
+                expect(style.keys()).to.deep.equal(['height', 'background-color']);
+                expect(style.get('height')).to.equal('5em');
+                expect(style.get('background-color')).to.equal('blue');
+            });
+        });
+    });
+    describe('ClassList', () => {
+        describe('parse/render', () => {
+            it('should parse a class name and render it', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p class="how many roads must a man go down">42</p>',
+                    contentAfter: '<p class="how many roads must a man go down">42</p>',
+                });
+            });
+        });
+        describe('constructor', () => {
+            it('should create a new empty ClassList', async () => {
+                const classList = new ClassList();
+                expect(classList instanceof ClassList).to.be.true;
+                expect(classList.length).to.equal(0);
+            });
+            it('should create a new ClassList from a string', async () => {
+                const classList = new ClassList('these are all classes all');
+                expect(classList instanceof ClassList).to.be.true;
+                expect(classList.length).to.equal(4);
+                expect(classList.items()).to.deep.equal(['these', 'are', 'all', 'classes']);
+            });
+            it('should create a new ClassList from a set', async () => {
+                const classList = new ClassList('these', 'are', 'all', 'classes');
+                expect(classList instanceof ClassList).to.be.true;
+                expect(classList.length).to.equal(4);
+                expect(classList.items()).to.deep.equal(['these', 'are', 'all', 'classes']);
+            });
+        });
+        describe('className', () => {
+            it('should show the classes in alphabetical order, as one string (get)', async () => {
+                const classList = new ClassList('these are all classes all');
+                expect(classList.className).to.equal('these are all classes');
+            });
+            it('should reinitialize the set with the given string (set)', async () => {
+                const classList = new ClassList('these are all classes all');
+                classList.className = 'Ileana rocks';
+                expect(classList.className).to.equal('Ileana rocks');
+                expect(classList.length).to.equal(2);
+            });
+        });
+        describe('parseClassName', () => {
+            it('should parse a class name and render it', async () => {
+                const classList = new ClassList();
+                const parsedSet = classList.parseClassName('classes are for losers are they not');
+                expect(Array.from(parsedSet)).to.deep.equal([
+                    'classes',
+                    'are',
+                    'for',
+                    'losers',
+                    'they',
+                    'not',
+                ]);
+            });
+        });
+        describe('clone', () => {
+            it('should clone a class list', async () => {
+                const classList = new ClassList('my favorite classes');
+                const clone = classList.clone();
+                expect(clone.length).to.equal(classList.length);
+                expect(clone.className).to.equal(classList.className);
+                expect(clone.items()).to.deep.equal(classList.items());
+            });
+        });
+        describe('has', () => {
+            it('should find that the class list has a class', async () => {
+                const classList = new ClassList('my favorite classes');
+                expect(classList.has('my')).to.be.true;
+                expect(classList.has('favorite')).to.be.true;
+                expect(classList.has('classes')).to.be.true;
+            });
+            it("should find that the class list doesn't have a class", async () => {
+                const classList = new ClassList('my favorite classes');
+                expect(classList.has('your')).to.be.false;
+                expect(classList.has(' ')).to.be.false;
+                expect(classList.has('my favorite')).to.be.false;
+                expect(classList.has('class')).to.be.false;
+            });
+        });
+        describe('items', () => {
+            it('should return the items in the class list', async () => {
+                const classList = new ClassList('classes are for losers are they not');
+                expect(classList.items()).to.deep.equal([
+                    'classes',
+                    'are',
+                    'for',
+                    'losers',
+                    'they',
+                    'not',
+                ]);
+            });
+        });
+        describe('add', () => {
+            it('should add a class', async () => {
+                const classList = new ClassList();
+                expect(classList.length).to.equal(0);
+                expect(classList.items()).to.deep.equal([]);
+                classList.add('Georges');
+                expect(classList.length).to.equal(1);
+                expect(classList.items()).to.deep.equal(['Georges']);
+                classList.add('Abitbol');
+                expect(classList.length).to.equal(2);
+                expect(classList.items()).to.deep.equal(['Georges', 'Abitbol']);
+            });
+            it('should add two classes', async () => {
+                const classList = new ClassList();
+                expect(classList.length).to.equal(0);
+                expect(classList.items()).to.deep.equal([]);
+                classList.add('Georges Abitbol');
+                expect(classList.length).to.equal(2);
+                expect(classList.items()).to.deep.equal(['Georges', 'Abitbol']);
+            });
+            it('should add two classes (with spaces)', async () => {
+                const classList = new ClassList();
+                expect(classList.length).to.equal(0);
+                expect(classList.items()).to.deep.equal([]);
+                classList.add(' Georges  Abitbol ');
+                expect(classList.length).to.equal(2);
+                expect(classList.items()).to.deep.equal(['Georges', 'Abitbol']);
+            });
+        });
+        describe('remove', () => {
+            it('should remove a class', async () => {
+                const classList = new ClassList('Georges Abitbol');
+                expect(classList.length).to.equal(2);
+                expect(classList.items()).to.deep.equal(['Georges', 'Abitbol']);
+                classList.remove('Georges');
+                expect(classList.length).to.equal(1);
+                expect(classList.items()).to.deep.equal(['Abitbol']);
+                classList.remove('Abitbol');
+                expect(classList.length).to.equal(0);
+                expect(classList.items()).to.deep.equal([]);
+            });
+            it('should remove two classes', async () => {
+                const classList = new ClassList('Georges Abitbol');
+                expect(classList.length).to.equal(2);
+                expect(classList.items()).to.deep.equal(['Georges', 'Abitbol']);
+                classList.remove('Abitbol Georges');
+                expect(classList.length).to.equal(0);
+                expect(classList.items()).to.deep.equal([]);
+            });
+            it('should not remove a class', async () => {
+                const classList = new ClassList('Georges Abitbol');
+                expect(classList.length).to.equal(2);
+                expect(classList.items()).to.deep.equal(['Georges', 'Abitbol']);
+                classList.remove('George');
+                expect(classList.length).to.equal(2);
+                expect(classList.items()).to.deep.equal(['Georges', 'Abitbol']);
+            });
+            it('should remove one class but not another', async () => {
+                const classList = new ClassList('Georges Abitbol');
+                expect(classList.length).to.equal(2);
+                expect(classList.items()).to.deep.equal(['Georges', 'Abitbol']);
+                classList.remove('Abitbol George');
+                expect(classList.length).to.equal(1);
+                expect(classList.items()).to.deep.equal(['Georges']);
+            });
+            it('should remove a class (with spaces)', async () => {
+                const classList = new ClassList('Georges Abitbol');
+                expect(classList.length).to.equal(2);
+                expect(classList.items()).to.deep.equal(['Georges', 'Abitbol']);
+                classList.remove(' Georges  ');
+                expect(classList.length).to.equal(1);
+                expect(classList.items()).to.deep.equal(['Abitbol']);
+            });
+        });
+        describe('clear', () => {
+            it('should remove all the classes', async () => {
+                const classList = new ClassList('Georges Abitbol is the classiest man alive');
+                expect(classList.length).to.equal(7);
+                classList.clear();
+                expect(classList.length).to.equal(0);
+                expect(classList.items()).to.deep.equal([]);
+            });
+        });
+        describe('reset', () => {
+            it('should remove all the classes', async () => {
+                const classList = new ClassList('Georges Abitbol is the classiest man alive');
+                expect(classList.length).to.equal(7);
+                classList.reset();
+                expect(classList.length).to.equal(0);
+                expect(classList.items()).to.deep.equal([]);
+            });
+            it('should remove all the classes and replace them with a new set of classes', async () => {
+                const classList = new ClassList('Georges Abitbol is the classiest man alive');
+                expect(classList.length).to.equal(7);
+                classList.reset('try', 'the', 'chocolate', 'mousse');
+                expect(classList.length).to.equal(4);
+                expect(classList.items()).to.deep.equal(['try', 'the', 'chocolate', 'mousse']);
+            });
+            it('should remove all the classes and replace them with a new parsed set of classes', async () => {
+                const classList = new ClassList('Georges Abitbol is the classiest man alive');
+                expect(classList.length).to.equal(7);
+                classList.reset('try the chocolate mousse');
+                expect(classList.length).to.equal(4);
+                expect(classList.items()).to.deep.equal(['try', 'the', 'chocolate', 'mousse']);
+            });
+        });
+        describe('toggle', () => {
+            it('should add a class by toggling', async () => {
+                const classList = new ClassList();
+                classList.toggle('classy');
+                expect(classList.length).to.equal(1);
+                expect(classList.items()).to.deep.equal(['classy']);
+            });
+            it('should remove a class by toggling', async () => {
+                const classList = new ClassList('classy');
+                expect(classList.length).to.equal(1);
+                expect(classList.items()).to.deep.equal(['classy']);
+                classList.toggle('classy');
+                expect(classList.length).to.equal(0);
+                expect(classList.items()).to.deep.equal([]);
+            });
+            it('should add two classes by toggling', async () => {
+                const classList = new ClassList();
+                classList.toggle('Georges Abitbol');
+                expect(classList.length).to.equal(2);
+                expect(classList.items()).to.deep.equal(['Georges', 'Abitbol']);
+            });
+            it('should remove two classes by toggling', async () => {
+                const classList = new ClassList('Georges Abitbol');
+                expect(classList.length).to.equal(2);
+                expect(classList.items()).to.deep.equal(['Georges', 'Abitbol']);
+                classList.toggle('Abitbol Georges');
+                expect(classList.length).to.equal(0);
+                expect(classList.items()).to.deep.equal([]);
+            });
+            it('should remove four classes by toggling with rest parameters', async () => {
+                const classList = new ClassList('Georges Abitbol is classy');
+                expect(classList.length).to.equal(4);
+                expect(classList.items()).to.deep.equal(['Georges', 'Abitbol', 'is', 'classy']);
+                classList.toggle('Abitbol classy', 'is Georges');
+                expect(classList.length).to.equal(0);
+                expect(classList.items()).to.deep.equal([]);
+            });
+            it('should add a class and remove another, by toggling', async () => {
+                const classList = new ClassList('Georges is classy');
+                expect(classList.length).to.equal(3);
+                classList.toggle('Georges Antoine');
+                expect(classList.length).to.equal(3);
+                expect(classList.items()).to.deep.equal(['is', 'classy', 'Antoine']);
+            });
+            it('should add two classes and remove two others, by toggling with rest parameters', async () => {
+                const classList = new ClassList('Georges Abitbol is classy');
+                expect(classList.length).to.equal(4);
+                classList.toggle('Georges Guenet', 'Antoine Abitbol');
+                expect(classList.length).to.equal(4);
+                expect(classList.items()).to.deep.equal(['is', 'classy', 'Guenet', 'Antoine']);
+            });
+        });
+    });
+});

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -1,7 +1,3 @@
-import { VNode } from '../../core/src/VNodes/VNode';
-import { Format } from '../../plugin-inline/src/Format';
-import { Attributes } from '../../plugin-xml/src/Attributes';
-
 export type Constructor<T> = new (...args) => T;
 
 /**
@@ -93,80 +89,4 @@ export function getDocument(node: Node): Document | ShadowRoot {
         }
     }
     return root || document;
-}
-
-/**
- * Get the target VNode or Format's style attribute as a record of style name to
- * style value.
- *
- * @param target
- */
-export function getStyles(target: VNode | Format): Record<string, string> {
-    const stylesArray = ((target.modifiers.find(Attributes)?.get('style') as string) || '')
-        .split(';')
-        .map(style => style.trim())
-        .filter(style => style.length);
-    const styles: Record<string, string> = {};
-    stylesArray.reduce((accumulator, value) => {
-        const [key, v] = value.split(':');
-        styles[key.trim()] = v.trim();
-        return accumulator;
-    }, styles);
-    return styles;
-}
-
-/**
- * Set the target VNode or Format's style attribute from a record of style name
- * to style value.
- *
- * @param target
- * @param styles
- */
-export function setStyles(target: VNode | Format, styles: Record<string, string>): void {
-    const stylesArray: string[] = [];
-    for (const key of Object.keys(styles)) {
-        stylesArray.push([key, styles[key]].join(': '));
-    }
-    if (stylesArray.length) {
-        target.modifiers.get(Attributes).set('style', stylesArray.join('; ') + ';');
-    } else {
-        target.modifiers.find(Attributes)?.remove('style');
-    }
-}
-
-/**
- * Get the value of the given style name from the target VNode or Format's style
- * attribute.
- *
- * @param target
- * @param styleName
- */
-export function getStyle(target: VNode | Format, styleName: string): string {
-    return getStyles(target)[styleName];
-}
-
-/**
- * Set the target VNode or Format's style attribute of the given name to the
- * given value.
- *
- * @param target
- * @param styleName
- * @param styleValue
- */
-export function setStyle(target: VNode | Format, styleName: string, styleValue: string): void {
-    const styles = getStyles(target);
-    styles[styleName] = styleValue;
-    setStyles(target, styles);
-}
-
-/**
- * Remove the given style from the target VNode or Format's style attribute.
- *
- * @param target
- * @param styleName
- */
-export function removeStyle(target: VNode | Format, styleName: string): void {
-    const styles = getStyles(target);
-    delete styles[styleName];
-    setStyles(target, styles);
 }


### PR DESCRIPTION
[IMP] Attributes: introduce CssStyle and ClassList

Attributes `style` and `class` can be manipulated in an easier way
through the new classes `CssStyle` and `ClassList`, which exist on the
`style` and `classList` properties of `Attributes`.

Examples:
```ts
node.modifiers.get(Attributes).style.set('color', 'red');
node.modifiers.find(Attributes)?.style.get('color'); // returns 'red'
node.modifiers.get(Attributes).set('style', 'width: 500px; background-color: blue;');
node.modifiers.find(Attributes)?.style.length; // returns 2
node.modifiers.find(Attributes)?.style.get('width'); // returns '500px'
node.modifiers.find(Attributes)?.style.get('color'); // returns undefined
node.modifiers.find(Attributes)?.get('style'); // returns 'width: 500px; background-color: blue;'
node.modifiers.find(Attributes)?.style.remove('width); // returns 'width: 500px; background-color: blue;'
node.modifiers.find(Attributes)?.style.length; // returns 1
```

```ts
node.modifiers.get(Attributes).classList.set('two classes');
node.modifiers.find(Attributes)?.classList.length; // returns 2
node.modifiers.find(Attributes)?.classList.has('two'); // returns true
node.modifiers.find(Attributes)?.classList.add('or more'); // returns true
node.modifiers.find(Attributes)?.get('class'); // returns 'two classes or more'
node.modifiers.find(Attributes)?.classList.length; // returns 4
node.modifiers.find(Attributes)?.classList.remove('or');
node.modifiers.find(Attributes)?.classList.toggle('two');
node.modifiers.find(Attributes)?.classList.toggle('three');
node.modifiers.find(Attributes)?.get('class'); // returns 'classes more three'
```