### PR TITLE
[FIX] DomLayout: pressing enter creates <p></p> without <br/>; + sele…

### DIFF
--- a/packages/core/test/VDocument.test.ts
+++ b/packages/core/test/VDocument.test.ts
@@ -1508,6 +1508,14 @@ describe('VDocument', () => {
                             '<p><span><b>ab</b></span></p><p><span><b>[]cd</b></span></p>',
                     });
                 });
+                it('should split a paragraph at its end, with a paragraph after it, and both have the same class', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p class="a">a[]</p><p class="a"><br></p>',
+                        stepFunction: insertParagraphBreak,
+                        contentAfter:
+                            '<p class="a">a</p><p class="a">[]<br></p><p class="a"><br></p>',
+                    });
+                });
             });
         });
         describe('Selection not collapsed', () => {

--- a/packages/plugin-dom-editable/src/DomEditable.ts
+++ b/packages/plugin-dom-editable/src/DomEditable.ts
@@ -84,8 +84,10 @@ export class DomEditable<T extends JWPluginConfig = JWPluginConfig> extends JWPl
                 const params: InsertTextParams = { text: action.text };
                 return ['insertText', params];
             }
-            case 'selectAll':
-                return ['selectAll', {}];
+            case 'selectAll': {
+                const domLayout = this.dependencies.get(DomLayout);
+                return domLayout.focusedNode ? ['selectAll', {}] : null;
+            }
             case 'setSelection': {
                 const layout = this.dependencies.get(Layout);
                 const domLayoutEngine = layout.engines.dom as DomLayoutEngine;

--- a/packages/plugin-dom-editable/test/DomEditable.test.ts
+++ b/packages/plugin-dom-editable/test/DomEditable.test.ts
@@ -25,6 +25,7 @@ export async function selectAllWithKeyA(container: HTMLElement | ShadowRoot): Pr
         container.querySelector('[contenteditable]').firstChild.firstChild,
         0,
     );
+    await nextTick();
     triggerEvent(container.querySelector('[contenteditable]'), 'keydown', {
         key: 'Control',
         code: 'ControlLeft',
@@ -886,17 +887,8 @@ describe('DomEditable', () => {
             const params = {
                 context: editor.contextManager.defaultContext,
             };
-            expect(execSpy.args).to.eql([
-                ['@focus'],
-                ['command-b', params],
-                ['@blur'],
-                // todo: There should not be a select all in the first editor.
-                // Correct this bug when having two editor at the same time
-                // becomes critical.
-                ['selectAll', {}],
-                ['@focus'],
-            ]);
-            expect(execSpy2.args).to.eql([['@focus'], ['@blur'], ['selectAll', {}]]);
+            expect(execSpy.args).to.eql([['@focus'], ['command-b', params], ['@blur']]);
+            expect(execSpy2.args).to.eql([['@focus'], ['selectAll', {}]]);
 
             await editor.stop();
             await editor2.stop();

--- a/packages/plugin-dom-layout/src/DomReconciliationEngine.ts
+++ b/packages/plugin-dom-layout/src/DomReconciliationEngine.ts
@@ -107,15 +107,17 @@ export class DomReconciliationEngine {
             }
             const nodes = this._items.get(domObject);
             for (const linkedNode of nodes) {
-                const ids = this._renderedNodes.get(linkedNode);
-                if (ids) {
-                    for (const id of ids) {
-                        if (!oldObjects.has(id)) {
-                            const object = this._objects[id].object;
-                            this._rendererTreated.delete(object);
-                            this._objectIds.delete(object);
-                            this._renderedIds.delete(id);
-                            oldObjects.add(id);
+                if (linkedNode instanceof AbstractNode) {
+                    const ids = this._renderedNodes.get(linkedNode);
+                    if (ids) {
+                        for (const id of ids) {
+                            if (!oldObjects.has(id)) {
+                                const object = this._objects[id].object;
+                                this._rendererTreated.delete(object);
+                                this._objectIds.delete(object);
+                                this._renderedIds.delete(id);
+                                oldObjects.add(id);
+                            }
                         }
                     }
                 }

--- a/packages/plugin-shadow/test/DomShadow.test.ts
+++ b/packages/plugin-shadow/test/DomShadow.test.ts
@@ -686,9 +686,17 @@ describe('DomShadow', async () => {
                 triggerEvent(domEditable, 'mousedown', {
                     button: 2,
                     detail: 1,
-                    clientX: 10,
-                    clientY: 10,
+                    clientX: 20,
+                    clientY: 20,
                 });
+                setDomSelection(
+                    domEditable.firstChild.firstChild,
+                    0,
+                    domEditable.lastChild.lastChild,
+                    4,
+                );
+                await nextTick();
+
                 triggerEvent(domEditable, 'keydown', {
                     key: 'Control',
                     code: 'ControlLeft',


### PR DESCRIPTION
…ctAll

Issue: When the two <p> has the same attributes, the rederer group this
into a batch. The layout reconcile associate the twice <p> has old
rendering when use the modifier for the matching. We don't use the
modifier to find the old nodes.
The fix of this bug trigger showed an inconsistency in a test of
selectAll. This has therefore been fixed as well.