### PR TITLE
[ADD] Small: handle <small>

### DIFF
--- a/packages/bundle-basic-editor/BasicEditor.ts
+++ b/packages/bundle-basic-editor/BasicEditor.ts
@@ -52,6 +52,7 @@ import { Button } from '../plugin-button/src/Button';
 import { HorizontalRule } from '../plugin-horizontal-rule/src/HorizontalRule';
 import { Strikethrough } from '../plugin-strikethrough/src/Strikethrough';
 import { Quote } from '../plugin-quote/src/Quote';
+import { Small } from '../plugin-small/src/Small';
 
 export class BasicEditor extends JWEditor {
     constructor(params?: { editable?: HTMLElement }) {
@@ -87,6 +88,7 @@ export class BasicEditor extends JWEditor {
                 [Quote],
                 [Underline],
                 [Strikethrough],
+                [Small],
                 [Link],
                 [Divider],
                 [HorizontalRule],

--- a/packages/bundle-odoo-website-editor/OdooWebsiteEditor.ts
+++ b/packages/bundle-odoo-website-editor/OdooWebsiteEditor.ts
@@ -68,6 +68,7 @@ import { Attributes } from '../plugin-xml/src/Attributes';
 import { Strikethrough } from '../plugin-strikethrough/src/Strikethrough';
 import { ReactiveEditorInfo } from '../plugin-reactive-info/src/ReactiveEditorInfo';
 import { Quote } from '../plugin-quote/src/Quote';
+import { Small } from '../plugin-small/src/Small';
 
 interface OdooWebsiteEditorOptions {
     source: HTMLElement;
@@ -145,6 +146,7 @@ export class OdooWebsiteEditor extends JWEditor {
                 [Quote],
                 [Underline],
                 [Strikethrough],
+                [Small],
                 [Input],
                 [FontSize],
                 [Link],

--- a/packages/plugin-char/test/Char.test.ts
+++ b/packages/plugin-char/test/Char.test.ts
@@ -176,6 +176,42 @@ describePlugin(Char, testEditor => {
                     });
                 });
             });
+            describe('space', () => {
+                it('should insert nbsp on press spacebar at start of paragraph', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>[]abc</p>',
+                        stepFunction: async editor => insertText(editor, ' '),
+                        contentAfter: '<p>&nbsp;[]abc</p>',
+                    });
+                });
+                it('should insert space on press spacebar within paragraph', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>a[]bc</p>',
+                        stepFunction: async editor => insertText(editor, ' '),
+                        contentAfter: '<p>a []bc</p>',
+                    });
+                });
+                it('should insert nbsp on press spacebar at end of paragraph', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>abc[]</p>',
+                        stepFunction: async editor => insertText(editor, ' '),
+                        contentAfter: '<p>abc&nbsp;[]</p>',
+                    });
+                });
+                it('should insert nbsp on press spacebar at start of div with adjacent block in div', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div>[]abc<p>def</p></div>',
+                        stepFunction: async editor => insertText(editor, ' '),
+                        contentAfter: '<div>&nbsp;[]abc<p>def</p></div>',
+                    });
+                });
+                it('should not transform space between inline nodes into nbsp', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<div> <a>a</a> <b>b</b> </div>',
+                        contentAfter: '<div><a>a</a> <b>b</b></div>',
+                    });
+                });
+            });
             describe('bold', () => {
                 describe('Selection collapsed', () => {
                     it('should insert char not bold when selection in between two paragraphs', async () => {

--- a/packages/plugin-small/src/Small.ts
+++ b/packages/plugin-small/src/Small.ts
@@ -1,0 +1,14 @@
+import { JWPlugin, JWPluginConfig } from '../../core/src/JWPlugin';
+import { Inline } from '../../plugin-inline/src/Inline';
+import { SmallXmlDomParser } from './SmallXmlDomParser';
+import { Loadables } from '../../core/src/JWEditor';
+import { Parser } from '../../plugin-parser/src/Parser';
+import { Keymap } from '../../plugin-keymap/src/Keymap';
+import { Layout } from '../../plugin-layout/src/Layout';
+
+export class Small<T extends JWPluginConfig = JWPluginConfig> extends JWPlugin<T> {
+    static dependencies = [Inline];
+    readonly loadables: Loadables<Parser & Keymap & Layout> = {
+        parsers: [SmallXmlDomParser],
+    };
+}

--- a/packages/plugin-small/src/SmallFormat.ts
+++ b/packages/plugin-small/src/SmallFormat.ts
@@ -1,0 +1,7 @@
+import { Format } from '../../core/src/Format';
+
+export class SmallFormat extends Format {
+    constructor() {
+        super('SMALL');
+    }
+}

--- a/packages/plugin-small/src/SmallXmlDomParser.ts
+++ b/packages/plugin-small/src/SmallXmlDomParser.ts
@@ -1,0 +1,27 @@
+import { FormatXmlDomParser } from '../../plugin-inline/src/FormatXmlDomParser';
+import { VNode } from '../../core/src/VNodes/VNode';
+import { SmallFormat } from './SmallFormat';
+import { nodeName } from '../../utils/src/utils';
+
+export class SmallXmlDomParser extends FormatXmlDomParser {
+    predicate = (item: Node): boolean => {
+        return item instanceof Element && nodeName(item) === 'SMALL';
+    };
+
+    /**
+     * Parse a small node.
+     *
+     * @param item
+     */
+    async parse(item: Element): Promise<VNode[]> {
+        const small = new SmallFormat();
+        const attributes = this.engine.parseAttributes(item);
+        if (attributes.length) {
+            small.modifiers.append(attributes);
+        }
+        const children = await this.engine.parse(...item.childNodes);
+        this.applyFormat(small, children);
+
+        return children;
+    }
+}

--- a/packages/utils/test/formattingSpace.test.ts
+++ b/packages/utils/test/formattingSpace.test.ts
@@ -290,6 +290,12 @@ describe('removeFormattingSpace() util function', () => {
         const nodes = htmlToElements('<textarea> a </textarea>');
         expect(removeFormattingSpace(nodes[0].firstChild)).to.equal(' a ');
     });
+    it('should remove space between blocks', async () => {
+        const nodes = htmlToElements('<div> <input/> <small>abc</small> </div>');
+        expect(removeFormattingSpace(nodes[0].firstChild)).to.equal('');
+        expect(removeFormattingSpace(nodes[0].childNodes[2])).to.equal(' ');
+        expect(removeFormattingSpace(nodes[0].childNodes[4])).to.equal('');
+    });
     describe('nested nodes', () => {
         it('Should return trimmed text when no space around text', async () => {
             const nodes = htmlToElements('<p><span><span><a>abc</a></span></span></p>');


### PR DESCRIPTION
Trying to fix the fact that
```html
<div>
    <input/>
    <small>abc</small>
</div>
```
rendered a non-breakable space between the `input` and the `small`, and after writing some tests, I realized that the cause for the bug was that we didn't actually handle `small` yet. So now we do.