### PR TITLE
[FIX] isBlock: properly parse formatting space around <li> in Firefox

### DIFF
--- a/packages/utils/src/isBlock.ts
+++ b/packages/utils/src/isBlock.ts
@@ -60,16 +60,20 @@ export function isBlock(node: Node): boolean {
     let result: boolean;
     if (node instanceof Element) {
         const tagName = nodeName(node);
-        // every custom jw-* node will be considered as blocks
+        // Every custom jw-* node will be considered as blocks.
         if (tagName.startsWith('JW-') || tagName === 'T') {
             return true;
+        }
+        // The node might not be in the DOM, in which case it has no CSS values.
+        if (window.document !== node.ownerDocument) {
+            return blockTagNames.includes(tagName);
         }
         // We won't call `getComputedStyle` more than once per node.
         let style = computedStyles.get(node);
         if (!style) {
             style = window.getComputedStyle(node);
+            computedStyles.set(node, style);
         }
-        // The node might not be in the DOM, in which case it has no CSS values.
         if (style.display) {
             result = !style.display.includes('inline') && style.display !== 'contents';
         } else {


### PR DESCRIPTION
On Firefox, calling `window.getComputedStyle` on a list item element that is not in the DOM wrongly returns "inline". As a result, some whitespace was not removed where it should have been.
Additionally, the `computedStyle` map was never set so time was lost computing styles that were already computed.

This commit checks whether the node is contained within the document of the current window before computing styles. If it isn't, our only recourse is to check the nodeName. As a side effect, this should save us a few milliseconds of parsing.
We also properly set the cache now, thereby saving a few extra milliseconds.

Addressing the following bug report:
> 12. [QSM - Firefox] Somehow, during the page edition, the footer exploded (I imagine some kind of normalizing the whole DOM that failed?)
> ╰─[DMO] What does "exploded" mean in this context ? A screenshot would have been helpful. I suspect this was caused by the triple-click "bug". Do you remember using triple-click to select the content at the end of the page ?
> ╰─[QSM] https://drive.google.com/drive/folders/1CDUIv2vMUtH6P8PsCPBMuN7vySyK94Wc?usp=sharing