### PR TITLE
[FIX] Image: click handler in mutex

### DIFF
--- a/packages/plugin-image/src/ImageDomObjectRenderer.ts
+++ b/packages/plugin-image/src/ImageDomObjectRenderer.ts
@@ -14,7 +14,7 @@ export class ImageDomObjectRenderer extends NodeRenderer<DomObject> {
     async render(node: ImageNode): Promise<DomObject> {
         const select = (): void => {
             this.engine.editor.nextEventMutex(() => {
-                this.engine.editor.execCustomCommand(async () => {
+                return this.engine.editor.execCustomCommand(async () => {
                     this.engine.editor.selection.select(node, node);
                 });
             });


### PR DESCRIPTION
Without that fix, if we try to click on an image when the editor is
redrawing, it will generate a "double redraw".