### PR TITLE
[IMP] Remove styles from Toolbar

### DIFF
--- a/examples/demo-odoo-fields/demo-odoo-fields.ts
+++ b/examples/demo-odoo-fields/demo-odoo-fields.ts
@@ -10,6 +10,7 @@ import { Layout } from '../../packages/plugin-layout/src/Layout';
 import { VNode } from '../../packages/core/src/VNodes/VNode';
 import JWEditor from '../../packages/core/src/JWEditor';
 
+import '../../packages/plugin-toolbar/assets/Toolbar.css';
 import layout from './layout.xml';
 import '../utils/fontawesomeAssets';
 

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -12,6 +12,7 @@ import './demo.css';
 import { VNode } from '../../packages/core/src/VNodes/VNode';
 
 import '../utils/fontawesomeAssets';
+import '../../packages/plugin-toolbar/assets/Toolbar.css';
 
 const target = document.getElementById('contentToEdit');
 target.style.paddingTop = '40px';

--- a/examples/jabberwockipedia/jabberwockipedia.ts
+++ b/examples/jabberwockipedia/jabberwockipedia.ts
@@ -1,6 +1,7 @@
 import { BasicEditor } from '../../packages/bundle-basic-editor/BasicEditor';
 import { DevTools } from '../../packages/plugin-devtools/src/DevTools';
 
+import '../../packages/plugin-toolbar/assets/Toolbar.css';
 import '../utils/fontawesomeAssets';
 
 const target = document.getElementById('example');

--- a/examples/jabberwocky/jabberwocky.ts
+++ b/examples/jabberwocky/jabberwocky.ts
@@ -4,6 +4,7 @@ import { DevTools } from '../../packages/plugin-devtools/src/DevTools';
 import '../utils/jabberwocky.css';
 import { DomLayout } from '../../packages/plugin-dom-layout/src/DomLayout';
 
+import '../../packages/plugin-toolbar/assets/Toolbar.css';
 import '../utils/fontawesomeAssets';
 
 const target = document.getElementById('contentToEdit');

--- a/examples/layout/layout.ts
+++ b/examples/layout/layout.ts
@@ -19,6 +19,7 @@ import { Fullscreen } from '../../packages/plugin-fullscreen/src/Fullscreen';
 import { Theme } from '../../packages/plugin-theme/src/Theme';
 import { Toolbar, ToolbarConfig } from '../../packages/plugin-toolbar/src/Toolbar';
 
+import '../../packages/plugin-toolbar/assets/Toolbar.css';
 import '../utils/fontawesomeAssets';
 import { Template } from '../../packages/plugin-template/src/Template';
 import { ZoneNode } from '../../packages/plugin-layout/src/ZoneNode';

--- a/examples/modes/modes.ts
+++ b/examples/modes/modes.ts
@@ -5,6 +5,7 @@ import { DomLayout } from '../../packages/plugin-dom-layout/src/DomLayout';
 import { DomEditable } from '../../packages/plugin-dom-editable/src/DomEditable';
 import template from './modes.xml';
 import '../utils/editor.css';
+import '../../packages/plugin-toolbar/assets/Toolbar.css';
 import '../utils/fontawesomeAssets';
 import { DividerNode } from '../../packages/plugin-divider/src/DividerNode';
 import { PreNode } from '../../packages/plugin-pre/src/PreNode';

--- a/examples/odoo/odoo.ts
+++ b/examples/odoo/odoo.ts
@@ -7,6 +7,7 @@ import { Toolbar } from '../../packages/plugin-toolbar/src/Toolbar';
 import { DomLayout } from '../../packages/plugin-dom-layout/src/DomLayout';
 import { OdooVideo } from '../../packages/plugin-odoo-video/src/OdooVideo';
 
+import '../../packages/plugin-toolbar/assets/Toolbar.css';
 import '../utils/fontawesomeAssets';
 
 const target = document.getElementById('wrapper');

--- a/examples/resizable/resizable.ts
+++ b/examples/resizable/resizable.ts
@@ -4,6 +4,7 @@ import '../utils/jabberwocky.css';
 import { DomLayout } from '../../packages/plugin-dom-layout/src/DomLayout';
 import { Resizer } from '../../packages/plugin-resizer/src/Resizer';
 
+import '../../packages/plugin-toolbar/assets/Toolbar.css';
 import '../utils/fontawesomeAssets';
 
 const target = document.getElementById('contentToEdit');

--- a/packages/plugin-toolbar/src/Toolbar.ts
+++ b/packages/plugin-toolbar/src/Toolbar.ts
@@ -8,7 +8,6 @@ import { ActionableNode } from '../../plugin-layout/src/ActionableNode';
 import { DomLayout } from '../../plugin-dom-layout/src/DomLayout';
 import { Layout } from '../../plugin-layout/src/Layout';
 
-import '../assets/Toolbar.css';
 import { ToolbarNode } from './ToolbarNode';
 import { ActionableGroupNode } from '../../plugin-layout/src/ActionableGroupNode';
 import { SeparatorNode } from '../../core/src/VNodes/SeparatorNode';


### PR DESCRIPTION
If we need to style the toolbar completely, we must not include the
css in the toolbar itself.