### PR TITLE
[FIX] Mode: allow cascading and non-cascading rule properties

### DIFF
--- a/examples/modes/modes.ts
+++ b/examples/modes/modes.ts
@@ -30,15 +30,30 @@ const modeDefinitions: ModeDefinition[] = [
         rules: [
             {
                 selector: [DividerNode],
-                editable: false,
+                properties: {
+                    editable: {
+                        value: false,
+                        cascading: true,
+                    },
+                },
             },
             {
                 selector: [DividerNode, PreNode],
-                editable: false,
+                properties: {
+                    editable: {
+                        value: false,
+                        cascading: true,
+                    },
+                },
             },
             {
                 selector: [PreNode],
-                editable: true,
+                properties: {
+                    editable: {
+                        value: true,
+                        cascading: true,
+                    },
+                },
             },
         ],
     },

--- a/packages/core/src/Core.ts
+++ b/packages/core/src/Core.ts
@@ -36,7 +36,6 @@ export class Core<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
             handler: this.deleteForward,
         },
     };
-    mode = this.editor.mode;
 
     //--------------------------------------------------------------------------
     // Public
@@ -51,7 +50,7 @@ export class Core<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
         if (!range.isCollapsed()) {
             range.empty();
         }
-        if (this.mode.is(range.startContainer, RuleProperty.BREAKABLE)) {
+        if (range.mode.is(range.startContainer, RuleProperty.BREAKABLE)) {
             range.startContainer.splitAt(range.start);
         } else {
             // Use a separator to break paragraphs in an unbreakable.
@@ -79,26 +78,26 @@ export class Core<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
         if (range.isCollapsed()) {
             // Basic case: remove the node directly preceding the range.
             const previousSibling = range.start.previousSibling();
-            if (previousSibling && this.mode.is(previousSibling, RuleProperty.EDITABLE)) {
+            if (previousSibling && range.mode.is(previousSibling, RuleProperty.EDITABLE)) {
                 previousSibling.removeBackward();
             } else if (
-                this.mode.is(range.startContainer, RuleProperty.BREAKABLE) &&
-                this.mode.is(range.startContainer, RuleProperty.EDITABLE)
+                range.mode.is(range.startContainer, RuleProperty.BREAKABLE) &&
+                range.mode.is(range.startContainer, RuleProperty.EDITABLE)
             ) {
                 // Otherwise set range start at previous valid leaf.
                 let ancestor = range.start.parent;
                 while (
                     ancestor &&
-                    this.mode.is(ancestor, RuleProperty.BREAKABLE) &&
-                    this.mode.is(ancestor, RuleProperty.EDITABLE) &&
+                    range.mode.is(ancestor, RuleProperty.BREAKABLE) &&
+                    range.mode.is(ancestor, RuleProperty.EDITABLE) &&
                     !ancestor.previousSibling()
                 ) {
                     ancestor = ancestor.parent;
                 }
                 if (
                     ancestor &&
-                    this.mode.is(ancestor, RuleProperty.BREAKABLE) &&
-                    this.mode.is(ancestor, RuleProperty.EDITABLE)
+                    range.mode.is(ancestor, RuleProperty.BREAKABLE) &&
+                    range.mode.is(ancestor, RuleProperty.EDITABLE)
                 ) {
                     const previous = ancestor.previousSibling().lastLeaf();
                     if (previous) {
@@ -119,26 +118,26 @@ export class Core<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
         if (range.isCollapsed()) {
             // Basic case: remove the node directly following the range.
             const nextSibling = range.end.nextSibling();
-            if (nextSibling && this.mode.is(nextSibling, RuleProperty.EDITABLE)) {
+            if (nextSibling && range.mode.is(nextSibling, RuleProperty.EDITABLE)) {
                 nextSibling.removeForward();
             } else if (
-                this.mode.is(range.endContainer, RuleProperty.BREAKABLE) &&
-                this.mode.is(range.endContainer, RuleProperty.EDITABLE)
+                range.mode.is(range.endContainer, RuleProperty.BREAKABLE) &&
+                range.mode.is(range.endContainer, RuleProperty.EDITABLE)
             ) {
                 // Otherwise set range end at next valid leaf.
                 let ancestor = range.end.parent;
                 while (
                     ancestor &&
-                    this.mode.is(ancestor, RuleProperty.BREAKABLE) &&
-                    this.mode.is(ancestor, RuleProperty.EDITABLE) &&
+                    range.mode.is(ancestor, RuleProperty.BREAKABLE) &&
+                    range.mode.is(ancestor, RuleProperty.EDITABLE) &&
                     !ancestor.nextSibling()
                 ) {
                     ancestor = ancestor.parent;
                 }
                 if (
                     ancestor &&
-                    this.mode.is(ancestor, RuleProperty.BREAKABLE) &&
-                    this.mode.is(ancestor, RuleProperty.EDITABLE)
+                    range.mode.is(ancestor, RuleProperty.BREAKABLE) &&
+                    range.mode.is(ancestor, RuleProperty.EDITABLE)
                 ) {
                     const next = ancestor.nextSibling().firstLeaf();
                     if (next) {

--- a/packages/core/src/JWEditor.ts
+++ b/packages/core/src/JWEditor.ts
@@ -75,13 +75,13 @@ export class JWEditor {
     // each command batch is waited for.
     preventRenders: Set<Function> = new Set();
     enableRender = true;
-    private _modes: Record<ModeIdentifier, Mode> = {
+    modes: Record<ModeIdentifier, Mode> = {
         default: new Mode({
             id: 'default',
             rules: [],
         }),
     };
-    mode: Mode = this._modes.default;
+    mode: Mode = this.modes.default;
 
     constructor() {
         this.dispatcher = new Dispatcher(this);
@@ -100,7 +100,7 @@ export class JWEditor {
      * Set the current mode of the editor.
      */
     setMode(modeIdentifier: ModeIdentifier): void {
-        this.mode = this._modes[modeIdentifier];
+        this.mode = this.modes[modeIdentifier];
     }
 
     async nextEventMutex(next: (...args) => void): Promise<void> {
@@ -124,7 +124,7 @@ export class JWEditor {
         }
 
         for (const mode of this.configuration.modes || []) {
-            this._modes[mode.id] = new Mode(mode);
+            this.modes[mode.id] = new Mode(mode);
         }
         if (this.configuration.mode) {
             this.setMode(this.configuration.mode);

--- a/packages/core/src/Mode.ts
+++ b/packages/core/src/Mode.ts
@@ -27,15 +27,15 @@ type RuleEntries = Partial<Record<RuleProperty, ContextualEntry<PropertyDefiniti
 
 export class Mode {
     id: ModeIdentifier;
-    private readonly _rules: ModeRule[];
+    readonly rules: ModeRule[];
     private readonly _entries: RuleEntries;
     constructor(mode: ModeDefinition) {
         this.id = mode.id;
-        this._rules = mode.rules;
+        this.rules = mode.rules;
 
         // Convert the rules into an object describing them for each property.
         const ruleEntries: RuleEntries = {};
-        this._entries = this._rules.reduce((accumulator, rule) => {
+        this._entries = this.rules.reduce((accumulator, rule) => {
             for (const property of Object.keys(rule.properties) as RuleProperty[]) {
                 const entry: ContextualEntry<PropertyDefinition> = {
                     selector: rule.selector,

--- a/packages/core/test/Mode.test.ts
+++ b/packages/core/test/Mode.test.ts
@@ -18,11 +18,21 @@ describe('core', () => {
                             rules: [
                                 {
                                     selector: [ContainerNode],
-                                    editable: false,
+                                    properties: {
+                                        editable: {
+                                            value: false,
+                                            cascading: true,
+                                        },
+                                    },
                                 },
                                 {
                                     selector: [ContainerNode, ContainerNode],
-                                    editable: true,
+                                    properties: {
+                                        editable: {
+                                            value: true,
+                                            cascading: true,
+                                        },
+                                    },
                                 },
                             ],
                         },
@@ -43,7 +53,17 @@ describe('core', () => {
                 const root = new ContainerNode();
                 const mode = new Mode({
                     id: 'special',
-                    rules: [{ selector: [], editable: false }],
+                    rules: [
+                        {
+                            selector: [],
+                            properties: {
+                                editable: {
+                                    value: false,
+                                    cascading: true,
+                                },
+                            },
+                        },
+                    ],
                 });
                 // With default mode.
                 await withRange(editor, VRange.at(root), async range => {
@@ -76,7 +96,12 @@ describe('core', () => {
                 rules: [
                     {
                         selector: [ContainerNode],
-                        editable: false,
+                        properties: {
+                            editable: {
+                                value: false,
+                                cascading: true,
+                            },
+                        },
                     },
                 ],
             };

--- a/packages/plugin-devtools/assets/DevTools.css
+++ b/packages/plugin-devtools/assets/DevTools.css
@@ -1,6 +1,8 @@
 /* GLOBAL */
 
 jw-devtools {
+    position: sticky;
+    position: -webkit-sticky;
     bottom: 0;
     min-height: 30px;
     max-height: 100%;

--- a/packages/plugin-devtools/assets/DevTools.css
+++ b/packages/plugin-devtools/assets/DevTools.css
@@ -19,6 +19,7 @@ jw-devtools {
 
 devtools-table {
     display: table;
+    width: 100%
 }
 devtools-tbody {
     display: table-row-group;
@@ -181,10 +182,6 @@ mainpane-contents {
     overflow: auto;
     flex: 1;
     padding: 1em;
-}
-
-mainpane-contents > devtools-table devtools-td:nth-child(1)  {
-    width: 100px;
 }
 
 devtools-command {

--- a/packages/plugin-devtools/assets/DevTools.xml
+++ b/packages/plugin-devtools/assets/DevTools.xml
@@ -397,8 +397,7 @@
 
     <!-- PLUGINS -->
     <devtools-panel t-name="PluginsComponent"
-        t-att-class="{active: props.isOpen}" tabindex="1"
-        t-on-keydown="onKeydown">
+        t-att-class="{active: props.isOpen}" tabindex="1">
         <devtools-contents t-if="props.isOpen">
             <devtools-mainpane style="overflow: hidden">
                 <mainpane-contents style="overflow: auto">
@@ -409,6 +408,63 @@
                     </devtools-table>
                 </mainpane-contents>
             </devtools-mainpane>
+        </devtools-contents>
+    </devtools-panel>
+
+    <!-- MODES -->
+    <devtools-panel t-name="ModesComponent"
+        t-att-class="{active: props.isOpen}" tabindex="1"
+        t-on-keydown="onKeydown">
+        <devtools-contents t-if="props.isOpen">
+            <devtools-mainpane style="overflow: hidden">
+                <mainpane-contents style="overflow: auto">
+                    <devtools-table>
+                        <devtools-tr t-foreach="Object.values(modes)"
+                            t-as="mode" t-key="mode.id"
+                            class="selectable-line"
+                            t-att-class="{
+                                selected: state.selectedMode and state.selectedMode.id == mode.id,
+                            }"
+                            t-on-click="selectMode(mode.id)"
+                            t-on-dblclick="setMode(mode.id)">
+                            <devtools-td><t t-if="mode.id == state.currentMode.id">✅</t> <t t-esc="mode.id"/></devtools-td>
+                        </devtools-tr>
+                    </devtools-table>
+                </mainpane-contents>
+            </devtools-mainpane>
+            <devtools-sidepane>
+                <devtools-info>
+                    <devtools-about t-if="state.selectedMode">
+                        <devtools-type>Mode</devtools-type> <t t-esc="state.selectedMode.id"/>
+                    </devtools-about>
+                    <devtools-properties t-if="state.selectedMode">
+                        <devtools-infotitle>📖 Rules</devtools-infotitle>
+                        <t t-if="state.selectedMode">
+                            <devtools-table>
+                                <devtools-tbody>
+                                    <devtools-tr
+                                    t-foreach="state.selectedMode.rules"
+                                    t-as="rule" t-key="rule.id"
+                                    class="selectable-line">
+                                        <devtools-td>
+                                            <devtools-list>
+                                                <devtools-listitem>Selector: <devtools-button t-on-click="logSelector(rule.selector)">&gt;_</devtools-button></devtools-listitem>
+                                                <devtools-listitem t-foreach="Object.keys(rule.properties)"
+                                                t-as="property"
+                                                t-key="property_id">
+                                                    <t t-esc="property"/>: <t t-esc="rule.properties[property].value"/>
+                                                    <t t-if="rule.properties[property].cascading"> (cascading)</t>
+                                                    <t t-else=""> (targeted)</t>
+                                                </devtools-listitem>
+                                            </devtools-list>
+                                        </devtools-td>
+                                    </devtools-tr>
+                                </devtools-tbody>
+                            </devtools-table>
+                        </t>
+                    </devtools-properties>
+                </devtools-info>
+            </devtools-sidepane>
         </devtools-contents>
     </devtools-panel>
 
@@ -435,6 +491,9 @@
             <devtools-button t-on-click="openTab('plugins')" t-att-class="{
                 selected: state.currentTab == 'plugins',
             }">Plugins</devtools-button>
+            <devtools-button t-on-click="openTab('modes')" t-att-class="{
+                selected: state.currentTab == 'modes',
+            }">Modes</devtools-button>
             <devtools-button t-on-click="inspectDom()">&#128269;</devtools-button>
         </devtools-navbar>
         <t t-if="!state.closed">
@@ -443,6 +502,7 @@
                 commands="state.commands"/>
             <ShortcutsComponent isOpen="state.currentTab == 'shortcuts'"/>
             <PluginsComponent isOpen="state.currentTab == 'plugins'"/>
+            <ModesComponent isOpen="state.currentTab == 'modes'"/>
         </t>
     </jw-devtools>
 

--- a/packages/plugin-devtools/src/components/DevToolsComponent.ts
+++ b/packages/plugin-devtools/src/components/DevToolsComponent.ts
@@ -2,6 +2,7 @@ import { CommandsComponent } from './CommandsComponent';
 import { InspectorComponent } from './InspectorComponent';
 import { ShortcutsComponent } from './ShortcutsComponent';
 import { PluginsComponent } from './PluginsComponent';
+import { ModesComponent } from './ModesComponent';
 import { OwlComponent } from '../../../plugin-owl/src/OwlComponent';
 import { CommandIdentifier, CommandParams } from '../../../core/src/Dispatcher';
 import { nodeName } from '../../../utils/src/utils';
@@ -22,6 +23,7 @@ export class DevToolsComponent<T = {}> extends OwlComponent<T> {
         InspectorComponent,
         ShortcutsComponent,
         PluginsComponent,
+        ModesComponent,
     };
     static template = 'devtools';
     inspectorRef = hooks.useRef('inspector');

--- a/packages/plugin-devtools/src/components/ModesComponent.ts
+++ b/packages/plugin-devtools/src/components/ModesComponent.ts
@@ -1,0 +1,62 @@
+import { OwlComponent } from '../../../plugin-owl/src/OwlComponent';
+import { Predicate } from '../../../core/src/VNodes/VNode';
+
+export class ModesComponent extends OwlComponent<{}> {
+    modes = this.env.editor.modes;
+    localStorage = ['currentTab'];
+    state = {
+        selectedMode: null,
+        currentMode: this.env.editor.mode,
+    };
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    /**
+     * Select the mode at given index.
+     *
+     * @param index
+     */
+    selectModeByIndex(index: number): void {
+        this.state.selectedMode = this.modes[Object.keys(this.modes)[index]];
+    }
+    /**
+     * Select the mode with given identifier.
+     *
+     * @param modeIdentifier
+     */
+    selectMode(modeIdentifier: string): void {
+        this.state.selectedMode = this.modes[modeIdentifier];
+    }
+    /**
+     * Handle keydown event to navigate in the modes list.
+     */
+    onKeydown(event: KeyboardEvent): void {
+        const modeIdentifiers = Object.keys(this.modes);
+        const currentModeIndex = modeIdentifiers.findIndex(
+            key => key === this.state.selectedMode.id,
+        );
+        if (event.code === 'ArrowDown') {
+            this.selectModeByIndex(Math.min(currentModeIndex + 1, modeIdentifiers.length - 1));
+        } else if (event.code === 'ArrowUp') {
+            this.selectModeByIndex(Math.max(currentModeIndex - 1, 0));
+        } else {
+            return;
+        }
+        event.preventDefault();
+        event.stopImmediatePropagation();
+    }
+    setMode(modeIdentifier: string): void {
+        this.env.editor.setMode(modeIdentifier);
+        this.state.currentMode = this.env.editor.mode;
+    }
+    /**
+     * Log a selector to the console.
+     *
+     * @param selector
+     */
+    logSelector(selector: Predicate[]): void {
+        console.log(selector);
+    }
+}

--- a/packages/plugin-dom-editable/src/EventNormalizer.ts
+++ b/packages/plugin-dom-editable/src/EventNormalizer.ts
@@ -580,7 +580,7 @@ export class EventNormalizer {
                 } else {
                     eventTarget = eventTarget?.ownerDocument.getSelection().focusNode;
                 }
-                if (!eventTarget || this._isInEditable(eventTarget)) {
+                if (eventTarget && this._isInEditable(eventTarget)) {
                     listener.call(this, ev);
                 }
             }

--- a/packages/plugin-dom-editable/test/EventNormalizerKeyboard.test.ts
+++ b/packages/plugin-dom-editable/test/EventNormalizerKeyboard.test.ts
@@ -5399,8 +5399,7 @@ describe('utils', () => {
                     ];
                     expect(ctx.eventBatches).to.deep.equal(batchEvents);
                 });
-                // ? when does these strange case comes from?
-                it('strange case arrow without range', async () => {
+                it('arrow without range', async () => {
                     const p = document.createElement('p');
                     const text = document.createTextNode('hello');
                     ctx.editable.innerHTML = '';
@@ -5412,27 +5411,12 @@ describe('utils', () => {
                     triggerEvent(ctx.editable, 'keydown', { key: 'ArrowLeft', code: 'ArrowLeft' });
                     await nextTick();
                     await nextTick();
-
-                    const keyboardActions: NormalizedAction[] = [
-                        {
-                            type: 'setSelection',
-                            domSelection: {
-                                anchorNode: document.body,
-                                anchorOffset: 0,
-                                focusNode: document.body,
-                                focusOffset: 0,
-                                direction: Direction.FORWARD,
-                            },
-                        },
-                    ];
-
-                    const batchEvents: EventBatch[] = [
-                        {
-                            actions: keyboardActions,
-                            mutatedElements: new Set([]),
-                        },
-                    ];
-                    expect(ctx.eventBatches).to.deep.equal(batchEvents);
+                    // All ranges were removed so the selection returns
+                    // document.body at offset 0. This is not in an editable
+                    // zone so the normalizer rejects the event.
+                    // This can occur when using the arrow keys in devtools for
+                    // instance.
+                    expect(ctx.eventBatches).to.deep.equal([]);
                 });
                 it('shift + arrow (ubuntu chrome)', async () => {
                     const p = document.createElement('p');


### PR DESCRIPTION
Up to this commit every rule property was set based on a cascading selector, which means the properties were always propagated to all descendants of the node matched by the selector. This makes sense for `editable` but caused issues with `breakable` and made little sense for `allowEmpty`.
This reorganizes the rule definition by introducing the `cascading` boolean (default: false).

Linked Odoo PR: https://github.com/odoo-dev/odoo/pull/339