### PR TITLE
[IMP] EventNormalizer: redraw editable on keydown in not-editable

### DIFF
--- a/packages/plugin-dom-editable/src/DomEditable.ts
+++ b/packages/plugin-dom-editable/src/DomEditable.ts
@@ -143,11 +143,16 @@ export class DomEditable<T extends JWPluginConfig = JWPluginConfig> extends JWPl
             }
             if (!processed) {
                 for (const action of batch.actions) {
-                    const commandSpec = this._matchCommand(action);
-                    if (commandSpec) {
-                        const [commandName, commandParams] = commandSpec;
-                        if (commandName) {
-                            await execCommand(commandName, commandParams);
+                    if (action.type === '@redraw') {
+                        domEngine.markForRedraw(action.domNodes);
+                        await domEngine.redraw();
+                    } else {
+                        const commandSpec = this._matchCommand(action);
+                        if (commandSpec) {
+                            const [commandName, commandParams] = commandSpec;
+                            if (commandName) {
+                                await execCommand(commandName, commandParams);
+                            }
                         }
                     }
                 }

--- a/packages/plugin-dom-layout/src/DomLayout.ts
+++ b/packages/plugin-dom-layout/src/DomLayout.ts
@@ -15,7 +15,7 @@ import { ZoneXmlDomParser } from './ZoneXmlDomParser';
 import { LayoutContainerDomObjectRenderer } from './LayoutContainerDomObjectRenderer';
 import { ZoneIdentifier, ZoneNode } from '../../plugin-layout/src/ZoneNode';
 import { Keymap } from '../../plugin-keymap/src/Keymap';
-import { CommandIdentifier } from '../../core/src/Dispatcher';
+import { CommandIdentifier, CommandParams } from '../../core/src/Dispatcher';
 import { ActionableDomObjectRenderer } from './ActionableDomObjectRenderer';
 import { ActionableGroupDomObjectRenderer } from './ActionableGroupDomObjectRenderer';
 import { ActionableGroupSelectItemDomObjectRenderer } from './ActionableGroupSelectItemDomObjectRenderer';

--- a/packages/plugin-dom-layout/src/DomLayoutEngine.ts
+++ b/packages/plugin-dom-layout/src/DomLayoutEngine.ts
@@ -122,7 +122,7 @@ export class DomLayoutEngine extends LayoutEngine {
     getDomNodes(node: VNode): Node[] {
         return this._domReconciliationEngine.toDom(node);
     }
-    async redraw(params: ChangesLocations): Promise<void> {
+    async redraw(params?: ChangesLocations): Promise<void> {
         if (this._currentlyRedrawing) {
             throw new Error('Double redraw detected');
         }
@@ -193,7 +193,14 @@ export class DomLayoutEngine extends LayoutEngine {
     // Private
     //--------------------------------------------------------------------------
 
-    private async _redraw(params: ChangesLocations): Promise<void> {
+    private async _redraw(
+        params: ChangesLocations = {
+            add: [],
+            move: [],
+            remove: [],
+            update: [],
+        },
+    ): Promise<void> {
         const updatedNodes = [...this._getInvalidNodes(params)];
 
         const layout = this.editor.plugins.get(Renderer);

--- a/packages/plugin-html/test/DefaultDomRenderer.test.ts
+++ b/packages/plugin-html/test/DefaultDomRenderer.test.ts
@@ -28,6 +28,7 @@ describe('Html', () => {
 
             expect(rootItem).to.exist;
             expect((rootItem[0] as Element).outerHTML).to.equal('<img src="toto">');
+            await editor.stop();
         });
         it('should parse autoclose and non-autoclose tags', async () => {
             await testEditor(BasicEditor, {
@@ -54,6 +55,7 @@ describe('Html', () => {
             expect((rootItem[0] as Element).outerHTML).to.equal(
                 '<table><colgroup><col><col></colgroup><tbody><tr><td>aaa</td></tr></tbody></table>',
             );
+            await editor.stop();
         });
         it('should parse special attribute and content', async () => {
             await testEditor(BasicEditor, {
@@ -80,6 +82,7 @@ describe('Html', () => {
             expect((rootItem[0] as Element).outerHTML).to.equal(
                 '<div>&lt;poulet&gt; kot kot &lt;/poulet&gt; <span data="1 < 2" tutu="b &nbsp; a">toto</span>&nbsp; a</div>',
             );
+            await editor.stop();
         });
         it('should parse special attribute and content (2)', async () => {
             await testEditor(BasicEditor, {
@@ -106,6 +109,7 @@ describe('Html', () => {
             expect((rootItem[0] as Element).outerHTML).to.equal(
                 '<p><b>a</b> "<div>b</div><a href="?debug=&amp;t=" title="<span data=&quot;view&quot;> mode </span>">toto</a> <img title="<b data=&quot;view&quot;>a</b>"></p>',
             );
+            await editor.stop();
         });
     });
     describe('DefaultDomObjectRenderer', () => {
@@ -126,6 +130,7 @@ describe('Html', () => {
                     node.id +
                     '"><br></containernode></containernode>',
             );
+            await editor.stop();
         });
         it('should render a VNode with style important', async () => {
             const editor = new JWEditor();
@@ -141,6 +146,7 @@ describe('Html', () => {
             expect(rootItem[0].children[0].getAttribute('style')).to.equal(
                 'border-radius: 10px !important;border: 10px !important;',
             );
+            await editor.stop();
         });
     });
 });


### PR DESCRIPTION
Addresses:

```
[JKE1-07]     Edit readonly field:
-> double click select the readonly and let think that it is editable (not saved)
https://drive.google.com/file/d/18hpjnzomHaVr8EclKPiaI3PJRYaf8yZk/view
╰─[DMO] I don't understand what we should be seeing in the video. I see you entering edit mode then saving the page. I'm sure I'm missing something but I don't understand what it is.
╰─[AGE] he clicks in the footer in a node that is not editable and:
if you double click in it, you can start typing (with a simple click, the range is properly canceled but apparently double click bypasses the check)
I'm on it.
╰─[AGE] oh man we are actually doing it right in our abstraction but the DOM changes and we don't redraw
```