### PR TITLE
[ADD] Core: handle triple-click delete special case

### DIFF
--- a/packages/core/src/Core.ts
+++ b/packages/core/src/Core.ts
@@ -137,7 +137,20 @@ export class Core<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
                 }
             }
         } else {
+            const shouldDeleteLine =
+                !range.start.previousSibling() &&
+                !range.end.previousSibling() &&
+                range.startContainer !== range.endContainer;
+            const oldEndContainer = range.endContainer;
+
             range.empty();
+
+            // This handles the special case of a triple click followed by a
+            // backspace: the line should be deleted with its container (no
+            // merging).
+            if (shouldDeleteLine) {
+                range.startContainer.replaceWith(oldEndContainer);
+            }
         }
     }
     /**
@@ -191,7 +204,20 @@ export class Core<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
                 }
             }
         } else {
+            const shouldDeleteLine =
+                !range.start.previousSibling() &&
+                !range.end.previousSibling() &&
+                range.startContainer !== range.endContainer;
+            const oldEndContainer = range.endContainer;
+
             range.empty();
+
+            // This handles the special case of a triple click followed by a
+            // delete: the line should be deleted with its container (no
+            // merging).
+            if (shouldDeleteLine) {
+                range.startContainer.replaceWith(oldEndContainer);
+            }
         }
     }
     async deleteWord(params: DeleteWordParams): Promise<void> {

--- a/packages/core/test/VDocument.test.ts
+++ b/packages/core/test/VDocument.test.ts
@@ -592,6 +592,13 @@ describe('VDocument', () => {
                     contentAfter: '<p>a[]</p><p>f</p>',
                 });
             });
+            it('should delete a heading (triple click delete)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h1>[abc</h1><p>]def</p>',
+                    stepFunction: deleteForward,
+                    contentAfter: '<p>[]def</p>',
+                });
+            });
         });
     });
     // Note: implementing a test for deleteBackward, make sure to implement
@@ -1233,6 +1240,13 @@ describe('VDocument', () => {
                     contentBefore: '<h1>]<b>abcd</b></h1><p>ef[gh</p>',
                     stepFunction: deleteBackward,
                     contentAfter: '<h1>[]gh</h1>',
+                });
+            });
+            it('should delete a heading (triple click backspace)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h1>[abc</h1><p>]def</p>',
+                    stepFunction: deleteBackward,
+                    contentAfter: '<p>[]def</p>',
                 });
             });
         });

--- a/packages/plugin-char/test/Char.test.ts
+++ b/packages/plugin-char/test/Char.test.ts
@@ -169,6 +169,13 @@ describePlugin(Char, testEditor => {
                         contentAfter: '<p>a[b]c</p>',
                     });
                 });
+                it('should delete a heading (triple click char)', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<h1>[abc</h1><p>]def</p>',
+                        stepFunction: (editor: JWEditor) => insertText(editor, 'g'),
+                        contentAfter: '<h1>g[]def</h1>',
+                    });
+                });
             });
             describe('bold', () => {
                 describe('Selection collapsed', () => {


### PR DESCRIPTION
Handles:

[FP] when deleting a paragraph (triple clicks), it sets the line style to the next paragraph: https://drive.google.com/file/d/1dFkex7dZkD4RTAZvUeK8hJa6XPcqiAN1/view