### PR TITLE
[FIX] Export FontAwesomeNode to fix a traceback in odoo media modal

### DIFF
--- a/packages/bundle-odoo-website-editor/odoo-integration.ts
+++ b/packages/bundle-odoo-website-editor/odoo-integration.ts
@@ -20,6 +20,7 @@ import { OdooField } from '../plugin-odoo-field/src/OdooField';
 import { OdooFieldNode } from '../plugin-odoo-field/src/OdooFieldNode';
 import { TagNode } from '../core/src/VNodes/TagNode';
 import { Parser } from '../plugin-parser/src/Parser';
+import { FontAwesomeNode } from '../plugin-fontawesome/src/FontAwesomeNode';
 
 export {
     OdooWebsiteEditor,
@@ -44,4 +45,5 @@ export {
     Inline,
     DomHelpers,
     Parser,
+    FontAwesomeNode,
 };


### PR DESCRIPTION

CF: 
> [SGE] opening the media modal when selecting a single character (range a[b]c) create a traceback https://i.imgur.com/kBHg6CR.jpg 
     ╰─ [SGE] on it