### PR TITLE
[IMP] JWEditor: no launch of execCommand at the same time, use mutex

### DIFF
--- a/packages/core/src/ContextManager.ts
+++ b/packages/core/src/ContextManager.ts
@@ -1,9 +1,14 @@
-import JWEditor from './JWEditor';
+import JWEditor, { Commands, CommandParamsType } from './JWEditor';
 import { VRange } from './VRange';
 import { Predicate, VNode } from './VNodes/VNode';
+import { JWPlugin } from './JWPlugin';
 
 export interface Context {
     range?: VRange;
+    execCommand: <P extends JWPlugin, C extends Commands<P> = Commands<P>>(
+        commandName: C | (() => Promise<void> | void),
+        params?: CommandParamsType<P, C>,
+    ) => Promise<void>;
 }
 
 export interface CheckingContext extends Context {
@@ -48,10 +53,11 @@ export class ContextManager {
     editor: JWEditor;
     defaultContext: Context;
 
-    constructor(editor: JWEditor) {
+    constructor(editor: JWEditor, execCommand: Context['execCommand']) {
         this.editor = editor;
         this.defaultContext = {
             range: this.editor.selection.range,
+            execCommand: execCommand,
         };
     }
 

--- a/packages/core/src/JWPlugin.ts
+++ b/packages/core/src/JWPlugin.ts
@@ -1,4 +1,4 @@
-import JWEditor, { Loader, PluginMap, Loadables } from './JWEditor';
+import { JWEditor, Loader, PluginMap, Loadables } from './JWEditor';
 import { CommandIdentifier, CommandImplementation, CommandHook } from './Dispatcher';
 
 export type JWPluginConfig = {};

--- a/packages/core/test/ContextManager.test.ts
+++ b/packages/core/test/ContextManager.test.ts
@@ -47,6 +47,7 @@ describe('core', () => {
                         const [matchedCommand, computedContext] = result;
                         expect(matchedCommand).to.deep.equal(commands[1]);
                         expect(computedContext).to.deep.equal({
+                            ...editor.contextManager.defaultContext,
                             range: editor.selection.range,
                         });
                     },
@@ -75,12 +76,14 @@ describe('core', () => {
                         const result = editor.contextManager.match(commands);
                         expect(checkSpy.callCount).to.eql(1);
                         expect(checkSpy.args[0][0]).to.eql({
+                            ...editor.contextManager.defaultContext,
                             range: editor.selection.range,
                             selector: [editor.selection.range.start.ancestor(ListNode)],
                         });
                         const [matchedCommand, computedContext] = result;
                         expect(matchedCommand).to.deep.equal(commands[0]);
                         expect(computedContext).to.deep.equal({
+                            ...editor.contextManager.defaultContext,
                             range: editor.selection.range,
                         });
                     },
@@ -112,12 +115,14 @@ describe('core', () => {
                         expect(checkSpy1.callCount).to.eql(0);
                         expect(checkSpy2.callCount).to.eql(1);
                         expect(checkSpy2.args[0][0]).to.eql({
+                            ...editor.contextManager.defaultContext,
                             range: editor.selection.range,
                             selector: [],
                         });
                         const [matchedCommand, computedContext] = result;
                         expect(matchedCommand).to.deep.equal(commands[1]);
                         expect(computedContext).to.deep.equal({
+                            ...editor.contextManager.defaultContext,
                             range: editor.selection.range,
                         });
                     },
@@ -157,6 +162,7 @@ describe('core', () => {
                         const result = editor.contextManager.match(commands);
                         const closestList = editor.selection.range.start.closest(ListNode);
                         const checkingContext: CheckingContext = {
+                            ...editor.contextManager.defaultContext,
                             range: editor.selection.range,
                             selector: [closestList.ancestor(ListNode), closestList],
                         };
@@ -167,6 +173,7 @@ describe('core', () => {
                         const [matchedCommand, computedContext] = result;
                         expect(matchedCommand).to.deep.equal(commands[1]);
                         expect(computedContext).to.deep.equal({
+                            ...editor.contextManager.defaultContext,
                             range: editor.selection.range,
                         });
                     },
@@ -197,12 +204,14 @@ describe('core', () => {
                         const result = editor.contextManager.match(commands);
                         expect(checkSpy.callCount).to.eql(1);
                         expect(checkSpy.args[0][0]).to.eql({
+                            ...editor.contextManager.defaultContext,
                             range: editor.selection.range,
                             selector: [editor.selection.range.start.ancestor(ParagraphNode)],
                         });
                         const [matchedCommand, computedContext] = result;
                         expect(matchedCommand).to.deep.equal(commands[0]);
                         expect(computedContext).to.deep.equal({
+                            ...editor.contextManager.defaultContext,
                             range: editor.selection.range,
                         });
                     },
@@ -244,6 +253,7 @@ describe('core', () => {
                         const result = editor.contextManager.match(commands);
                         expect(checkSpy.callCount).to.eql(1);
                         expect(checkSpy.args[0][0]).to.eql({
+                            ...editor.contextManager.defaultContext,
                             range: editor.selection.range,
                             selector: [
                                 editor.selection.range.start.ancestor(isUl),
@@ -254,6 +264,7 @@ describe('core', () => {
                         const [matchedCommand, computedContext] = result;
                         expect(matchedCommand).to.deep.equal(commands[1]);
                         expect(computedContext).to.deep.equal({
+                            ...editor.contextManager.defaultContext,
                             range: editor.selection.range,
                         });
                     },
@@ -316,10 +327,12 @@ describe('core', () => {
                         ];
 
                         const result1 = editor.contextManager.match(commands, {
+                            ...editor.contextManager.defaultContext,
                             range: newSelection.range,
                         });
                         expect(checkSpy1.callCount).to.eql(1);
                         expect(checkSpy1.args[0][0]).to.eql({
+                            ...editor.contextManager.defaultContext,
                             range: newSelection.range,
                             selector: [newSelection.range.start.ancestor(ParagraphNode)],
                         });
@@ -327,23 +340,27 @@ describe('core', () => {
                         const [matchedCommand1, computedContext1] = result1;
                         expect(matchedCommand1).to.deep.equal(commands[0]);
                         expect(computedContext1).to.deep.equal({
+                            ...editor.contextManager.defaultContext,
                             range: newSelection.range,
                         });
 
                         // Which itself can still be overriden by the caller.
                         const context: Context = {
+                            ...editor.contextManager.defaultContext,
                             range: editor.selection.range,
                         };
                         const result2 = editor.contextManager.match(commands, context);
                         expect(checkSpy1.callCount).to.eql(1);
                         expect(checkSpy2.callCount).to.eql(1);
                         expect(checkSpy2.args[0][0]).to.eql({
+                            ...editor.contextManager.defaultContext,
                             range: editor.selection.range,
                             selector: [editor.selection.range.start.ancestor(ListNode)],
                         });
                         const [matchedCommand2, computedContext2] = result2;
                         expect(matchedCommand2).to.deep.equal(commands[1]);
                         expect(computedContext2).to.deep.equal({
+                            ...editor.contextManager.defaultContext,
                             range: editor.selection.range,
                         });
                     },

--- a/packages/core/test/Mode.test.ts
+++ b/packages/core/test/Mode.test.ts
@@ -66,13 +66,15 @@ describe('core', () => {
                     ],
                 });
                 // With default mode.
-                await editor.withRange(VRange.at(root), async range => {
+                await editor.execWithRange(VRange.at(root), async context => {
+                    const range = context.range;
                     expect(range.mode.is(range.startContainer, RuleProperty.EDITABLE)).to.be.true;
                 });
                 // With special mode
-                await editor.withRange(
+                await editor.execWithRange(
                     VRange.at(root),
-                    async range => {
+                    async context => {
+                        const range = context.range;
                         expect(range.mode.is(range.startContainer, RuleProperty.EDITABLE)).to.be
                             .false;
                     },

--- a/packages/core/test/VDocument.test.ts
+++ b/packages/core/test/VDocument.test.ts
@@ -566,12 +566,13 @@ describe('VDocument', () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>a[bc</p><p>de]f</p>',
                     stepFunction: (editor: JWEditor) => {
-                        const domEngine = editor.plugins.get(Layout).engines.dom;
+                        const pluginLayout = editor.plugins.get(Layout);
+                        const domEngine = pluginLayout.engines.dom;
                         const editable = domEngine.components.get('editable')[0];
-                        return editor.execCommand(() => {
+                        return editor.execCommand(context => {
                             editable.firstChild().breakable = false;
                             editable.lastChild().breakable = false;
-                            return deleteForward(editor);
+                            return context.execCommand('deleteBackward');
                         });
                     },
                     contentAfter: '<p>a[</p><p>]f</p>',
@@ -1550,14 +1551,7 @@ describe('VDocument', () => {
                     const domEngine = editor.plugins.get(Layout).engines.dom;
                     const editable = domEngine.components.get('editable')[0];
                     const aNode = editable.next(node => node.name === 'a');
-                    await editor.withRange(VRange.at(aNode), async range => {
-                        await editor.execCommand<Char>('insertText', {
-                            text: 'c',
-                            context: {
-                                range: range,
-                            },
-                        });
-                    });
+                    await editor.execWithRange<Char>(VRange.at(aNode), 'insertText', { text: 'c' });
                 },
                 contentAfter: 'cab[]',
             });
@@ -1569,13 +1563,8 @@ describe('VDocument', () => {
                     const domEngine = editor.plugins.get(Layout).engines.dom;
                     const editable = domEngine.components.get('editable')[0];
                     const aNode = editable.next(node => node.name === 'a');
-                    await editor.withRange(VRange.selecting(aNode, aNode), async range => {
-                        await editor.execCommand<Char>('insertText', {
-                            text: 'c',
-                            context: {
-                                range: range,
-                            },
-                        });
+                    await editor.execWithRange<Char>(VRange.selecting(aNode, aNode), 'insertText', {
+                        text: 'c',
                     });
                 },
                 contentAfter: 'cb[]',
@@ -1592,14 +1581,7 @@ describe('VDocument', () => {
                         [aNode, RelativePosition.BEFORE],
                         [aNode, RelativePosition.BEFORE],
                     ];
-                    await editor.withRange(rangeParams, async range => {
-                        await editor.execCommand<Char>('insertText', {
-                            text: 'c',
-                            context: {
-                                range: range,
-                            },
-                        });
-                    });
+                    await editor.execWithRange<Char>(rangeParams, 'insertText', { text: 'c' });
                 },
                 contentAfter: 'cab[]',
             });
@@ -1615,14 +1597,7 @@ describe('VDocument', () => {
                         [aNode, RelativePosition.BEFORE],
                         [aNode, RelativePosition.AFTER],
                     ];
-                    await editor.withRange(rangeParams, async range => {
-                        await editor.execCommand<Char>('insertText', {
-                            text: 'c',
-                            context: {
-                                range: range,
-                            },
-                        });
-                    });
+                    await editor.execWithRange<Char>(rangeParams, 'insertText', { text: 'c' });
                 },
                 contentAfter: 'cb[]',
             });
@@ -1638,14 +1613,7 @@ describe('VDocument', () => {
                         [aNode, RelativePosition.AFTER],
                         [aNode, RelativePosition.AFTER],
                     ];
-                    await editor.withRange(rangeParams, async range => {
-                        await editor.execCommand<Char>('insertText', {
-                            text: 'c',
-                            context: {
-                                range: range,
-                            },
-                        });
-                    });
+                    await editor.execWithRange<Char>(rangeParams, 'insertText', { text: 'c' });
                 },
                 contentAfter: 'acb[]',
             });
@@ -1662,14 +1630,7 @@ describe('VDocument', () => {
                         [aNode, RelativePosition.AFTER],
                         [bNode, RelativePosition.BEFORE],
                     ];
-                    await editor.withRange(rangeParams, async range => {
-                        await editor.execCommand<Char>('insertText', {
-                            text: 'c',
-                            context: {
-                                range: range,
-                            },
-                        });
-                    });
+                    await editor.execWithRange<Char>(rangeParams, 'insertText', { text: 'c' });
                 },
                 contentAfter: 'acb[]',
             });
@@ -1686,14 +1647,7 @@ describe('VDocument', () => {
                         [aNode, RelativePosition.AFTER],
                         [bNode, RelativePosition.AFTER],
                     ];
-                    await editor.withRange(rangeParams, async range => {
-                        await editor.execCommand<Char>('insertText', {
-                            text: 'c',
-                            context: {
-                                range: range,
-                            },
-                        });
-                    });
+                    await editor.execWithRange<Char>(rangeParams, 'insertText', { text: 'c' });
                 },
                 contentAfter: 'ac[]',
             });

--- a/packages/plugin-align/test/Align.test.ts
+++ b/packages/plugin-align/test/Align.test.ts
@@ -37,12 +37,13 @@ describePlugin(Align, testEditor => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>ab</p><p style="text-align: right;">c[]d</p>',
                     stepFunction: (editor: JWEditor) => {
-                        const domEngine = editor.plugins.get(Layout).engines.dom;
+                        const domLayout = editor.plugins.get(Layout);
+                        const domEngine = domLayout.engines.dom;
                         const editable = domEngine.components.get('editable')[0];
                         const root = editable;
-                        return editor.execCommand(() => {
+                        return editor.execCommand(context => {
                             root.lastChild().editable = false;
-                            return align(AlignType.LEFT)(editor);
+                            return context.execCommand<Align>('align', { type: AlignType.LEFT });
                         });
                     },
                     contentAfter: '<p>ab</p><p style="text-align: right;">c[]d</p>',

--- a/packages/plugin-code/src/Code.ts
+++ b/packages/plugin-code/src/Code.ts
@@ -10,6 +10,7 @@ import { VNode } from '../../core/src/VNodes/VNode';
 import { parseEditable } from '../../utils/src/configuration';
 import { DomLayoutEngine } from '../../plugin-dom-layout/src/DomLayoutEngine';
 import { isBlock } from '../../utils/src/isBlock';
+import { CommandParams } from '../../core/src/Dispatcher';
 
 export class Code<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T> {
     codeView = new CodeViewNode();
@@ -52,14 +53,14 @@ export class Code<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
     // Public
     //--------------------------------------------------------------------------
 
-    async toggle(): Promise<void> {
+    async toggle(params: CommandParams): Promise<void> {
         if (this.active) {
-            return this.deactivate();
+            return this.deactivate(params);
         } else {
-            return this.activate();
+            return this.activate(params);
         }
     }
-    async activate(): Promise<void> {
+    async activate(params: CommandParams): Promise<void> {
         this.active = true;
         const domLayoutEngine = this.editor.plugins.get(Layout).engines.dom as DomLayoutEngine;
         const editable = domLayoutEngine.components.get('editable')[0];
@@ -70,9 +71,9 @@ export class Code<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
 
         // Show the code view and hide the editable.
         await this.editor.plugins.get(Layout).append('code', 'main');
-        await this.editor.execCommand('hide', { componentId: 'editable' });
+        await params.context.execCommand('hide', { componentId: 'editable' });
     }
-    async deactivate(): Promise<void> {
+    async deactivate(params: CommandParams): Promise<void> {
         this.active = false;
         const domLayoutEngine = this.editor.plugins.get(Layout).engines.dom as DomLayoutEngine;
         const editable = domLayoutEngine.components.get('editable')[0];
@@ -87,7 +88,7 @@ export class Code<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
         editable.append(...newEditable[0].children());
 
         // Show the editable and hide the code view.
-        await this.editor.execCommand('show', { componentId: 'editable' });
+        await params.context.execCommand('show', { componentId: 'editable' });
         await this.editor.plugins.get(Layout).remove('code', 'main');
     }
 

--- a/packages/plugin-dom-editable/src/DomEditable.ts
+++ b/packages/plugin-dom-editable/src/DomEditable.ts
@@ -113,34 +113,34 @@ export class DomEditable<T extends JWPluginConfig = JWPluginConfig> extends JWPl
      * @param batchPromise
      */
     async _onNormalizedEvent(batchPromise: Promise<EventBatch>): Promise<void> {
-        return this.editor.nextEventMutex(
-            async (): Promise<void> => {
-                const batch = await batchPromise;
-                const domEngine = this.dependencies.get(Layout).engines.dom as DomLayoutEngine;
-                if (batch.mutatedElements) {
-                    domEngine.markForRedraw(batch.mutatedElements);
+        // TODO: The `nextEventMutex` shenanigans that were removed in this
+        // commit should be reinstated unless we want the normalizer to call
+        // `execCommand` regardless of the observation outcome like it used to
+        // call `nextEventMutex` before calling `execCommand`.
+        const batch = await batchPromise;
+        const domEngine = this.dependencies.get(Layout).engines.dom as DomLayoutEngine;
+        if (batch.mutatedElements) {
+            domEngine.markForRedraw(batch.mutatedElements);
+        }
+        let processed = false;
+        if (batch.inferredKeydownEvent) {
+            const domLayout = this.dependencies.get(DomLayout);
+            processed = !!(await domLayout.processKeydown(
+                new KeyboardEvent('keydown', {
+                    ...batch.inferredKeydownEvent,
+                    key: batch.inferredKeydownEvent.key,
+                    code: batch.inferredKeydownEvent.code,
+                }),
+            ));
+        }
+        if (!processed) {
+            for (const action of batch.actions) {
+                const commandSpec = this._matchCommand(action);
+                if (commandSpec) {
+                    await this.editor.execCommand(...commandSpec);
                 }
-                let processed = false;
-                if (batch.inferredKeydownEvent) {
-                    const domLayout = this.dependencies.get(DomLayout);
-                    processed = !!(await domLayout.processKeydown(
-                        new KeyboardEvent('keydown', {
-                            ...batch.inferredKeydownEvent,
-                            key: batch.inferredKeydownEvent.key,
-                            code: batch.inferredKeydownEvent.code,
-                        }),
-                    ));
-                }
-                if (!processed) {
-                    for (const action of batch.actions) {
-                        const commandSpec = this._matchCommand(action);
-                        if (commandSpec) {
-                            await this.editor.execCommand(...commandSpec);
-                        }
-                    }
-                }
-            },
-        );
+            }
+        }
     }
     /**
      * In DomLayout, KeyboardEvent listener to be added to the DOM that calls

--- a/packages/plugin-dom-editable/test/DomEditable.test.ts
+++ b/packages/plugin-dom-editable/test/DomEditable.test.ts
@@ -152,7 +152,6 @@ describe('DomEditable', () => {
         });
     });
     describe('_onNormalizedEvent', () => {
-        let commandNames: string[];
         let editor: JWEditor;
         afterEach(async () => {
             return editor.stop();
@@ -178,20 +177,6 @@ describe('DomEditable', () => {
                 section.innerHTML = '<div>abcd</div>';
                 setSelection(section.firstChild.firstChild, 2, section.firstChild.firstChild, 2);
                 await editor.start();
-                commandNames = [];
-                const execCommand = editor.execCommand;
-                editor.execCommand = async (
-                    commandName: string | (() => Promise<void> | void),
-                    params?: object,
-                ): Promise<void> => {
-                    if (typeof commandName === 'function') {
-                        commandNames.push('@custom');
-                        await commandName();
-                    } else {
-                        commandNames.push(commandName);
-                    }
-                    return execCommand.call(editor, commandName, params);
-                };
             });
             it('enter in the middle of the word', async () => {
                 const p = container.querySelector('section').firstChild;
@@ -220,7 +205,7 @@ describe('DomEditable', () => {
                 await nextTick();
                 await nextTick();
 
-                expect(commandNames.join(',')).to.equal('insertParagraphBreak');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('insertParagraphBreak');
                 expect(container.innerHTML).to.equal(
                     '<jw-editor><section contenteditable="true">' +
                         '<div>ab</div><div>cd</div>' +
@@ -265,7 +250,7 @@ describe('DomEditable', () => {
                 await nextTick();
                 await nextTick();
 
-                expect(commandNames.join(',')).to.equal('insertLineBreak,insert');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('insertLineBreak,insert');
                 expect(container.innerHTML).to.equal(
                     '<jw-editor><section contenteditable="true">' +
                         '<div>ab<br>cd</div>' +
@@ -314,7 +299,7 @@ describe('DomEditable', () => {
                     [{ 'type': 'keyup', 'key': 'o', 'code': 'KeyO' }],
                 ]);
 
-                expect(commandNames.join(',')).to.equal('insertText');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('insertText');
                 expect(container.innerHTML).to.equal(
                     '<jw-editor><section contenteditable="true">' +
                         '<div>abocd</div>' +
@@ -339,7 +324,7 @@ describe('DomEditable', () => {
             });
             it('select all: ctrl + a', async () => {
                 await selectAllWithKeyA(container);
-                expect(commandNames.join(',')).to.equal('selectAll');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('selectAll');
                 expect(container.innerHTML).to.equal(
                     '<jw-editor><section contenteditable="true">' +
                         '<div>abcd</div>' +
@@ -372,7 +357,7 @@ describe('DomEditable', () => {
                 await nextTick();
                 await nextTick();
 
-                expect(commandNames.join(',')).to.equal('setSelection');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('setSelection');
                 expect(container.innerHTML).to.equal(
                     '<jw-editor><section contenteditable="true">' +
                         '<div>abcd</div>' +
@@ -455,7 +440,7 @@ describe('DomEditable', () => {
                     [{ 'type': 'keyup', 'key': 'Control', 'code': 'ControlLeft' }],
                 ]);
 
-                expect(commandNames.join(',')).to.equal('deleteBackward');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('deleteBackward');
                 expect(container.innerHTML).to.equal(
                     '<jw-editor><section contenteditable="true">' +
                         '<div><br></div>' +
@@ -538,7 +523,7 @@ describe('DomEditable', () => {
                     [{ 'type': 'keyup', 'key': 'Control', 'code': 'ControlLeft' }],
                 ]);
 
-                expect(commandNames.join(',')).to.equal('deleteForward');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('deleteForward');
                 expect(container.innerHTML).to.equal(
                     '<jw-editor><section contenteditable="true">' +
                         '<div><br></div>' +
@@ -603,7 +588,7 @@ describe('DomEditable', () => {
                     ],
                 ]);
 
-                expect(commandNames.join(',')).to.equal('deleteBackward');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('deleteBackward');
                 expect(container.innerHTML).to.equal(
                     '<jw-editor><section contenteditable="true">' +
                         '<div>acd</div>' +
@@ -668,7 +653,7 @@ describe('DomEditable', () => {
                     ],
                 ]);
 
-                expect(commandNames.join(',')).to.equal('deleteForward');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('deleteForward');
                 expect(container.innerHTML).to.equal(
                     '<jw-editor><section contenteditable="true">' +
                         '<div>abd</div>' +
@@ -717,7 +702,7 @@ describe('DomEditable', () => {
                     ],
                 ]);
 
-                expect(commandNames.join(',')).to.equal('deleteBackward');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('deleteBackward');
                 expect(container.innerHTML).to.equal(
                     '<jw-editor><section contenteditable="true">' +
                         '<div>acd</div>' +
@@ -881,20 +866,6 @@ describe('DomEditable', () => {
                 },
             );
             await editor.start();
-            commandNames = [];
-            const execCommand = editor.execCommand;
-            editor.execCommand = async (
-                commandName: string | (() => Promise<void> | void),
-                params?: object,
-            ): Promise<void> => {
-                if (typeof commandName === 'function') {
-                    commandNames.push('@custom');
-                    await commandName();
-                } else {
-                    commandNames.push(commandName);
-                }
-                return execCommand.call(editor, commandName, params);
-            };
 
             // key: o
             await triggerEvents([
@@ -925,7 +896,7 @@ describe('DomEditable', () => {
                 ],
             ]);
 
-            expect(commandNames.join(',')).to.equal('deleteForward');
+            expect(editor.memoryInfo.commandNames.join(',')).to.equal('deleteForward');
             expect(container.innerHTML).to.equal(
                 '<jw-editor><section contenteditable="true">' +
                     '<div>abd</div>' +

--- a/packages/plugin-dom-editable/test/EventManager.test.ts
+++ b/packages/plugin-dom-editable/test/EventManager.test.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import { JWPlugin, JWPluginConfig } from '../../core/src/JWPlugin';
 import { JWEditor, Loadables } from '../../core/src/JWEditor';
 import { Keymap } from '../../plugin-keymap/src/Keymap';
-import { DomEditable } from './DomEditable';
+import { DomEditable } from '../src/DomEditable';
 
 describe('core', () => {
     describe('EventManager', () => {

--- a/packages/plugin-dom-layout/src/ActionableDomObjectRenderer.ts
+++ b/packages/plugin-dom-layout/src/ActionableDomObjectRenderer.ts
@@ -83,11 +83,6 @@ export class ActionableDomObjectRenderer extends NodeRenderer<DomObject> {
      * enabled change.
      */
     protected _updateActionables(): void {
-        const commandNames = this.engine.editor.memoryInfo.commandNames;
-        if (commandNames.length === 1 && commandNames.includes('insertText')) {
-            // By default the actionable buttons are not update for a text insertion.
-            return;
-        }
         for (const [actionable, element] of this.actionableNodes) {
             const editor = this.engine.editor;
             const select = !!actionable.selected(editor);

--- a/packages/plugin-dom-layout/src/ActionableGroupSelectItemDomObjectRenderer.ts
+++ b/packages/plugin-dom-layout/src/ActionableGroupSelectItemDomObjectRenderer.ts
@@ -117,11 +117,6 @@ export class ActionableGroupSelectItemDomObjectRenderer extends NodeRenderer<Dom
      * @param element
      */
     protected _updateActionables(): void {
-        const commandNames = this.engine.editor.memoryInfo.commandNames;
-        if (commandNames.length === 1 && commandNames.includes('insertText')) {
-            // By default the actionable buttons are not update for a text insertion.
-            return;
-        }
         for (const [aactionable, element] of this.actionableNodes) {
             const editor = this.engine.editor;
             const select = aactionable.selected(editor);

--- a/packages/plugin-dom-layout/src/DomLayout.ts
+++ b/packages/plugin-dom-layout/src/DomLayout.ts
@@ -111,9 +111,7 @@ export class DomLayout<T extends DomLayoutConfig = DomLayoutConfig> extends JWPl
             event.preventDefault();
             event.stopPropagation();
             event.stopImmediatePropagation();
-            this.editor.nextEventMutex(() => {
-                return this.editor.execCommand(command.commandId, params);
-            });
+            await this.editor.execCommand(command.commandId, params);
             return command.commandId;
         }
     }

--- a/packages/plugin-dom-layout/test/DomLayout.test.ts
+++ b/packages/plugin-dom-layout/test/DomLayout.test.ts
@@ -1632,9 +1632,9 @@ describe('DomLayout', () => {
                     const editable = domEngine.components.get('editable')[0];
                     const renderer = editor.plugins.get(Renderer);
                     const br = editable.children()[2];
-                    await editor.execCommand(() => {
+                    await editor.execCommand(context => {
                         new BoldFormat().applyTo(br);
-                        return editor.execCommand<Inline>('toggleFormat', {
+                        return context.execCommand<Inline>('toggleFormat', {
                             FormatClass: BoldFormat,
                         });
                     });
@@ -2352,12 +2352,12 @@ describe('DomLayout', () => {
                         const renderer = editor.plugins.get(Renderer);
                         const br = editable.children()[2];
 
-                        await editor.execCommand(() => {
+                        await editor.execCommand(context => {
                             new BoldFormat().applyTo(br);
 
                             mutationNumber = 0;
 
-                            return editor.execCommand<Inline>('toggleFormat', {
+                            return context.execCommand<Inline>('toggleFormat', {
                                 FormatClass: BoldFormat,
                             });
                         });

--- a/packages/plugin-dom-layout/test/DomLayout.test.ts
+++ b/packages/plugin-dom-layout/test/DomLayout.test.ts
@@ -1397,7 +1397,7 @@ describe('DomLayout', () => {
 
             await editor.stop();
         });
-        it.skip('should not redraw a selection in a part removed from the arch/DOM', async () => {
+        it('should not redraw a selection in a part removed from the arch/DOM', async () => {
             const Component: ComponentDefinition = {
                 id: 'test',
                 render(editor: JWEditor): Promise<VNode[]> {
@@ -1428,22 +1428,15 @@ describe('DomLayout', () => {
 
             expect(container.innerHTML).to.equal('<jw-editor></jw-editor>');
 
-            let hasError = false;
-            await editor
-                .execCommand(() => {
-                    editor.selection.set({
-                        anchorNode: div.descendants(CharNode)[0],
-                        anchorPosition: RelativePosition.AFTER,
-                        focusNode: div.descendants(CharNode)[0],
-                        direction: Direction.BACKWARD,
-                        focusPosition: RelativePosition.AFTER,
-                    });
-                })
-                .catch(error => {
-                    hasError = true;
-                    expect(error.message).to.include('selection');
+            await editor.execCommand(() => {
+                editor.selection.set({
+                    anchorNode: div.descendants(CharNode)[0],
+                    anchorPosition: RelativePosition.AFTER,
+                    focusNode: div.descendants(CharNode)[0],
+                    direction: Direction.BACKWARD,
+                    focusPosition: RelativePosition.AFTER,
                 });
-            expect(hasError).to.equal(true);
+            });
 
             const domSelection = target.ownerDocument.getSelection();
 

--- a/packages/plugin-history/src/History.ts
+++ b/packages/plugin-history/src/History.ts
@@ -105,8 +105,9 @@ export class History<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin
                     this._memoryKeys[this._memoryStep] = sliceKey;
                     return;
                 }
+            } else if (this.editor.memoryInfo.uiCommand) {
+                return;
             }
-
             this._memoryStep++;
             this._memoryKeys.splice(this._memoryStep, Infinity, sliceKey);
             this._memoryCommands.splice(this._memoryStep, Infinity, [...commands]);

--- a/packages/plugin-history/src/History.ts
+++ b/packages/plugin-history/src/History.ts
@@ -1,5 +1,5 @@
 import { JWPlugin, JWPluginConfig } from '../../core/src/JWPlugin';
-import { JWEditor, Loadables } from '../../core/src/JWEditor';
+import { JWEditor, Loadables, CommitParams } from '../../core/src/JWEditor';
 import { Keymap } from '../../plugin-keymap/src/Keymap';
 import { Layout } from '../../plugin-layout/src/Layout';
 import { ActionableNode } from '../../plugin-layout/src/ActionableNode';
@@ -90,10 +90,10 @@ export class History<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin
         }
         this.editor.memory.switchTo(this._memoryKeys[this._memoryStep]);
     }
-    private _registerMemoryKey(): void {
+    private _registerMemoryKey(commitParams: CommitParams): void {
         const sliceKey = this.editor.memory.sliceKey;
         if (!this._memoryKeys.includes(sliceKey)) {
-            const commands = this.editor.memoryInfo.commandNames;
+            const commands = commitParams.commandNames;
             if (commands.length === 1 && commands[0] === 'setSelection') {
                 if (this._memoryStep > this._memoryKeys.length - 1) {
                     // After an undo, don't replace history for setSelection.
@@ -109,9 +109,7 @@ export class History<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin
 
             this._memoryStep++;
             this._memoryKeys.splice(this._memoryStep, Infinity, sliceKey);
-            this._memoryCommands.splice(this._memoryStep, Infinity, [
-                ...this.editor.memoryInfo.commandNames,
-            ]);
+            this._memoryCommands.splice(this._memoryStep, Infinity, [...commands]);
         }
     }
 }

--- a/packages/plugin-image/src/ImageDomObjectRenderer.ts
+++ b/packages/plugin-image/src/ImageDomObjectRenderer.ts
@@ -13,10 +13,8 @@ export class ImageDomObjectRenderer extends NodeRenderer<DomObject> {
 
     async render(node: ImageNode, worker: RenderingEngineWorker<DomObject>): Promise<DomObject> {
         const select = (): void => {
-            this.engine.editor.nextEventMutex(() => {
-                return this.engine.editor.execCommand(async () => {
-                    this.engine.editor.selection.select(node, node);
-                });
+            this.engine.editor.execCommand(() => {
+                this.engine.editor.selection.select(node, node);
             });
         };
         const image: DomObject = {

--- a/packages/plugin-indent/src/Indent.ts
+++ b/packages/plugin-indent/src/Indent.ts
@@ -90,11 +90,9 @@ export class Indent<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<
         // Only indent when there is at leat two lines selected, that is when
         // at least one segment break could be identified in the selection.
         if (range.isCollapsed() || !segmentBreaks.length) {
-            await this.editor.execCommand<Char>('insertText', {
+            await params.context.execCommand<Char>('insertText', {
                 text: this.tab,
-                context: {
-                    range: range,
-                },
+                context: { ...params.context, range },
             });
         } else {
             // The first line of the selection is neither fully selected nor
@@ -106,13 +104,8 @@ export class Indent<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<
             for (const segmentBreak of segmentBreaks) {
                 // Insert 4 spaces at the start of next segment.
                 const [node, position] = this._nextSegmentStart(segmentBreak);
-                await this.editor.withRange(VRange.at(node, position), async range => {
-                    return this.editor.execCommand<Char>('insertText', {
-                        text: this.tab,
-                        context: {
-                            range: range,
-                        },
-                    });
+                await this.editor.execWithRange<Char>(VRange.at(node, position), 'insertText', {
+                    text: this.tab,
                 });
             }
         }

--- a/packages/plugin-indent/test/Indent.test.ts
+++ b/packages/plugin-indent/test/Indent.test.ts
@@ -950,13 +950,7 @@ describePlugin(Indent, testEditor => {
                     const editable = domEngine.components.get('editable')[0];
                     const bNode = editable.next(node => node.name === 'b');
                     const dNode = editable.next(node => node.name === 'd');
-                    await editor.withRange(VRange.selecting(bNode, dNode), async range => {
-                        await editor.execCommand<Indent>('indent', {
-                            context: {
-                                range: range,
-                            },
-                        });
-                    });
+                    await editor.execWithRange<Indent>(VRange.selecting(bNode, dNode), 'indent');
                 },
                 contentAfter: '\u2003ab<br>\u2003cd[]',
             });
@@ -1034,13 +1028,7 @@ describePlugin(Indent, testEditor => {
                     const editable = domEngine.components.get('editable')[0];
                     const bNode = editable.next(node => node.name === 'b');
                     const dNode = editable.next(node => node.name === 'd');
-                    await editor.withRange(VRange.selecting(bNode, dNode), async range => {
-                        await editor.execCommand<Indent>('outdent', {
-                            context: {
-                                range: range,
-                            },
-                        });
-                    });
+                    await editor.execWithRange<Indent>(VRange.selecting(bNode, dNode), 'outdent');
                 },
                 contentAfter: 'ab<br>cd[]',
             });

--- a/packages/plugin-linebreak/src/LineBreak.ts
+++ b/packages/plugin-linebreak/src/LineBreak.ts
@@ -6,6 +6,7 @@ import { Core } from '../../core/src/Core';
 import { Loadables } from '../../core/src/JWEditor';
 import { Parser } from '../../plugin-parser/src/Parser';
 import { Renderer } from '../../plugin-renderer/src/Renderer';
+import { CommandParams } from '../../core/src/Dispatcher';
 
 export class LineBreak<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T> {
     readonly loadables: Loadables<Parser & Renderer> = {
@@ -25,8 +26,8 @@ export class LineBreak<T extends JWPluginConfig = JWPluginConfig> extends JWPlug
     /**
      * Insert a line break node at range.
      */
-    insertLineBreak(): Promise<void> {
-        return this.editor.execCommand<Core>('insert', {
+    insertLineBreak(params: CommandParams): Promise<void> {
+        return params.context.execCommand<Core>('insert', {
             node: new LineBreakNode(),
         });
     }

--- a/packages/plugin-link/src/Link.ts
+++ b/packages/plugin-link/src/Link.ts
@@ -145,7 +145,7 @@ export class Link<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
         if (params.target) {
             link.modifiers.get(Attributes).set('target', params.target);
         }
-        return this.editor.execCommand<Char>('insertText', {
+        return params.context.execCommand<Char>('insertText', {
             text: label || link.url,
             formats: new Modifiers(link),
             context: params.context,

--- a/packages/plugin-link/src/components/LinkComponent.ts
+++ b/packages/plugin-link/src/components/LinkComponent.ts
@@ -21,15 +21,20 @@ export class LinkComponent<T extends LinkProps = {}> extends OwlComponent<T> {
     //--------------------------------------------------------------------------
 
     async saveLink(): Promise<void> {
-        await this.env.editor.execCommand('link', {
-            url: this.state.url,
-            label: this.state.label,
-        } as LinkParams);
-        this.env.editor.plugins.get(Layout).remove('link');
+        await this.env.editor.execCommand(async context => {
+            const params: LinkParams = {
+                url: this.state.url,
+                label: this.state.label,
+            };
+            await context.execCommand('link', params);
+            this.env.editor.plugins.get(Layout).remove('link');
+        });
         this.destroy();
     }
-    cancel(): void {
-        this.env.editor.plugins.get(Layout).remove('link');
+    async cancel(): Promise<void> {
+        await this.env.editor.execCommand(async () => {
+            this.env.editor.plugins.get(Layout).remove('link');
+        });
         this.destroy();
     }
 }

--- a/packages/plugin-list/src/ListDomObjectRenderer.ts
+++ b/packages/plugin-list/src/ListDomObjectRenderer.ts
@@ -11,6 +11,7 @@ import { VNode } from '../../core/src/VNodes/VNode';
 import { VRange } from '../../core/src/VRange';
 import { ListItemAttributes } from './ListItemXmlDomParser';
 import { RenderingEngineWorker } from '../../plugin-renderer/src/RenderingEngineCache';
+import { List } from './List';
 
 export class ListDomObjectRenderer extends NodeRenderer<DomObject> {
     static id = DomObjectRenderingEngine.id;
@@ -122,16 +123,12 @@ export class ListDomObjectRenderer extends NodeRenderer<DomObject> {
                 if (ev.offsetX < 0) {
                     ev.stopImmediatePropagation();
                     ev.preventDefault();
-                    this.engine.editor.withRange(
-                        VRange.at(listItem.firstChild() || listItem),
-                        range => {
-                            return this.engine.editor.execCommand('toggleChecked', {
-                                context: {
-                                    range: range,
-                                },
-                            });
-                        },
-                    );
+                    this.engine.editor.execCommand(() => {
+                        return this.engine.editor.execWithRange<List>(
+                            VRange.at(listItem.firstChild() || listItem),
+                            'toggleChecked',
+                        );
+                    });
                 }
             };
             li.attach = (el: HTMLElement): void => {

--- a/packages/plugin-odoo-video/src/OdooVideoDomObjectRenderer.ts
+++ b/packages/plugin-odoo-video/src/OdooVideoDomObjectRenderer.ts
@@ -14,19 +14,15 @@ export class OdooVideoHtmlDomRenderer extends NodeRenderer<DomObject> {
 
     async render(node: OdooVideoNode): Promise<DomObject> {
         const setSelection = (): void => {
-            this.engine.editor.nextEventMutex(() => {
-                this.engine.editor.execCommand<Core>('setSelection', {
-                    vSelection: {
-                        anchorNode: node,
-                        direction: Direction.FORWARD,
-                    },
-                });
+            this.engine.editor.execCommand<Core>('setSelection', {
+                vSelection: {
+                    anchorNode: node,
+                    direction: Direction.FORWARD,
+                },
             });
         };
         const openMedia = (): void => {
-            this.engine.editor.nextEventMutex(() => {
-                this.engine.editor.execCommand('openMedia');
-            });
+            this.engine.editor.execCommand('openMedia');
         };
         const wrapper: DomObject = {
             tag: 'DIV',

--- a/packages/plugin-shadow/test/DomShadow.test.ts
+++ b/packages/plugin-shadow/test/DomShadow.test.ts
@@ -511,7 +511,6 @@ describe('DomShadow', async () => {
     });
     describe('normalize editable events', async () => {
         describe('hande user events with EventNormalizer', async () => {
-            let commandNames: string[];
             let editor: JWEditor;
             let domEngine: DomLayoutEngine;
             let editable: VNode;
@@ -541,20 +540,6 @@ describe('DomShadow', async () => {
                 section.innerHTML = '<div>abcd</div>';
                 setSelection(section.firstChild.firstChild, 2, section.firstChild.firstChild, 2);
                 await editor.start();
-                commandNames = [];
-                const execCommand = editor.execCommand;
-                editor.execCommand = async (
-                    commandName: string | (() => Promise<void> | void),
-                    params?: object,
-                ): Promise<void> => {
-                    if (typeof commandName === 'function') {
-                        commandNames.push('@custom');
-                        await commandName();
-                    } else {
-                        commandNames.push(commandName);
-                    }
-                    return execCommand.call(editor, commandName, params);
-                };
                 domEngine = editor.plugins.get(Layout).engines.dom as DomLayoutEngine;
                 editable = domEngine.components.get('editable')[0].firstChild();
             });
@@ -584,7 +569,7 @@ describe('DomShadow', async () => {
                 await nextTick();
                 await nextTick();
 
-                expect(commandNames.join(',')).to.equal('insertParagraphBreak');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('insertParagraphBreak');
                 domEditable = domEngine.getDomNodes(editable)[0] as Element;
                 expect((domEditable.parentNode as ShadowRoot).innerHTML).to.equal(
                     '<section contenteditable="true">' +
@@ -630,7 +615,7 @@ describe('DomShadow', async () => {
                 await nextTick();
 
                 domEditable = domEngine.getDomNodes(editable)[0] as Element;
-                expect(commandNames.join(',')).to.equal('insertLineBreak,insert');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('insertLineBreak,insert');
                 expect((domEditable.parentNode as ShadowRoot).innerHTML).to.equal(
                     '<section contenteditable="true">' + '<div>ab<br>cd</div>' + '</section>',
                 );
@@ -677,7 +662,7 @@ describe('DomShadow', async () => {
                     [{ 'type': 'keyup', 'key': 'o', 'code': 'KeyO' }],
                 ]);
 
-                expect(commandNames.join(',')).to.equal('insertText');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('insertText');
                 const domEditable = domEngine.getDomNodes(editable)[0] as Element;
                 domEditable.removeAttribute('id');
                 expect((domEditable.parentNode as ShadowRoot).innerHTML).to.equal(
@@ -727,7 +712,7 @@ describe('DomShadow', async () => {
                 await nextTick();
                 await nextTick();
 
-                expect(commandNames.join(',')).to.equal('selectAll');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('selectAll');
                 domEditable = domEngine.getDomNodes(editable)[0] as Element;
                 expect((domEditable.parentNode as ShadowRoot).innerHTML).to.equal(
                     '<section contenteditable="true"><div>abcd</div></section>',
@@ -761,7 +746,7 @@ describe('DomShadow', async () => {
                 await nextTick();
                 await nextTick();
 
-                expect(commandNames.join(',')).to.equal('setSelection');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('setSelection');
                 domEditable = domEngine.getDomNodes(editable)[0] as Element;
                 expect((domEditable.parentNode as ShadowRoot).innerHTML).to.equal(
                     '<section contenteditable="true">' + '<div>abcd</div>' + '</section>',
@@ -843,7 +828,7 @@ describe('DomShadow', async () => {
                     [{ 'type': 'keyup', 'key': 'Control', 'code': 'ControlLeft' }],
                 ]);
 
-                expect(commandNames.join(',')).to.equal('deleteBackward');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('deleteBackward');
                 const domEditable = domEngine.getDomNodes(editable)[0] as Element;
                 domEditable.removeAttribute('id');
                 expect((domEditable.parentNode as ShadowRoot).innerHTML).to.equal(
@@ -926,7 +911,7 @@ describe('DomShadow', async () => {
                     [{ 'type': 'keyup', 'key': 'Control', 'code': 'ControlLeft' }],
                 ]);
 
-                expect(commandNames.join(',')).to.equal('deleteForward');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('deleteForward');
                 const domEditable = domEngine.getDomNodes(editable)[0] as Element;
                 domEditable.removeAttribute('id');
                 expect((domEditable.parentNode as ShadowRoot).innerHTML).to.equal(
@@ -991,7 +976,7 @@ describe('DomShadow', async () => {
                     ],
                 ]);
 
-                expect(commandNames.join(',')).to.equal('deleteBackward');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('deleteBackward');
                 const domEditable = domEngine.getDomNodes(editable)[0] as Element;
                 domEditable.removeAttribute('id');
                 expect((domEditable.parentNode as ShadowRoot).innerHTML).to.equal(
@@ -1056,7 +1041,7 @@ describe('DomShadow', async () => {
                     ],
                 ]);
 
-                expect(commandNames.join(',')).to.equal('deleteForward');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('deleteForward');
                 const domEditable = domEngine.getDomNodes(editable)[0] as Element;
                 domEditable.removeAttribute('id');
                 expect((domEditable.parentNode as ShadowRoot).innerHTML).to.equal(
@@ -1105,7 +1090,7 @@ describe('DomShadow', async () => {
                     ],
                 ]);
 
-                expect(commandNames.join(',')).to.equal('deleteBackward');
+                expect(editor.memoryInfo.commandNames.join(',')).to.equal('deleteBackward');
                 const domEditable = domEngine.getDomNodes(editable)[0] as Element;
                 domEditable.removeAttribute('id');
                 expect((domEditable.parentNode as ShadowRoot).innerHTML).to.equal(
@@ -1162,20 +1147,6 @@ describe('DomShadow', async () => {
                 },
             );
             await editor.start();
-            const commandNames = [];
-            const execCommand = editor.execCommand;
-            editor.execCommand = async (
-                commandName: string | (() => Promise<void> | void),
-                params?: object,
-            ): Promise<void> => {
-                if (typeof commandName === 'function') {
-                    commandNames.push('@custom');
-                    await commandName();
-                } else {
-                    commandNames.push(commandName);
-                }
-                return execCommand.call(editor, commandName, params);
-            };
             const domEngine = editor.plugins.get(Layout).engines.dom as DomLayoutEngine;
             const editable = domEngine.components.get('editable')[0].firstChild();
 
@@ -1208,7 +1179,7 @@ describe('DomShadow', async () => {
                 ],
             ]);
 
-            expect(commandNames.join(',')).to.equal('deleteForward');
+            expect(editor.memoryInfo.commandNames.join(',')).to.equal('deleteForward');
             const domEditable = domEngine.getDomNodes(editable)[0] as Element;
             domEditable.removeAttribute('id');
             expect((domEditable.parentNode as ShadowRoot).innerHTML).to.equal(

--- a/packages/plugin-table/src/Table.ts
+++ b/packages/plugin-table/src/Table.ts
@@ -178,6 +178,7 @@ export class Table<T extends TableConfig = TableConfig> extends JWPlugin<T> {
             await layout.remove('TablePicker');
         }
         if (!params.rowCount || !params.columnCount) {
+            this.editor.memoryInfo.uiCommand = true;
             if (!this.isTablePickerOpen) {
                 await layout.append('TablePicker', 'TableButton');
             }

--- a/packages/plugin-table/src/TablePickerCellDomObjectRenderer.ts
+++ b/packages/plugin-table/src/TablePickerCellDomObjectRenderer.ts
@@ -56,6 +56,8 @@ export class TablePickerCellDomObjectRenderer extends NodeRenderer<DomObject> {
                 tablePicker.columnCount > minColumnCount
             ) {
                 this.engine.editor.execCommand(() => {
+                    this.engine.editor.memoryInfo.uiCommand = true;
+
                     const toRedraw = new Set<VNode>();
                     // Add/remove rows.
                     if (tablePickerCell.rowIndex >= tablePicker.rowCount - 1) {

--- a/packages/utils/src/Dom.ts
+++ b/packages/utils/src/Dom.ts
@@ -40,3 +40,13 @@ export function nodeLength(node: Node): number {
         return node.childNodes.length;
     }
 }
+
+/**
+ * Return if the node is a text node. Don't use instance of to allow iframe
+ * uses.
+ *
+ * @param node
+ */
+export function isTextNode(node: Node): node is Text {
+    return node.nodeName === '#text';
+}


### PR DESCRIPTION
[IMP] JWEditor: no launch of execCommand at the same time, use mutex

Add command on plugin to execute the sub command and add 'execSubCommand'
on editor for some redering who want to call sub command into a custom
execCommand.