### PR TITLE
[FIX] DomEditable: encapsulate _matchCommand

### DIFF
--- a/packages/plugin-dom-editable/src/DomEditable.ts
+++ b/packages/plugin-dom-editable/src/DomEditable.ts
@@ -191,13 +191,13 @@ export class DomEditable<T extends JWPluginConfig = JWPluginConfig> extends JWPl
             }
             if (!processed) {
                 for (const action of batch.actions) {
-                    const commandSpec = this._matchCommand(action);
-                    if (commandSpec) {
-                        const [commandName, commandParams] = commandSpec;
-                        if (commandName) {
-                            await execCommand(commandName, commandParams);
+                    await execCommand(async params => {
+                        const commandSpec = this._matchCommand(action);
+                        if (commandSpec) {
+                            const [commandName, commandParams] = commandSpec;
+                            await params.execCommand(commandName, commandParams);
                         }
-                    }
+                    });
                 }
             }
         });


### PR DESCRIPTION
_matchCommand might create a new range and need the memory to be open to
do that.