### PR TITLE
[FIX] Devtools: can display: “Beware the Jabberwock, my son!

### DIFF
--- a/packages/plugin-devtools/assets/DevTools.css
+++ b/packages/plugin-devtools/assets/DevTools.css
@@ -224,7 +224,7 @@ jw-devtools devtools-nodename.inline {
 devtools-tree devtools-nodename.block {
     color: #76526c;
     width: 100%;
-    display: inline-block;
+    display: block;
 }
 
 devtools-tree devtools-nodename.line-break:after {


### PR DESCRIPTION
In the devtools, the special char “ and the rest of the sentence are
displayed out of the box on the right.