### PR TITLE
[FIX] plugin-textarea: use tag name for textarea parser predicate

### DIFF
--- a/packages/plugin-textarea/src/TextareaXmlDomParser.ts
+++ b/packages/plugin-textarea/src/TextareaXmlDomParser.ts
@@ -1,12 +1,13 @@
 import { VNode } from '../../core/src/VNodes/VNode';
 import { AbstractParser } from '../../plugin-parser/src/AbstractParser';
 import { XmlDomParsingEngine } from '../../plugin-xml/src/XmlDomParsingEngine';
+import { nodeName } from '../../utils/src/utils';
 import { TextareaNode } from './TextareaNode';
 
 export class TextareaXmlDomParser extends AbstractParser<Node> {
     static id = XmlDomParsingEngine.id;
     engine: XmlDomParsingEngine;
-    predicate = (item: Node): boolean => item instanceof HTMLTextAreaElement;
+    predicate = (item: Node): boolean => nodeName(item) === 'TEXTAREA';
 
     /**
      * Parse a list (UL, OL) and its children list elements (LI).


### PR DESCRIPTION
Textarea were not parsed correctly when parsed as xml, which happened when loading existing page from the backend.