### PR TITLE
[FIX] XML: fix style parsing

### DIFF
--- a/packages/plugin-xml/src/CssStyle.ts
+++ b/packages/plugin-xml/src/CssStyle.ts
@@ -63,8 +63,8 @@ export class CssStyle extends VersionableObject {
             .map(style => style.trim())
             .filter(style => style.length)
             .reduce((accumulator, value) => {
-                const [key, v] = value.split(':');
-                style[key.trim()] = v.trim();
+                const [key, ...v] = value.split(':');
+                style[key.trim()] = v.join(':').trim();
                 return accumulator;
             }, style);
     }


### PR DESCRIPTION
Before this commit, when parsing a style property with the char ":",
the parsing was incorrect.
For instance "background-image: url(http:whatever)" was parsed as
"background-image: url(http".