### PR TITLE
[FIX] Tests: make them faster

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 
 module.exports = function(config) {
     const coverageReporters = [];
@@ -81,7 +82,7 @@ module.exports = function(config) {
         frameworks: ['mocha', 'chai', 'sinon'],
 
         // list of files / patterns to load in the browser
-        files: config.includeFiles ? config.includeFiles.split(',') : ['packages/**/test/**/*.ts'],
+        files: ['test_index.ts'],
 
         // list of files / patterns to exclude
         exclude: [],
@@ -89,7 +90,7 @@ module.exports = function(config) {
         // preprocess matching files before serving them to the browser
         // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
         preprocessors: {
-            'packages/**/test/**/*.ts': ['webpack'],
+            'test_index.ts': ['webpack'],
         },
 
         // test results reporter to use

--- a/test_index.ts
+++ b/test_index.ts
@@ -1,0 +1,3 @@
+// load all specs into one bundle
+const testsContext = (require as any).context('./packages/', true, /.test.ts$/i);
+testsContext.keys().forEach(testsContext);


### PR DESCRIPTION
Before this commit, all individual test files were containing all the
source and sourcemap. Which created performance issues.
N test files where N big bundles.
Now all test files are all container within 1 big bundle.