### PR TITLE
[FIX] Owl: bump version and add env browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/odoo/jabberwock#readme",
   "devDependencies": {
-    "@odoo/owl": "^1.0.5",
+    "@odoo/owl": "^1.0.7",
     "@types/chai": "^4.2.10",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.12.30",

--- a/packages/plugin-owl/src/Owl.ts
+++ b/packages/plugin-owl/src/Owl.ts
@@ -5,6 +5,7 @@ import { Loadables } from '../../core/src/JWEditor';
 import { Renderer } from '../../plugin-renderer/src/Renderer';
 import { OwlEnv, OwlComponent } from './ui/OwlComponent';
 import { VNode } from '../../core/src/VNodes/VNode';
+import { browser } from '@odoo/owl/dist/types/browser';
 
 export class Owl<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T> {
     readonly loadables: Loadables<Renderer> = {
@@ -17,6 +18,7 @@ export class Owl<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T> 
     env: OwlEnv = {
         qweb: new QWeb(),
         editor: this.editor,
+        browser: browser,
     };
 
     components = new Map<VNode, OwlComponent<{}>>();


### PR DESCRIPTION
Owl updated the Env interface by restricting the properties to be
more specific and introduced the "browser" property.

This commit explicitly bump the version number of Owl as well as
adding browser to our Owl plugin.