### PR TITLE
[FIX] Odoo: wrap only inlineNode

### DIFF
--- a/packages/plugin-odoo/src/NoteEditableXmlDomParser.ts
+++ b/packages/plugin-odoo/src/NoteEditableXmlDomParser.ts
@@ -1,0 +1,45 @@
+import { XmlDomParsingEngine } from '../../plugin-xml/src/XmlDomParsingEngine';
+import { DividerNode } from '../../plugin-divider/src/DividerNode';
+import { nodeName } from '../../utils/src/utils';
+import { DividerXmlDomParser } from '../../plugin-divider/src/DividerXmlDomParser';
+import { AtomicNode } from '../../core/src/VNodes/AtomicNode';
+import { VNode } from '../../core/src/VNodes/VNode';
+
+export class NoteEditableXmlDomParser extends DividerXmlDomParser {
+    static id = XmlDomParsingEngine.id;
+    engine: XmlDomParsingEngine;
+
+    predicate = (item: Node): boolean => {
+        return (
+            item instanceof Element &&
+            nodeName(item) === 'DIV' &&
+            item.classList.contains('note-editable')
+        );
+    };
+
+    async parse(item: Element): Promise<DividerNode[]> {
+        const divider = (await super.parse(item))[0];
+
+        let looseChildren: VNode[] = [];
+        const newChildren: VNode[] = [];
+        for (const child of divider.childVNodes) {
+            if (child instanceof AtomicNode) {
+                looseChildren.push(child);
+            } else {
+                this.addChildren(newChildren, looseChildren);
+                looseChildren = [];
+                newChildren.push(child);
+            }
+        }
+        this.addChildren(newChildren, looseChildren);
+        divider.append(...newChildren);
+        return [divider];
+    }
+    addChildren(mainChildren: VNode[], children: VNode[]): void {
+        if (children.length) {
+            const container = new this.engine.editor.configuration.defaults.Container();
+            container.append(...children);
+            mainChildren.push(container);
+        }
+    }
+}

--- a/packages/plugin-odoo/src/Odoo.ts
+++ b/packages/plugin-odoo/src/Odoo.ts
@@ -24,6 +24,7 @@ import { TableNode } from '../../plugin-table/src/TableNode';
 import { CharNode } from '../../plugin-char/src/CharNode';
 import { HeadingParams } from '../../plugin-heading/src/Heading';
 import { isTextVisible } from '../../utils/src/utils';
+import { NoteEditableXmlDomParser } from './NoteEditableXmlDomParser';
 
 export enum OdooPaddingClasses {
     NONE = 'padding-none',
@@ -99,7 +100,7 @@ export interface SetImageClassParams extends CommandParams {
 export class Odoo<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T> {
     static dependencies = [Inline, Link, Xml];
     readonly loadables: Loadables<Parser & Renderer & Layout> = {
-        parsers: [OdooStructureXmlDomParser, OdooTranslationXmlDomParser],
+        parsers: [NoteEditableXmlDomParser, OdooStructureXmlDomParser, OdooTranslationXmlDomParser],
         renderers: [OdooImageDomObjectRenderer, OdooFontAwesomeDomObjectRenderer],
         components: [
             {


### PR DESCRIPTION
In the signature of Odoo, the content is only based of inline nodes
and the Editor does not yet support properly when that case happen.

For instance, when trying to align the content that does not have
a ContainerNode that is editable, the command will do nothing.

This commit fix that by wrapping all the node inside the default
container of the editor.