### PR TITLE
[FIX] DomLayout: Can redraw an altered text node without content.

### DIFF
--- a/packages/plugin-dom-layout/src/DomReconciliationEngine.ts
+++ b/packages/plugin-dom-layout/src/DomReconciliationEngine.ts
@@ -1542,8 +1542,12 @@ export class DomReconciliationEngine {
             const chars: [string, Text, number][] = [];
             for (const textNode of textNodes) {
                 const split = textNode.textContent.split('');
-                for (let i = 0; i < split.length; i++) {
-                    chars.push([split[i], textNode, i]);
+                if (split.length) {
+                    for (let i = 0; i < split.length; i++) {
+                        chars.push([split[i], textNode, i]);
+                    }
+                } else {
+                    chars.push(['', textNode, 0]);
                 }
             }
 


### PR DESCRIPTION
Issue: Dom alteration by an external code or by deletion with a broken
range during a user action. For example the fact of doing backspace
with a selection of the whole DOM not communicated to the VDom.