### PR TITLE
[FIX] List: toggle list should removes list-style from li element

### DIFF
--- a/packages/plugin-list/src/List.ts
+++ b/packages/plugin-list/src/List.ts
@@ -209,6 +209,19 @@ export class List<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T>
         const targetedNodes = range.targetedNodes();
         const ancestors = targetedNodes.map(node => node.closest(ListNode));
         const targetedLists = ancestors.filter(list => !!list);
+
+        for (const list of targetedLists) {
+            // Some list-style either override the list type or are incompatible
+            // with some list types. Remove the list-style attributes so that
+            // the default style of the selected list applies correctly.
+            for (const node of list.children()) {
+                const attr = node.modifiers.find(ListItemAttributes);
+                if (attr) {
+                    attr.style.remove('list-style');
+                }
+            }
+        }
+
         if (
             targetedLists.length === targetedNodes.length &&
             targetedLists.every(list => list.listType === type)

--- a/packages/plugin-list/src/ListItemXmlDomParser.ts
+++ b/packages/plugin-list/src/ListItemXmlDomParser.ts
@@ -71,6 +71,9 @@ export class ListItemXmlDomParser extends AbstractParser<Node> {
                             for (const child of parsedChild) {
                                 const attributes = itemModifiers.get(Attributes);
                                 attributes.remove('value');
+                                if (attributes.style.get('list-style') === 'none') {
+                                    attributes.style.remove('list-style');
+                                }
                                 child.modifiers.set(new ListItemAttributes(attributes));
                             }
                         }

--- a/packages/plugin-list/test/List.test.ts
+++ b/packages/plugin-list/test/List.test.ts
@@ -827,6 +827,26 @@ describePlugin(List, testEditor => {
                         </ul>`),
                 });
             });
+            it('should keep the list-style of indented list', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: unformat(`
+                        <ul>
+                            <li style="list-style: cambodian;">
+                                <ul>
+                                    <li>a[b]c</li>
+                                </ul>
+                            </li>
+                        </ul>`),
+                    contentAfter: unformat(`
+                        <ul>
+                            <li style="list-style: cambodian;">
+                                <ul>
+                                    <li>a[b]c</li>
+                                </ul>
+                            </li>
+                        </ul>`),
+                });
+            });
         });
     });
     describe('toggleList', () => {
@@ -1148,6 +1168,19 @@ describePlugin(List, testEditor => {
                                         </ul>
                                     </li>
                                 </ul>`),
+                        });
+                    });
+                    it('should remove the list-style when change the list style', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: unformat(`
+                                <ul>
+                                    <li style="list-style: cambodian;">a[]</li>
+                                </ul>`),
+                            stepFunction: toggleChecklist,
+                            contentAfter: unformat(`
+                            <ul class="checklist">
+                                <li class="unchecked">a[]</li>
+                            </ul>`),
                         });
                     });
                 });
@@ -6381,6 +6414,20 @@ describePlugin(List, testEditor => {
                                     '<ul><li><div class="a">abc</div><div class="a">b</div><div class="a">[]<br></div></li></ul>',
                             });
                         });
+                        it('should keep the list-style when add li', async () => {
+                            await testEditor(BasicEditor, {
+                                contentBefore: unformat(`
+                                    <ul>
+                                        <li style="list-style: cambodian;">a[]</li>
+                                    </ul>`),
+                                stepFunction: insertParagraphBreak,
+                                contentAfter: unformat(`
+                                <ul>
+                                    <li style="list-style: cambodian;">a</li>
+                                    <li style="list-style: cambodian;">[]<br></li>
+                                </ul>`),
+                            });
+                        });
                     });
                 });
                 describe('Checklist', () => {
@@ -7116,6 +7163,25 @@ describePlugin(List, testEditor => {
             });
         });
         describe('outdent', () => {
+            describe('Regular list', () => {
+                it('should remove the list-style when outdent the list', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: unformat(`
+                            <ul>
+                                <li style="list-style: cambodian;">
+                                    <ul>
+                                        <li>a[b]c</li>
+                                    </ul>
+                                </li>
+                            </ul>`),
+                        stepFunction: outdentList,
+                        contentAfter: unformat(`
+                            <ul>
+                                <li>a[b]c</li>
+                            </ul>`),
+                    });
+                });
+            });
             describe('Checklist', () => {
                 it('should outdent a checklist', async () => {
                     await testEditor(BasicEditor, {

--- a/packages/plugin-list/test/List.test.ts
+++ b/packages/plugin-list/test/List.test.ts
@@ -7,7 +7,7 @@ import { BasicEditor } from '../../bundle-basic-editor/BasicEditor';
 import { LineBreakNode } from '../../plugin-linebreak/src/LineBreakNode';
 import { List } from '../src/List';
 import { ListXmlDomParser } from '../src/ListXmlDomParser';
-import { ListItemXmlDomParser } from '../src/ListItemXmlDomParser';
+import { ListItemAttributes, ListItemXmlDomParser } from '../src/ListItemXmlDomParser';
 import { CharXmlDomParser } from '../../plugin-char/src/CharXmlDomParser';
 import { HeadingXmlDomParser } from '../../plugin-heading/src/HeadingXmlDomParser';
 import { LineBreakXmlDomParser } from '../../plugin-linebreak/src/LineBreakXmlDomParser';
@@ -840,6 +840,37 @@ describePlugin(List, testEditor => {
                     contentAfter: unformat(`
                         <ul>
                             <li style="list-style: cambodian;">
+                                <ul>
+                                    <li>a[b]c</li>
+                                </ul>
+                            </li>
+                        </ul>`),
+                });
+            });
+            it('should remove the list-style:none in VDom from the indented list', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: unformat(`
+                        <ul>
+                            <li>title</li>
+                            <li style="list-style: none;">
+                                <ul>
+                                    <li>a[b]c</li>
+                                </ul>
+                            </li>
+                        </ul>`),
+                    stepFunction: (editor: JWEditor) => {
+                        const p = editor.selection.anchor.parent;
+                        const containerLiAttribute = p.parent;
+                        expect(
+                            containerLiAttribute.modifiers
+                                .get(ListItemAttributes)
+                                .style.get('list-style'),
+                        ).to.equal(undefined);
+                    },
+                    contentAfter: unformat(`
+                        <ul>
+                            <li>title</li>
+                            <li style="list-style: none;">
                                 <ul>
                                     <li>a[b]c</li>
                                 </ul>


### PR DESCRIPTION
Issue: if a list-style add marker in the attributes, this breaks the
rendering of the checklist.