### PR TITLE
[FIX] EventNormalizer: Don't force a line break with [any key] + [ENTER]

### DIFF
--- a/packages/plugin-dom-editable/src/EventNormalizer.ts
+++ b/packages/plugin-dom-editable/src/EventNormalizer.ts
@@ -836,7 +836,10 @@ export class EventNormalizer {
             (cutEvent && 'deleteByCut') ||
             (dropEvent && 'insertFromDrop') ||
             (pasteEvent && 'insertFromPaste') ||
-            (key === 'Enter' && inputEvent?.inputType === 'insertText' && 'insertLineBreak') ||
+            (key === 'Enter' &&
+                keydownEvent.shiftKey &&
+                inputEvent?.inputType === 'insertText' &&
+                'insertLineBreak') ||
             (inputEvent && inputEvent.inputType);
 
         // In case of accent inserted from a Mac, check that the char before was


### PR DESCRIPTION
Only [shift] + [ENTER] should create a lineBreak


----

7. [FP] randomly inserts <br> instead of <p>, sometimes: https://drive.google.com/file/d/1ABvxKLR76JY1FB1apbd4HtWqOci9E0wq/view
    ╰─[AGE] can't reproduce on jabberwock demo so it's an integration issue
    ╰─[SGE] seems to be when the user press ENTER before he release the last keypress