### PR TITLE
[FIX] Template: ensure an overflow on the template container

### DIFF
--- a/packages/plugin-template/assets/Template.css
+++ b/packages/plugin-template/assets/Template.css
@@ -8,6 +8,7 @@ jw-templates {
     background-color: #ffffff;
     padding: 3px;
     display: block;
+    overflow: auto;
 }
 jw-templates ~ * {
     display: none !important;


### PR DESCRIPTION
This is important for mass mailing as otherwise the template picker
doesn't have a scrollbar and there are templates that can't be selected.