### PR TITLE
[FIX] FontAwesome: remove FontAwesome classes on parsing

### DIFF
--- a/packages/plugin-fontawesome/src/FontAwesomeDomObjectRenderer.ts
+++ b/packages/plugin-fontawesome/src/FontAwesomeDomObjectRenderer.ts
@@ -20,7 +20,12 @@ export class FontAwesomeDomObjectRenderer extends NodeRenderer<DomObject> {
         node: FontAwesomeNode,
         worker: RenderingEngineWorker<DomObject>,
     ): Promise<DomObject> {
-        const fontawesome: DomObjectElement = { tag: node.htmlTag };
+        const fontawesome: DomObjectElement = {
+            tag: node.htmlTag,
+            attributes: {
+                class: new Set(node.faClasses),
+            },
+        };
         // Surround the fontawesome with two invisible characters so the
         // selection can navigate around it.
         const domObject: DomObjectFragment = {

--- a/packages/plugin-fontawesome/src/FontAwesomeNode.ts
+++ b/packages/plugin-fontawesome/src/FontAwesomeNode.ts
@@ -3,12 +3,15 @@ import { AbstractNodeParams } from '../../core/src/VNodes/AbstractNode';
 
 export interface FontAwesomeNodeParams extends AbstractNodeParams {
     htmlTag: string;
+    faClasses: string[];
 }
 export class FontAwesomeNode extends InlineNode {
     static readonly atomic = true;
     htmlTag: string;
+    faClasses: string[];
     constructor(params: FontAwesomeNodeParams) {
         super(params);
         this.htmlTag = params.htmlTag;
+        this.faClasses = params.faClasses;
     }
 }

--- a/packages/plugin-fontawesome/src/FontAwesomeXmlDomParser.ts
+++ b/packages/plugin-fontawesome/src/FontAwesomeXmlDomParser.ts
@@ -2,8 +2,9 @@ import { FontAwesomeNode } from './FontAwesomeNode';
 import { AbstractParser } from '../../plugin-parser/src/AbstractParser';
 import { XmlDomParsingEngine } from '../../plugin-xml/src/XmlDomParsingEngine';
 import { nodeName } from '../../utils/src/utils';
+import { VersionableArray } from '../../core/src/Memory/VersionableArray';
 
-export const FontAwesomeRegex = /(^|[\s*\n*])fa[bdlrs]?[\s*\n*$]/;
+export const FontAwesomeRegex = /(?:^|\s|\n)(fa[bdlrs]?)(?:.|\n)*?(fa-.*?)(?:\s|\n|$)/;
 
 export class FontAwesomeXmlDomParser extends AbstractParser<Node> {
     static id = XmlDomParsingEngine.id;
@@ -14,11 +15,18 @@ export class FontAwesomeXmlDomParser extends AbstractParser<Node> {
     };
 
     async parse(item: Element): Promise<FontAwesomeNode[]> {
-        const fontawesome = new FontAwesomeNode({ htmlTag: nodeName(item) });
         const attributes = this.engine.parseAttributes(item);
-        if (attributes.length) {
-            fontawesome.modifiers.append(attributes);
-        }
+        // Remove fa classes to avoid having them spread to nearby nodes.
+        // They will be put back at renderng time.
+        const faClasses = item.className.match(FontAwesomeRegex).slice(1);
+        const fontawesome = new FontAwesomeNode({
+            htmlTag: nodeName(item),
+            faClasses: new VersionableArray(...faClasses),
+        });
+        attributes.classList.remove(...faClasses);
+        // Keep the attributes even though it might be empty as it will be used
+        // to restore the proper order of classes.
+        fontawesome.modifiers.append(attributes);
         return [fontawesome];
     }
 

--- a/packages/plugin-fontawesome/test/FontAwesome.test.ts
+++ b/packages/plugin-fontawesome/test/FontAwesome.test.ts
@@ -3,6 +3,7 @@ import { FontAwesome } from '../src/FontAwesome';
 import { BasicEditor } from '../../bundle-basic-editor/BasicEditor';
 import JWEditor from '../../core/src/JWEditor';
 import { Core } from '../../core/src/Core';
+import { Char } from '../../plugin-char/src/Char';
 
 const deleteForward = async (editor: JWEditor): Promise<void> =>
     await editor.execCommand<Core>('deleteForward');
@@ -174,6 +175,22 @@ describePlugin(FontAwesome, testEditor => {
                         contentAfter: '<p>ab[]cd</p>',
                     });
                 });
+            });
+        });
+    });
+    describe('Text insertion', () => {
+        it('should insert a character before', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>ab[]<i class="fa fa-pastafarianism"></i>cd</p>',
+                stepFunction: editor => editor.execCommand<Char>('insertText', { text: 's' }),
+                contentAfter: '<p>abs[]\u200b<i class="fa fa-pastafarianism"></i>\u200bcd</p>',
+            });
+        });
+        it('should insert a character after', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>ab<i class="fa fa-pastafarianism"></i>[]cd</p>',
+                stepFunction: editor => editor.execCommand<Char>('insertText', { text: 's' }),
+                contentAfter: '<p>ab\u200b<i class="fa fa-pastafarianism"></i>\u200bs[]cd</p>',
             });
         });
     });

--- a/packages/plugin-xml/src/AttributesDomObjectModifierRenderer.ts
+++ b/packages/plugin-xml/src/AttributesDomObjectModifierRenderer.ts
@@ -20,11 +20,15 @@ export class AttributesDomObjectModifierRenderer extends ModifierRenderer<DomObj
      */
     async render(modifier: Attributes, contents: DomObject[]): Promise<DomObject[]> {
         const keys = modifier.keys();
-        if (keys.length) {
+        const classHistory: Record<string, boolean> = modifier.classList.history();
+        if (keys.length || Object.keys(classHistory).length) {
             const attributes: DomObjectAttributes = {};
             for (const name of keys) {
                 if (name === 'class') {
-                    attributes.class = new Set(modifier.classList.items());
+                    // This is going to use the class history feature anyway.
+                    // TODO: This entire file should probably be reorganized to
+                    // avoid using a `DomObjectAttributes` object in between.
+                    attributes.class = new Set();
                 } else if (name === 'style') {
                     attributes.style = modifier.style.toJSON();
                 } else {
@@ -35,7 +39,7 @@ export class AttributesDomObjectModifierRenderer extends ModifierRenderer<DomObj
             for (let index = 0; index < contents.length; index++) {
                 let content = contents[index];
                 if ('tag' in content) {
-                    this._applyAttributes(content, attributes);
+                    this._applyAttributes(content, attributes, classHistory);
                 } else if (
                     'children' in content &&
                     !content.children.find(
@@ -46,7 +50,7 @@ export class AttributesDomObjectModifierRenderer extends ModifierRenderer<DomObj
                 ) {
                     for (const child of content.children) {
                         if ('tag' in child) {
-                            this._applyAttributes(child, attributes);
+                            this._applyAttributes(child, attributes, classHistory);
                         }
                     }
                 } else {
@@ -78,20 +82,51 @@ export class AttributesDomObjectModifierRenderer extends ModifierRenderer<DomObj
         return contents;
     }
 
-    private _applyAttributes(content: DomObjectElement, attributes: DomObjectAttributes): void {
+    private _applyAttributes(
+        content: DomObjectElement,
+        attributes: DomObjectAttributes,
+        classHistory: Record<string, boolean>,
+    ): void {
         if (!content.attributes) content.attributes = {};
         const attr = content.attributes;
         for (const name in attributes) {
             if (name === 'class') {
-                if (!attr.class) attr.class = new Set();
-                for (const className of attributes.class) {
-                    attr.class.add(className);
-                }
+                this._applyClassHistory(content, classHistory);
             } else if (name === 'style') {
                 attr.style = Object.assign({}, attributes.style, attr.style);
             } else {
                 attr[name] = attributes[name];
             }
         }
+    }
+
+    /**
+     * Apply the history of the class attributes stored in the given Record to
+     * the given DomObject. Basically, if the DomObject is restoring a class
+     * that used to be present in the class history, it will be reordered to
+     * match its original position.
+     *
+     * @param content
+     * @param classHistory
+     */
+    private _applyClassHistory(
+        content: DomObjectElement,
+        classHistory: Record<string, boolean>,
+    ): void {
+        // Reorganize `class` set to restore order thanks to ClassList history.
+        const classNames = new Set<string>();
+        if (content.attributes.class) {
+            for (const className of content.attributes.class) {
+                if (classHistory[className] !== false) {
+                    classNames.add(className);
+                }
+            }
+        }
+        for (const className in classHistory) {
+            if (classHistory[className] || content.attributes.class.has(className)) {
+                classNames.add(className);
+            }
+        }
+        content.attributes.class = classNames;
     }
 }


### PR DESCRIPTION
And restore them afterwards. This required to rewrite how ClassList
worked in order to keep a history of parsed-then-removed classes to
be able to restore them at their previous position on rendering.