### PR TITLE
[FIX] EventNormalizer: consistently apply insertLineBreak on shift+enter

### DIFF
--- a/packages/plugin-dom-editable/src/EventNormalizer.ts
+++ b/packages/plugin-dom-editable/src/EventNormalizer.ts
@@ -836,6 +836,7 @@ export class EventNormalizer {
             (cutEvent && 'deleteByCut') ||
             (dropEvent && 'insertFromDrop') ||
             (pasteEvent && 'insertFromPaste') ||
+            (key === 'Enter' && inputEvent?.inputType === 'insertText' && 'insertLineBreak') ||
             (inputEvent && inputEvent.inputType);
 
         // In case of accent inserted from a Mac, check that the char before was


### PR DESCRIPTION
Prior to this fix, there were certain situations where doing `shift+enter` was triggering an `insertParagraph` action instead of `insertLineBreak`. The reason was that in those situations, the browser was actually giving an `insertText` input type together with the `Enter` key, for some reason...

Steps to reproduce the fixed issue:
- open example Note "Project N.947.5" in Odoo
- add: `Enter` - couple of characters - `Enter` - couple of characters
- make the last line `blockquote`
- at the end of the last line, add: `Shift+Enter` - couple of characters
- Shift+enter at this point broke the `blockquote`.