### PR TITLE
[IMP] Core: delete an empty container instead of merging into it

### DIFF
--- a/packages/core/src/Core.ts
+++ b/packages/core/src/Core.ts
@@ -100,9 +100,13 @@ export class Core<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
                     this.mode.is(ancestor, RuleProperty.BREAKABLE) &&
                     this.mode.is(ancestor, RuleProperty.EDITABLE)
                 ) {
-                    const previous = ancestor.previousSibling().lastLeaf();
-                    if (previous) {
-                        range.setStart(previous, RelativePosition.AFTER);
+                    const previous = ancestor.previousSibling();
+                    const previousLeaf = previous.lastLeaf();
+                    if (previous && !previous.hasChildren()) {
+                        // If the previous sibling is empty, remove it.
+                        previous.removeBackward();
+                    } else if (previousLeaf) {
+                        range.setStart(previousLeaf, RelativePosition.AFTER);
                         range.empty();
                     }
                 }
@@ -141,7 +145,12 @@ export class Core<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
                     this.mode.is(ancestor, RuleProperty.EDITABLE)
                 ) {
                     const next = ancestor.nextSibling().firstLeaf();
-                    if (next) {
+                    if (next && !range.endContainer.hasChildren()) {
+                        // If the current container is empty, remove it.
+                        range.endContainer.removeForward();
+                        range.setStart(next, RelativePosition.BEFORE);
+                        range.setEnd(next, RelativePosition.BEFORE);
+                    } else if (next) {
                         range.setEnd(next, RelativePosition.BEFORE);
                         range.empty();
                     }

--- a/packages/core/test/VDocument.test.ts
+++ b/packages/core/test/VDocument.test.ts
@@ -353,13 +353,20 @@ describe('VDocument', () => {
                         contentAfter: '<h1>ab[]</h1>',
                     });
                 });
+                it('should merge a heading1 with text into an empty paragraph (keeping the heading)', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p><br>[]</p><h1>ab</h1>',
+                        stepFunction: deleteForward,
+                        contentAfter: '<h1>[]ab</h1>',
+                    });
+                });
             });
             describe('With attributes', () => {
                 it('should merge a paragraph without class into an empty paragraph with a class', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p class="a"><br>[]</p><p>abc</p>',
                         stepFunction: deleteForward,
-                        contentAfter: '<p class="a">[]abc</p>',
+                        contentAfter: '<p>[]abc</p>',
                     });
                 });
                 it('should merge two paragraphs with spans of same classes', async () => {
@@ -948,6 +955,13 @@ describe('VDocument', () => {
                         contentAfter: '<h1>ab[]</h1>',
                     });
                 });
+                it('should merge a heading1 with text into an empty paragraph (keeping the heading)', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p><br></p><h1>[]ab</h1>',
+                        stepFunction: deleteBackward,
+                        contentAfter: '<h1>[]ab</h1>',
+                    });
+                });
                 it('should merge with previous node (default behaviour)', async () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<jw-block-a>a</jw-block-a><jw-block-b>[]b</jw-block-b>',
@@ -989,7 +1003,7 @@ describe('VDocument', () => {
                     await testEditor(BasicEditor, {
                         contentBefore: '<p class="a"><br></p><p>[]abc</p>',
                         stepFunction: deleteBackward,
-                        contentAfter: '<p class="a">[]abc</p>',
+                        contentAfter: '<p>[]abc</p>',
                     });
                 });
                 it('should merge two paragraphs with spans of same classes', async () => {

--- a/packages/plugin-list/test/List.test.ts
+++ b/packages/plugin-list/test/List.test.ts
@@ -4337,7 +4337,7 @@ describePlugin(List, testEditor => {
                                     '<ul class="checklist"><li class="unchecked"><br></li><li class="unchecked"><br></li><li class="checked">[]abc</li></ul>',
                                 stepFunction: deleteBackward,
                                 contentAfter:
-                                    '<ul class="checklist"><li class="unchecked"><br></li><li class="unchecked">[]abc</li></ul>',
+                                    '<ul class="checklist"><li class="unchecked"><br></li><li class="checked">[]abc</li></ul>',
                             });
                         });
                         it('should rejoin sibling lists', async () => {


### PR DESCRIPTION
If a heading is preceded by an empty paragraph and we press backspace at the beginning of said heading, we want to simply move the heading up, we don't want it to become a paragraph. This commit addresses that issue so the behavior of `deleteBackward` and `deleteForward` follows the GSpec.