### PR TITLE
[FIX] table: table-picker rendered under some buttons

### DIFF
--- a/packages/plugin-table/assets/tableUI.css
+++ b/packages/plugin-table/assets/tableUI.css
@@ -1,5 +1,6 @@
 table.table-picker {
     position: absolute;
+    z-index: 1;
     background-color: white;
     border: 1px solid black;
     -webkit-box-shadow: 2px 2px 5px 0px rgba(0,0,0,.4);


### PR DESCRIPTION
When inactive, the "unlink" button in web_editor has an opacity below one.
This creates a new stacking context, which resets the z-index.
See [this link](https://coder-coder.com/z-index-isnt-working/#3-youre-setting-opacity-transform-or-other-css-properties-that-put-the-element-in-a-new-stacking-context) for more info.
It made the "unlink" button visible even when the table picker was over it.
It was fixed by giving the table picker a higher z-index, default being zero.