### PR TITLE
[IMP] Odoo: expand parsing range of OdooStructureNode

### DIFF
--- a/packages/plugin-odoo/src/OdooStructureNode.ts
+++ b/packages/plugin-odoo/src/OdooStructureNode.ts
@@ -9,6 +9,7 @@ export class OdooStructureNode extends TagNode {
     viewId: string;
     breakable = false;
     dirty = false;
+    allowEmpty = true;
 
     constructor(params: OdooStructureNodeParams) {
         super(params);

--- a/packages/plugin-odoo/src/OdooStructureXmlDomParser.ts
+++ b/packages/plugin-odoo/src/OdooStructureXmlDomParser.ts
@@ -11,8 +11,14 @@ export class OdooStructureXmlDomParser extends AbstractParser {
     predicate = (item: Node): boolean => {
         return (
             item instanceof Element &&
-            item.classList.contains('oe_structure') &&
             item.attributes &&
+            (
+                item.classList.contains('oe_structure') ||
+                (
+                    item.attributes['data-oe-model']?.value === 'ir.ui.view' &&
+                    item.attributes['data-oe-field']?.value === 'arch'
+                )
+            ) &&
             item.attributes['data-oe-xpath'] &&
             item.attributes['data-oe-id']
         );


### PR DESCRIPTION
A block without the "oe_structure" class but with data-oe-field="arch" should be considered an OdooStructure as it hosts an architecture and contains all the information required in order to save it.

This ensures proper parsing of the form builder snippet in the context of the "contact us" section (in which the form builder snippet is appended outside the .oe_structure).