### PR TITLE
[FIX] Odoo: check if containernode dirty

### DIFF
--- a/packages/plugin-odoo/src/OdooStructureNode.ts
+++ b/packages/plugin-odoo/src/OdooStructureNode.ts
@@ -14,14 +14,5 @@ export class OdooStructureNode extends TagNode {
         super(params);
         this.xpath = params.xpath;
         this.viewId = params.viewId;
-        // Don't trigger the first change as it comes from parsing.
-        let firstChange = false;
-        this.on('childList', () => {
-            if (!firstChange) {
-                firstChange = true;
-                return;
-            }
-            this.dirty = true;
-        });
     }
 }

--- a/packages/plugin-odoo/src/OdooStructureXmlDomParser.ts
+++ b/packages/plugin-odoo/src/OdooStructureXmlDomParser.ts
@@ -32,6 +32,10 @@ export class OdooStructureXmlDomParser extends AbstractParser {
         odooStructure.modifiers.append(this.engine.parseAttributes(item));
         const children = await this.engine.parse(...item.childNodes);
         odooStructure.append(...children);
+
+        odooStructure.on('childList', () => {
+            odooStructure.dirty = true;
+        });
         return [odooStructure];
     }
 }


### PR DESCRIPTION
When parsing the ContainerNode if we set no child in it, firstChange
will remain false. So the next insertion will not set the property
`dirty`. Which was wrong.

Now we check that the parsing is finish properly.