### PR TITLE
[IMP] core: add cascading modifier support

### DIFF
--- a/packages/core/src/Modifier.ts
+++ b/packages/core/src/Modifier.ts
@@ -2,6 +2,7 @@ import { Constructor } from '../../utils/src/utils';
 import { VNode } from './VNodes/VNode';
 import { EventMixin } from '../../utils/src/EventMixin';
 import { makeVersionable } from './Memory/Versionable';
+import { Modifiers } from './Modifiers';
 
 export enum ModifierLevel {
     LOW,
@@ -15,15 +16,18 @@ export type ModifierPredicate<T = Modifier | boolean> = T extends Modifier
 
 interface ModifierConstructor {
     new <T extends Constructor<Modifier>>(...args: ConstructorParameters<T>): this;
+    cascading: boolean;
 }
 export interface Modifier {
     constructor: ModifierConstructor & this;
 }
 export class Modifier extends EventMixin {
+    static cascading = false;
     preserveAfterNode = true; // True to preserve modifier after the node that holds it.
     preserveAfterParagraphBreak = true; // True to preserve modifier after a paragraph break.
     preserveAfterLineBreak = true; // True to preserve modifier after a line break.
     level = ModifierLevel.MEDIUM;
+    modifiers?: Modifiers;
 
     constructor() {
         super();

--- a/packages/core/src/VRange.ts
+++ b/packages/core/src/VRange.ts
@@ -525,9 +525,7 @@ export class VRange {
     private _updateModifiers(): void {
         let nodeToCopyModifiers: VNode;
         if (this.isCollapsed()) {
-            nodeToCopyModifiers =
-                this.start.previousSibling() ||
-                this.start.nextSibling();
+            nodeToCopyModifiers = this.start.previousSibling() || this.start.nextSibling();
         } else {
             nodeToCopyModifiers = this.start.nextSibling();
         }

--- a/packages/core/test/Modifiers.test.ts
+++ b/packages/core/test/Modifiers.test.ts
@@ -1,5 +1,5 @@
 import { Modifiers } from '../src/Modifiers';
-import { Modifier } from '../src/Modifier';
+import { CascadingMixin, Modifier } from '../src/Modifier';
 import { expect } from 'chai';
 
 function id<T>(x: T): T {
@@ -218,6 +218,43 @@ describe('core', () => {
             it('should not find a modifier if there are no modifiers', () => {
                 const modifiers = new Modifiers();
                 expect(modifiers.find(Modifier)).to.be.undefined;
+            });
+            it('should find a modifier of a modifier if it has a cascading effect', () => {
+                const modifiers = new Modifiers();
+                const m1 = new Modifier();
+                const subModifiers = new Modifiers();
+                m1.modifiers = subModifiers;
+                class CascadingModifier extends Modifier {
+                    static cascading = true;
+                }
+                const cascadingModifier = new CascadingModifier();
+                subModifiers.append(cascadingModifier);
+                modifiers.append(m1);
+                // find by class
+                expect(modifiers.find(CascadingModifier)).to.equal(cascadingModifier);
+                // find by instance
+                expect(modifiers.find(cascadingModifier)).to.equal(cascadingModifier);
+                // find by predicate
+                expect(modifiers.find(modifier => modifier === cascadingModifier)).to.equal(
+                    cascadingModifier,
+                );
+            });
+            it('should not find a modifier of a modifier if it does not have a cascading effect', () => {
+                const modifiers = new Modifiers();
+                const m1 = new Modifier();
+                const subModifiers = new Modifiers();
+                m1.modifiers = subModifiers;
+                class NotCascadingModifier extends Modifier {}
+                const notCascadingModifier = new NotCascadingModifier();
+                subModifiers.append(notCascadingModifier);
+                modifiers.append(m1);
+                // find by class
+                expect(modifiers.find(NotCascadingModifier)).to.be.undefined;
+                // find by instance
+                expect(modifiers.find(notCascadingModifier)).to.be.undefined;
+                // find by predicate
+                expect(modifiers.find(modifier => modifier === notCascadingModifier)).to.be
+                    .undefined;
             });
         });
         describe('get()', () => {

--- a/packages/plugin-char/test/Char.test.ts
+++ b/packages/plugin-char/test/Char.test.ts
@@ -9,7 +9,6 @@ import { XmlDomParsingEngine } from '../../plugin-xml/src/XmlDomParsingEngine';
 import { BoldFormat } from '../../plugin-bold/src/BoldFormat';
 import { ItalicFormat } from '../../plugin-italic/src/ItalicFormat';
 import { Inline } from '../../plugin-inline/src/Inline';
-import { Constructor } from '../../utils/src/utils';
 import { Format } from '../../core/src/Format';
 import { UnderlineFormat } from '../../plugin-underline/src/UnderlineFormat';
 import { Modifiers } from '../../core/src/Modifiers';
@@ -21,7 +20,7 @@ const insertText = async function(editor: JWEditor, text: string, select = false
         select,
     });
 };
-const toggleFormat = async (editor: JWEditor, FormatClass: Constructor<Format>): Promise<void> => {
+const toggleFormat = async (editor: JWEditor, FormatClass: typeof Format): Promise<void> => {
     await editor.execCommand<Inline>('toggleFormat', {
         FormatClass: FormatClass,
     });

--- a/packages/plugin-dom-helpers/src/DomHelpers.ts
+++ b/packages/plugin-dom-helpers/src/DomHelpers.ts
@@ -25,7 +25,7 @@ import {
 
 export class DomHelpers<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T> {
     static dependencies = [Parser];
-    private _specializedAttributes: Map<AbstractParser<Node>, Constructor<Attributes>> = new Map();
+    private _specializedAttributes: Map<AbstractParser<Node>, typeof Attributes> = new Map();
 
     async start(): Promise<void> {
         await super.start();
@@ -504,7 +504,7 @@ export class DomHelpers<T extends JWPluginConfig = JWPluginConfig> extends JWPlu
         div.innerHTML = html;
         return parser.parse('dom/html', ...div.childNodes);
     }
-    private _getAttributesConstructor(node: Node): Constructor<Attributes> {
+    private _getAttributesConstructor(node: Node): typeof Attributes {
         for (const [parser, Attributes] of this._specializedAttributes) {
             if (parser.predicate(node)) {
                 return Attributes;

--- a/packages/plugin-inline/src/Inline.ts
+++ b/packages/plugin-inline/src/Inline.ts
@@ -16,7 +16,7 @@ import { ActionableNode } from '../../plugin-layout/src/ActionableNode';
 import { VRange } from '../../core/src/VRange';
 
 export interface FormatParams extends CommandParams {
-    FormatClass: Constructor<Format>;
+    FormatClass: typeof Format;
 }
 export type RemoveFormatParams = CommandParams;
 
@@ -107,7 +107,7 @@ export class Inline<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<
             }
         }
     }
-    isAllFormat(FormatClass: Constructor<Modifier>, range = this.editor.selection.range): boolean {
+    isAllFormat(FormatClass: typeof Modifier, range = this.editor.selection.range): boolean {
         if (range.isCollapsed()) {
             return !!range.modifiers?.find(FormatClass);
         } else {

--- a/packages/plugin-inline/test/Inline.test.ts
+++ b/packages/plugin-inline/test/Inline.test.ts
@@ -1,7 +1,6 @@
 import { describePlugin } from '../../utils/src/testUtils';
 import { Inline } from '../src/Inline';
 import JWEditor from '../../core/src/JWEditor';
-import { Constructor } from '../../utils/src/utils';
 import { Format } from '../../core/src/Format';
 import { BasicEditor } from '../../bundle-basic-editor/BasicEditor';
 import { BoldFormat } from '../../plugin-bold/src/BoldFormat';
@@ -14,7 +13,7 @@ import { ModifierLevel } from '../../core/src/Modifier';
 import { SpanFormat } from '../../plugin-span/src/SpanFormat';
 import { FormatXmlDomParser } from '../src/FormatXmlDomParser';
 
-const toggleFormat = async (editor: JWEditor, FormatClass: Constructor<Format>): Promise<void> => {
+const toggleFormat = async (editor: JWEditor, FormatClass: typeof Format): Promise<void> => {
     await editor.execCommand<Inline>('toggleFormat', {
         FormatClass: FormatClass,
     });

--- a/packages/plugin-renderer/src/RenderingEngine.ts
+++ b/packages/plugin-renderer/src/RenderingEngine.ts
@@ -1,5 +1,5 @@
 import { VNode } from '../../core/src/VNodes/VNode';
-import { isConstructor } from '../../utils/src/utils';
+import { Constructor, isConstructor } from '../../utils/src/utils';
 import JWEditor from '../../core/src/JWEditor';
 import { Modifier } from '../../core/src/Modifier';
 import { ModifierRenderer, ModifierRendererConstructor } from './ModifierRenderer';
@@ -203,7 +203,7 @@ export class RenderingEngine<T> {
             nextRendererIndex++;
         } while (
             nextRenderer.predicate &&
-            !(isConstructor(nextRenderer.predicate, Modifier)
+            !(isConstructor<Constructor<Modifier>>(nextRenderer.predicate, Modifier)
                 ? modifier instanceof nextRenderer.predicate
                 : nextRenderer.predicate(modifier))
         );


### PR DESCRIPTION
Some modifiers have a cascading effect (e.g.: bold).
Coupled with the fact that some modifiers can have such modifiers themselves (e.g.: a SpanFormat with a bold modifier), it is possible that an effect happens to the range that is not caused by a modifier acting directly on that range.
This commit aims at providing support for the use case while altering the least possible the rest of the code base.
Actual implementation for the existing modifiers that are concerned should come in a later commit.