### PR TITLE
[IMP] Inline: can nest every inlineNode into format tag.

### DIFF
--- a/packages/plugin-char/src/CharDomObjectRenderer.ts
+++ b/packages/plugin-char/src/CharDomObjectRenderer.ts
@@ -1,134 +1,41 @@
 import { CharNode } from './CharNode';
 import { InlineNode } from '../../plugin-inline/src/InlineNode';
-import { VNode } from '../../core/src/VNodes/VNode';
-import { Attributes } from '../../plugin-xml/src/Attributes';
 import {
     DomObjectRenderingEngine,
-    DomObject,
+    DomObjectText,
 } from '../../plugin-html/src/DomObjectRenderingEngine';
 import { InlineFormatDomObjectRenderer } from '../../plugin-inline/src/InlineFormatDomObjectRenderer';
-import { Format } from '../../plugin-inline/src/Format';
-import { Modifier } from '../../core/src/Modifier';
+import { Predicate } from '../../core/src/VNodes/VNode';
 
 export class CharDomObjectRenderer extends InlineFormatDomObjectRenderer {
     static id = DomObjectRenderingEngine.id;
     engine: DomObjectRenderingEngine;
-    predicate = CharNode;
+    predicate: Predicate = CharNode;
 
-    async render(node: CharNode): Promise<DomObject> {
-        // Consecutive char nodes are rendered in same time.
-        const charNodes: CharNode[] = [];
-        const charFormats: Modifier[][] = [];
-        const siblings = node.parent.children();
-        let sibling: VNode;
-        let index = siblings.indexOf(node);
-        while ((sibling = siblings[index]) && sibling instanceof CharNode) {
-            charNodes.unshift(sibling);
-            charFormats.unshift(
-                sibling.modifiers.filter(
-                    modifier =>
-                        modifier instanceof Format ||
-                        (modifier instanceof Attributes && !!modifier.length),
-                ),
-            );
-            index--;
-        }
-        index = siblings.indexOf(node) + 1;
-        while ((sibling = siblings[index]) && sibling instanceof CharNode) {
-            charNodes.push(sibling);
-            charFormats.push(
-                sibling.modifiers.filter(
-                    modifier =>
-                        modifier instanceof Format ||
-                        (modifier instanceof Attributes && !!modifier.length),
-                ),
-            );
-            index++;
-        }
-
-        const promise = this._renderFormattedCharNodes(charNodes, charFormats);
-        this.engine.rendered(charNodes, this, promise);
-        return promise;
-    }
-    private async _renderFormattedCharNodes(
-        charNodes: CharNode[],
-        charFormats: Modifier[][],
-    ): Promise<DomObject> {
-        let domObject: DomObject;
-        for (let charIndex = 0; charIndex < charNodes.length; charIndex++) {
-            let nextCharIndex = charIndex;
-            let nestObject: DomObject;
-            const format = charFormats[charIndex][0];
-            if (format) {
-                // Group same formating.
-                const newChars: CharNode[] = [charNodes[charIndex]];
-                const newCharFormats: Modifier[][] = [charFormats[charIndex].slice(1)];
-                while (
-                    nextCharIndex + 1 < charNodes.length &&
-                    format.isSameAs(charFormats[nextCharIndex + 1][0])
-                ) {
-                    nextCharIndex++;
-                    newChars.push(charNodes[nextCharIndex]);
-                    newCharFormats.push(charFormats[nextCharIndex].slice(1));
-                }
-
-                // Create formatObject.
-                const childObject = await this._renderFormattedCharNodes(newChars, newCharFormats);
-                if (format instanceof Format) {
-                    nestObject = await this.renderFormats(childObject, format);
-                } else {
-                    nestObject = {
-                        tag: 'SPAN',
-                        children: [childObject],
-                    };
-                    this.engine.renderAttributes(Attributes, charNodes[charIndex], nestObject);
-                }
+    async renderInline(charNodes: CharNode[]): Promise<DomObjectText[]> {
+        // Create textObject.
+        const texts = [];
+        for (const charNode of charNodes) {
+            // Same text node.
+            if (charNode.char === ' ' && texts[texts.length - 1] === ' ') {
+                // Browsers don't render consecutive space chars otherwise.
+                texts.push('\u00A0');
             } else {
-                // Create textObject.
-                const texts = [charNodes[charIndex].char];
-                while (
-                    nextCharIndex + 1 < charNodes.length &&
-                    !charFormats[nextCharIndex + 1].length
-                ) {
-                    nextCharIndex++;
-                    const charNode = charNodes[nextCharIndex];
-                    // Same text node.
-                    if (charNode.char === ' ' && texts[texts.length - 1] === ' ') {
-                        // Browsers don't render consecutive space chars otherwise.
-                        texts.push('\u00A0');
-                    } else {
-                        texts.push(charNode.char);
-                    }
-                }
-
-                // Render block edge spaces as non-breakable space (otherwise browsers
-                // won't render them).
-                const previous = charNodes[charIndex].previousSibling();
-                if (!previous || !previous.is(InlineNode)) {
-                    texts[0] = texts[0].replace(/^ /g, '\u00A0');
-                }
-                const next = charNodes[nextCharIndex].nextSibling();
-                if (!next || !next.is(InlineNode)) {
-                    texts[texts.length - 1] = texts[texts.length - 1].replace(/^ /g, '\u00A0');
-                }
-                nestObject = {
-                    text: texts.join(''),
-                };
-                this.engine.locate(charNodes.slice(charIndex, nextCharIndex + 1), nestObject);
+                texts.push(charNode.char);
             }
-
-            // Add to the list of domObject.
-            if (domObject) {
-                if ('tag' in domObject || 'text' in domObject || 'dom' in domObject) {
-                    domObject = { children: [domObject] };
-                }
-                domObject.children.push(nestObject);
-            } else {
-                domObject = nestObject;
-            }
-
-            charIndex = nextCharIndex;
         }
-        return domObject;
+        // Render block edge spaces as non-breakable space (otherwise browsers
+        // won't render them).
+        const previous = charNodes[0].previousSibling();
+        if (!previous || !previous.is(InlineNode)) {
+            texts[0] = texts[0].replace(/^ /g, '\u00A0');
+        }
+        const next = charNodes[charNodes.length - 1].nextSibling();
+        if (!next || !next.is(InlineNode)) {
+            texts[texts.length - 1] = texts[texts.length - 1].replace(/^ /g, '\u00A0');
+        }
+        const domObject = { text: texts.join('') };
+        this.engine.locate(charNodes, domObject);
+        return [domObject];
     }
 }

--- a/packages/plugin-char/test/CharDomObjectRenderer.test.ts
+++ b/packages/plugin-char/test/CharDomObjectRenderer.test.ts
@@ -7,8 +7,6 @@ import { ContainerNode } from '../../core/src/VNodes/ContainerNode';
 import { DomObject } from '../../plugin-html/src/DomObjectRenderingEngine';
 import { DomLayout } from '../../plugin-dom-layout/src/DomLayout';
 import { VNode } from '../../core/src/VNodes/VNode';
-import { testEditor } from '../../utils/src/testUtils';
-import { BasicEditor } from '../../../bundles/BasicEditor';
 
 describe('CharDomObjectRenderer', () => {
     describe('render', () => {
@@ -60,74 +58,6 @@ describe('CharDomObjectRenderer', () => {
                     VNode[]
                 >;
                 expect(rendered && locations.get(rendered)).to.deep.equal(root.children());
-            });
-        });
-        describe('format and attributes', () => {
-            it('should keep formats in order', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<b><i>g[]g</i></b>',
-                    contentAfter: '<b><i>g[]g</i></b>',
-                });
-            });
-            it('should keep formats and attributes in order', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<b><span a="b">g[]g</span></b>',
-                    contentAfter: '<b><span a="b">g[]g</span></b>',
-                });
-            });
-            it('should keep nested formats in order', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<b><i>g[g</i>o]o</b>',
-                    contentAfter: '<b><i>g[g</i>o]o</b>',
-                });
-            });
-            it('should keep nested formats and attributes in order', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<b><span a="b">g[g</span>o]o</b>',
-                    contentAfter: '<b><span a="b">g[g</span>o]o</b>',
-                });
-            });
-            it('should nest identical formats', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<b><i>g[g</i></b><b><i>o]o</i></b>',
-                    contentAfter: '<b><i>g[go]o</i></b>',
-                });
-            });
-            it('should nest identical formats and attributes', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<b><span a="b">g[g</span></b><b><span a="b">o]o</span></b>',
-                    contentAfter: '<b><span a="b">g[go]o</span></b>',
-                });
-            });
-            it('should nest ordered formats', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<b><i>g[g</i></b><b>o]o</b>',
-                    contentAfter: '<b><i>g[g</i>o]o</b>',
-                });
-            });
-            it('should nest ordered formats and attributes', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<b><span a="b">g[g</span></b><b>o]o</b>',
-                    contentAfter: '<b><span a="b">g[g</span>o]o</b>',
-                });
-            });
-            it('should not nest unordered formats', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<b><i>g[g</i></b><i><b>o]o</b></i>',
-                    contentAfter: '<b><i>g[g</i></b><i><b>o]o</b></i>',
-                });
-            });
-            it('should not nest formats with different attributes', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<b>g[g</b><b a="b">o]o</b>',
-                    contentAfter: '<b>g[g</b><b a="b">o]o</b>',
-                });
-            });
-            it('should not nest unordered formats and attributes', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<b><span a="b">g[g</span></b><span a="b"><b>o]o</b></span>',
-                    contentAfter: '<b><span a="b">g[g</span></b><span a="b"><b>o]o</b></span>',
-                });
             });
         });
     });

--- a/packages/plugin-devtools/test/devtools.test.ts
+++ b/packages/plugin-devtools/test/devtools.test.ts
@@ -899,7 +899,7 @@ describe('Plugin: DevTools', () => {
             const subpanel = wrapper.querySelector(
                 'jw-devtools devtools-panel.active mainpane-contents',
             );
-            expect(subpanel.textContent).to.equal('insertTextsetSelection');
+            expect(subpanel.textContent).to.equal('2insertText1setSelection');
         });
         it('should select "hide"', async () => {
             await openDevTools();

--- a/packages/plugin-image/src/ImageDomObjectRenderer.ts
+++ b/packages/plugin-image/src/ImageDomObjectRenderer.ts
@@ -1,4 +1,4 @@
-import { AbstractRenderer } from '../../plugin-renderer/src/AbstractRenderer';
+import { InlineFormatDomObjectRenderer } from '../../plugin-inline/src/InlineFormatDomObjectRenderer';
 import { ImageNode } from './ImageNode';
 import {
     DomObjectRenderingEngine,
@@ -6,16 +6,21 @@ import {
 } from '../../plugin-html/src/DomObjectRenderingEngine';
 import { Attributes } from '../../plugin-xml/src/Attributes';
 
-export class ImageDomObjectRenderer extends AbstractRenderer<DomObject> {
+export class ImageDomObjectRenderer extends InlineFormatDomObjectRenderer {
     static id = DomObjectRenderingEngine.id;
     engine: DomObjectRenderingEngine;
     predicate = ImageNode;
+    createSpanForAttributes = false;
 
-    async render(node: ImageNode): Promise<DomObject> {
-        const image: DomObject = {
-            tag: 'IMG',
-        };
-        this.engine.renderAttributes(Attributes, node, image);
-        return image;
+    async renderInline(nodes: ImageNode[]): Promise<DomObject[]> {
+        const rendering = nodes.map(node => {
+            const image: DomObject = {
+                tag: 'IMG',
+            };
+            this.engine.renderAttributes(Attributes, node, image);
+            this.engine.locate([node], image);
+            return image;
+        });
+        return Promise.all(rendering);
     }
 }

--- a/packages/plugin-inline/src/InlineFormatDomObjectRenderer.ts
+++ b/packages/plugin-inline/src/InlineFormatDomObjectRenderer.ts
@@ -4,17 +4,53 @@ import {
 } from '../../plugin-html/src/DomObjectRenderingEngine';
 import { AbstractRenderer } from '../../plugin-renderer/src/AbstractRenderer';
 import { InlineNode } from './InlineNode';
-import { Predicate, VNode } from '../../core/src/VNodes/VNode';
+import { VNode, Predicate } from '../../core/src/VNodes/VNode';
 import { Format } from './Format';
 import { Attributes } from '../../plugin-xml/src/Attributes';
+import { Modifier } from '../../core/src/Modifier';
+
+type InlineRenderingUnit = [InlineNode, Modifier[], InlineFormatDomObjectRenderer];
 
 export class InlineFormatDomObjectRenderer extends AbstractRenderer<DomObject> {
     static id = DomObjectRenderingEngine.id;
-    predicate: Predicate<boolean | VNode> = InlineNode;
+    engine: DomObjectRenderingEngine;
+    predicate: Predicate = InlineNode;
+    // TODO: this is specific to CharNode and should only be handled for them.
+    createSpanForAttributes = true;
 
+    /**
+     * Render formatted inline nodes. Don't override this method if you want to
+     * have nested modifiers rendering. Override 'renderInline' method instead.
+     * @see renderInline
+     *
+     * @param node
+     */
     async render(node: InlineNode): Promise<DomObject> {
-        const inline = await this.super.render(node);
-        return this.renderFormats(inline, ...node.modifiers.filter(Format));
+        const renderingUnits = this._getRenderingUnits(node);
+        const rendering = this._renderFormattedInlineNodes(renderingUnits);
+
+        // Group the rendered nodes by renderer to call `renderered`.
+        const rendererGroup = new Map<InlineFormatDomObjectRenderer, VNode[]>();
+        for (const [inlineNode, , renderer] of renderingUnits) {
+            if (!rendererGroup.get(renderer)) {
+                rendererGroup.set(renderer, []);
+            }
+            rendererGroup.get(renderer).push(inlineNode);
+        }
+        for (const [render, nodes] of rendererGroup) {
+            this.engine.rendered(nodes, render, rendering);
+        }
+
+        return rendering;
+    }
+    /**
+     * Recive the list of node to render nested into the formting tag.
+     * Don't forget to locate the node.
+     *
+     * @param nodes
+     */
+    async renderInline(nodes: InlineNode[]): Promise<DomObject[]> {
+        return Promise.all(nodes.map(node => this.super.render(node)));
     }
     /**
      * Render an inline node's formats and return them in a fragment.
@@ -43,5 +79,138 @@ export class InlineFormatDomObjectRenderer extends AbstractRenderer<DomObject> {
             children = [domObject];
         }
         return domObject;
+    }
+    private _getRenderingUnits(inlineNode: InlineNode): InlineRenderingUnit[] {
+        // Consecutive char nodes are rendered in same time.
+        const renderingUnits: InlineRenderingUnit[] = [];
+        const siblings = inlineNode.parent.children();
+        let sibling: VNode;
+        let renderer: InlineFormatDomObjectRenderer;
+        let index = siblings.indexOf(inlineNode);
+        while (
+            (sibling = siblings[index]) &&
+            sibling instanceof InlineNode &&
+            (renderer = this._getCompatibleRenderer(sibling))
+        ) {
+            renderingUnits.unshift([
+                sibling,
+                sibling.modifiers.filter(
+                    modifier =>
+                        modifier instanceof Format ||
+                        (modifier instanceof Attributes && !!modifier.length),
+                ),
+                renderer,
+            ]);
+            index--;
+        }
+        index = siblings.indexOf(inlineNode) + 1;
+        while (
+            (sibling = siblings[index]) &&
+            sibling instanceof InlineNode &&
+            (renderer = this._getCompatibleRenderer(sibling))
+        ) {
+            renderingUnits.push([
+                sibling,
+                sibling.modifiers.filter(
+                    modifier =>
+                        modifier instanceof Format ||
+                        (modifier instanceof Attributes && !!modifier.length),
+                ),
+                renderer,
+            ]);
+            index++;
+        }
+
+        return renderingUnits;
+    }
+    private async _renderFormattedInlineNodes(
+        renderingUnits: InlineRenderingUnit[],
+    ): Promise<DomObject> {
+        let domObject: DomObject;
+        for (let inlineIndex = 0; inlineIndex < renderingUnits.length; inlineIndex++) {
+            let nextCharIndex = inlineIndex;
+            let nestObjects: DomObject[];
+            const unit = renderingUnits[inlineIndex];
+            if (this._hasDisplayedFormat(unit)) {
+                // Group same formating.
+                const format = unit[1][0];
+                const newRenderingUnits: InlineRenderingUnit[] = [
+                    [unit[0], unit[1].slice(1), unit[2]],
+                ];
+                while (
+                    nextCharIndex + 1 < renderingUnits.length &&
+                    format.isSameAs(renderingUnits[nextCharIndex + 1][1][0])
+                ) {
+                    nextCharIndex++;
+                    const inline = renderingUnits[nextCharIndex];
+                    newRenderingUnits.push([inline[0], inline[1].slice(1), inline[2]]);
+                }
+
+                // Create formatObject.
+                const childObject = await this._renderFormattedInlineNodes(newRenderingUnits);
+                if (format instanceof Format) {
+                    nestObjects = [await this.renderFormats(childObject, format)];
+                } else {
+                    nestObjects = [
+                        {
+                            tag: 'SPAN',
+                            children: [childObject],
+                        },
+                    ];
+                    this.engine.renderAttributes(Attributes, unit[0], nestObjects[0]);
+                }
+            } else {
+                // Call each inline node's `renderInline` method.
+                nestObjects = [];
+                let inlineNodes: InlineNode[] = [];
+                let currentRenderer: InlineFormatDomObjectRenderer;
+                nextCharIndex -= 1; // to render also the current inlineNode
+                while (
+                    nextCharIndex + 1 < renderingUnits.length &&
+                    !this._hasDisplayedFormat(renderingUnits[nextCharIndex + 1])
+                ) {
+                    nextCharIndex++;
+                    const [inlineNode, , renderer] = renderingUnits[nextCharIndex];
+                    if (currentRenderer && currentRenderer !== renderer) {
+                        nestObjects.push(...(await currentRenderer.renderInline(inlineNodes)));
+                        inlineNodes = [];
+                    }
+                    inlineNodes.push(inlineNode);
+                    currentRenderer = renderer;
+                }
+                if (currentRenderer) {
+                    nestObjects.push(...(await currentRenderer.renderInline(inlineNodes)));
+                }
+            }
+
+            // Add to the list of domObject.
+            if (domObject) {
+                if ('tag' in domObject || 'text' in domObject || 'dom' in domObject) {
+                    domObject = { children: [domObject] };
+                }
+                domObject.children.push(...nestObjects);
+            } else if (nestObjects.length === 1) {
+                domObject = nestObjects[0];
+            } else {
+                domObject = { children: nestObjects };
+            }
+
+            inlineIndex = nextCharIndex;
+        }
+        return domObject;
+    }
+    private _getCompatibleRenderer(inlineNode: InlineNode): InlineFormatDomObjectRenderer {
+        const renderer = this.engine.renderers.find(renderer =>
+            inlineNode.test(renderer.predicate),
+        );
+        return renderer instanceof InlineFormatDomObjectRenderer && renderer;
+    }
+    // TODO: remove this function when `createSpanForAttributes` is removed.
+    private _hasDisplayedFormat(unit: InlineRenderingUnit): boolean {
+        return (
+            unit[1].length > 1 ||
+            (unit[1].length === 1 &&
+                (!(unit[1][0] instanceof Attributes) || unit[2].createSpanForAttributes))
+        );
     }
 }

--- a/packages/plugin-inline/test/Inline.test.ts
+++ b/packages/plugin-inline/test/Inline.test.ts
@@ -79,4 +79,84 @@ describePlugin(Inline, testEditor => {
             });
         });
     });
+    describe('format and attributes', () => {
+        it('should keep formats in order', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<b><i>g[]ga</i></b>',
+                contentAfter: '<b><i>g[]ga</i></b>',
+            });
+        });
+        it('should keep formats in order with inline node who use the inline renderer like image', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<b><i>g[]g<img src="#"></i></b>',
+                contentAfter: '<b><i>g[]g<img src="#"></i></b>',
+            });
+        });
+        it('should keep formats in order with inlines nodes who use the inline renderer like image', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<b><i>g[]g<img src="#1"><img src="#2"></i></b>',
+                contentAfter: '<b><i>g[]g<img src="#1"><img src="#2"></i></b>',
+            });
+        });
+        it('should keep formats and attributes in order', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<b><span a="b">g[]g</span></b>',
+                contentAfter: '<b><span a="b">g[]g</span></b>',
+            });
+        });
+        it('should keep nested formats in order', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<b><i>g[g</i>o]o</b>',
+                contentAfter: '<b><i>g[g</i>o]o</b>',
+            });
+        });
+        it('should keep nested formats and attributes in order', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<b><span a="b">g[g</span>o]o</b>',
+                contentAfter: '<b><span a="b">g[g</span>o]o</b>',
+            });
+        });
+        it('should nest identical formats', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<b><i>g[g</i></b><b><i>o]o</i></b>',
+                contentAfter: '<b><i>g[go]o</i></b>',
+            });
+        });
+        it('should nest identical formats and attributes', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<b><span a="b">g[g</span></b><b><span a="b">o]o</span></b>',
+                contentAfter: '<b><span a="b">g[go]o</span></b>',
+            });
+        });
+        it('should nest ordered formats', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<b><i>g[g</i></b><b>o]o</b>',
+                contentAfter: '<b><i>g[g</i>o]o</b>',
+            });
+        });
+        it('should nest ordered formats and attributes', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<b><span a="b">g[g</span></b><b>o]o</b>',
+                contentAfter: '<b><span a="b">g[g</span>o]o</b>',
+            });
+        });
+        it('should not nest unordered formats', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<b><i>g[g</i></b><i><b>o]o</b></i>',
+                contentAfter: '<b><i>g[g</i></b><i><b>o]o</b></i>',
+            });
+        });
+        it('should not nest formats with different attributes', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<b>g[g</b><b a="b">o]o</b>',
+                contentAfter: '<b>g[g</b><b a="b">o]o</b>',
+            });
+        });
+        it('should not nest unordered formats and attributes', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<b><span a="b">g[g</span></b><span a="b"><b>o]o</b></span>',
+                contentAfter: '<b><span a="b">g[g</span></b><span a="b"><b>o]o</b></span>',
+            });
+        });
+    });
 });


### PR DESCRIPTION
To use nesting, you just have to inherit from the InlineDomObjectRenderer
class and override the renderNodes method without taking into account the
format. An option is added to create or not span for the attributes.