### PR TITLE
[FIX] DomEditable: check TouchEvent

### DIFF
--- a/packages/plugin-dom-editable/src/EventNormalizer.ts
+++ b/packages/plugin-dom-editable/src/EventNormalizer.ts
@@ -559,7 +559,10 @@ export class EventNormalizer {
                     this._shadowNormalizers.set(shadowRoot, eventNormalizer);
                 }
             } else {
-                if (eventTarget && (ev instanceof MouseEvent || ev instanceof TouchEvent)) {
+                if (
+                    eventTarget &&
+                    (ev instanceof MouseEvent || (window.TouchEvent && ev instanceof TouchEvent))
+                ) {
                     eventTarget = this._getEventTarget(ev);
                 } else {
                     eventTarget = eventTarget?.ownerDocument.getSelection().focusNode;


### PR DESCRIPTION
In firefox, it is required to perfor this check because the TouchEvent
might not be present.