### PR TITLE
[FIX] DomLayout: must keep all origin when redraw a custom node

### DIFF
--- a/packages/plugin-dom-layout/src/DomReconciliationEngine.ts
+++ b/packages/plugin-dom-layout/src/DomReconciliationEngine.ts
@@ -1776,7 +1776,14 @@ export class DomReconciliationEngine {
      */
     private isAvailableNode(id: DomObjectID, domNode: Node): boolean {
         const linkedId = this._fromDom.get(domNode);
-        if (!linkedId || linkedId === id) {
+        if (!linkedId) {
+            // The browser can separate an item and keep all attributes on the
+            // clone. In the event of a new element to be associated, a
+            // complete redrawing is requested.
+            this._diff[id].askCompleteRedrawing = true;
+            return true;
+        }
+        if (linkedId === id) {
             return true;
         }
         if (this._diff[linkedId]?.askCompleteRedrawing) {

--- a/packages/plugin-list/src/ListDomObjectRenderer.ts
+++ b/packages/plugin-list/src/ListDomObjectRenderer.ts
@@ -33,7 +33,6 @@ export class ListDomObjectRenderer extends NodeRenderer<DomObject> {
                 this._renderLi(listNode, children[index], domObjects[index], worker),
             );
         }
-
         return list;
     }
     private _renderLi(
@@ -41,7 +40,7 @@ export class ListDomObjectRenderer extends NodeRenderer<DomObject> {
         listItem: VNode,
         rendering: DomObject,
         worker: RenderingEngineWorker<DomObject>,
-    ): DomObject | VNode {
+    ): DomObject {
         let li: DomObjectElement;
         // The node was wrapped in a "LI" but needs to be rendered as well.
         if ('tag' in rendering && rendering.tag === 'P' && !rendering.shadowRoot) {

--- a/packages/plugin-list/src/ListItemXmlDomParser.ts
+++ b/packages/plugin-list/src/ListItemXmlDomParser.ts
@@ -42,9 +42,9 @@ export class ListItemXmlDomParser extends AbstractParser<Node> {
                     // wrapped together in a base container.
                     if (!inlinesContainer) {
                         inlinesContainer = new Container();
-                        inlinesContainer.modifiers.append(
-                            new ListItemAttributes(itemModifiers.get(Attributes)),
-                        );
+                        const attributes = itemModifiers.get(Attributes);
+                        attributes.remove('value');
+                        inlinesContainer.modifiers.append(new ListItemAttributes(attributes));
                         nodes.push(inlinesContainer);
                     }
                     inlinesContainer.append(...parsedChild);
@@ -54,9 +54,9 @@ export class ListItemXmlDomParser extends AbstractParser<Node> {
                     } else {
                         inlinesContainer = null; // Close the inlinesContainer.
                         for (const child of parsedChild) {
-                            child.modifiers.set(
-                                new ListItemAttributes(itemModifiers.get(Attributes)),
-                            );
+                            const attributes = itemModifiers.get(Attributes);
+                            attributes.remove('value');
+                            child.modifiers.set(new ListItemAttributes(attributes));
                         }
                         nodes.push(...parsedChild);
                     }

--- a/packages/plugin-list/test/List.test.ts
+++ b/packages/plugin-list/test/List.test.ts
@@ -5776,6 +5776,38 @@ describePlugin(List, testEditor => {
                                 contentAfter: '<ol><li>abc</li><li>[]<br></li></ol>',
                             });
                         });
+                        it('should indent an item in an ordered list and add value (with dom mutations)', async () => {
+                            await testEditor(BasicEditor, {
+                                contentBefore: unformat(`
+                                    <ol>
+                                        <li>a</li>
+                                        <li style="list-style: none;">
+                                            <ol>
+                                                <li>b</li>
+                                            </ol>
+                                        </li>
+                                        <li value="2">c[]</li>
+                                    </ol>`),
+                                stepFunction: async (editor: JWEditor): Promise<void> => {
+                                    const ol = document.querySelector('ol');
+                                    const li = document.createElement('li');
+                                    li.append(document.createElement('br'));
+                                    ol.insertBefore(li, ol.lastElementChild);
+                                    await editor.execCommand<Core>('insertParagraphBreak'); // new line
+                                },
+                                contentAfter: unformat(`
+                                    <ol>
+                                        <li>a</li>
+                                        <li style="list-style: none;">
+                                            <ol>
+                                                <li>b</li>
+                                            </ol>
+                                        </li>
+                                        <li value="2">c</li>
+                                        <li>[]<br></li>
+                                    </ol>`),
+                            });
+                        });
                     });
                     describe('Removing items', () => {
                         it('should add an empty list item at the end of a list, then remove it', async () => {

--- a/packages/plugin-list/test/List.test.ts
+++ b/packages/plugin-list/test/List.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import JWEditor from '../../core/src/JWEditor';
 import { Core } from '../../core/src/Core';
 import { ListType, ListNode } from '../src/ListNode';
-import { describePlugin, keydown, unformat, click } from '../../utils/src/testUtils';
+import { describePlugin, keydown, unformat, click, nextTick } from '../../utils/src/testUtils';
 import { BasicEditor } from '../../bundle-basic-editor/BasicEditor';
 import { LineBreakNode } from '../../plugin-linebreak/src/LineBreakNode';
 import { List } from '../src/List';
@@ -6694,6 +6694,52 @@ describePlugin(List, testEditor => {
                                     </ul>
                                 </li>
                             </ul>`),
+                    });
+                });
+            });
+            describe('Regular list', () => {
+                it('should indent a regular list empty item', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: unformat(`
+                            <ul>
+                                <li>abc</li>
+                                <li>[]</li>
+                            </ul>
+                            <p>def</p>`),
+                        stepFunction: indentList,
+                        contentAfter: unformat(`
+                            <ul>
+                                <li>abc</li>
+                                <li style="list-style: none;">
+                                    <ul>
+                                        <li>[]<br></li>
+                                    </ul>
+                                </li>
+                            </ul>
+                            <p>def</p>`),
+                    });
+                });
+                it('should indent a regular list empty item after an insertParagraphBreak', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: unformat(`
+                            <ul>
+                                <li>abc[]</li>
+                            </ul>
+                            <p>def</p>`),
+                        stepFunction: async (editor: JWEditor): Promise<void> => {
+                            await editor.execCommand<Core>('insertParagraphBreak');
+                            await editor.execCommand<List>('indent');
+                        },
+                        contentAfter: unformat(`
+                            <ul>
+                                <li>abc</li>
+                                <li style="list-style: none;">
+                                    <ul>
+                                        <li>[]<br></li>
+                                    </ul>
+                                </li>
+                            </ul>
+                            <p>def</p>`),
                     });
                 });
             });


### PR DESCRIPTION
Issue: After insertBreakLine in list, indent in list moves the cursor
outside of the list