### PR TITLE
[IMP] Heading, Blockquote, Pre: do not preserve modifiers on end split

### DIFF
--- a/packages/plugin-blockquote/src/Blockquote.ts
+++ b/packages/plugin-blockquote/src/Blockquote.ts
@@ -99,6 +99,7 @@ export class Blockquote<T extends JWPluginConfig = JWPluginConfig> extends JWPlu
             const DefaultContainer = this.editor.configuration.defaults.Container;
             const newContainer = new DefaultContainer();
             duplicate.replaceWith(newContainer);
+            range.modifiers = undefined;
         }
     }
 }

--- a/packages/plugin-blockquote/test/Blockquote.test.ts
+++ b/packages/plugin-blockquote/test/Blockquote.test.ts
@@ -77,5 +77,15 @@ describePlugin(Blockquote, testEditor => {
                 contentAfter: '<blockquote>abc</blockquote><p>[]<br></p>',
             });
         });
+        it('should insert a new paragraph after the blockquote and not preserve modifiers', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<blockquote><u>abc[]</u></blockquote>',
+                stepFunction: async editor => {
+                    await editor.execCommand('insertParagraphBreak');
+                    await editor.execCommand('insertText', { text: 'a' });
+                },
+                contentAfter: '<blockquote><u>abc</u></blockquote><p>a[]</p>',
+            });
+        });
     });
 });

--- a/packages/plugin-heading/src/Heading.ts
+++ b/packages/plugin-heading/src/Heading.ts
@@ -163,6 +163,7 @@ export class Heading<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin
         const duplicate = heading.splitAt(range.start);
         const newContainer = new ParagraphNode();
         duplicate.replaceWith(newContainer);
+        range.modifiers = undefined;
     }
 
     //--------------------------------------------------------------------------

--- a/packages/plugin-heading/test/Heading.test.ts
+++ b/packages/plugin-heading/test/Heading.test.ts
@@ -294,6 +294,16 @@ describePlugin(Heading, testEditor => {
                 contentAfter: '<h1>abc</h1><p>[]<br></p>',
             });
         });
+        it('should insert a new paragraph after the heading and not preserve modifiers', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<h1><u>abc[]</u></h1>',
+                stepFunction: async editor => {
+                    await editor.execCommand('insertParagraphBreak');
+                    await editor.execCommand('insertText', { text: 'a' });
+                },
+                contentAfter: '<h1><u>abc</u></h1><p>a[]</p>',
+            });
+        });
         it('should insert a line break at the end of the heading if the heading is not breakable', async () => {
             await testEditor(BasicEditor, {
                 beforeStart: editor => {

--- a/packages/plugin-pre/src/Pre.ts
+++ b/packages/plugin-pre/src/Pre.ts
@@ -96,6 +96,7 @@ export class Pre<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T> 
             const DefaultContainer = this.editor.configuration.defaults.Container;
             const newContainer = new DefaultContainer();
             duplicate.replaceWith(newContainer);
+            range.modifiers = undefined;
         }
     }
 }

--- a/packages/plugin-pre/test/Pre.test.ts
+++ b/packages/plugin-pre/test/Pre.test.ts
@@ -291,6 +291,16 @@ describePlugin(Pre, testEditor => {
                 contentAfter: '<pre>abc</pre><p>[]<br></p>',
             });
         });
+        it('should insert a new paragraph after the pre and not preserve modifiers', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<pre><u>abc[]</u></pre>',
+                stepFunction: async editor => {
+                    await editor.execCommand('insertParagraphBreak');
+                    await editor.execCommand('insertText', { text: 'a' });
+                },
+                contentAfter: '<pre><u>abc</u></pre><p>a[]</p>',
+            });
+        });
     });
     describePlugin(Heading, testHeadingEditor => {
         describe('applyHeadingStyle', () => {


### PR DESCRIPTION
`insertParagraphBreak` at the end of a `Heading`, a `Blockquote` or a `Pre` inserts a new default container instead of splitting the
container. This is meant as some sort of edition "reboot": we start a new fresh paragraph. In this context it makes no sense to preserve the modifiers of the container. This commit clears the range modifiers in these cases.