### PR TITLE
[FIX] Layout: remove extra parenthesis

### DIFF
--- a/examples/layout/layout.ts
+++ b/examples/layout/layout.ts
@@ -176,7 +176,10 @@ const toolbarConfig = editor.configuration.plugins.find(
 if (Array.isArray(toolbarConfig.layout)) {
     toolbarConfig.layout.push(['ThemeButton'], ['TemplateSelector']);
 } else {
-    Object.assign(toolbarConfig.layout, { theme: ['ThemeButton'], templateSelector: ['TemplateSelector']}));
+    Object.assign(toolbarConfig.layout, {
+        theme: ['ThemeButton'],
+        templateSelector: ['TemplateSelector'],
+    });
 }
 editor.configure(Toolbar, toolbarConfig);
 


### PR DESCRIPTION
I blame @Goaman for this :smiling_imp:
The editor won't compile without this fix so it's pretty important.